### PR TITLE
2d gpdma support

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -24,6 +24,7 @@ DMA:
 - fix: stm32/dma: auto-set `TR1.PAM = Pack` on GPDMA when source and destination widths differ, instead of silently zero-extending one beat per destination beat
 - fix: stm32/dma: compute GPDMA `BR1.BNDT` from the memory-side width regardless of direction, fixing destination overrun on reads with peripheral width > memory width
 - feat: stm32/dma: GPDMA: allow access to construct custom LinkedList chains for scatter/gather DMA
+- feat: stm32/dma: add `TwoDItem`, `TwoDConfig`, and `LinkedListItem` trait; `Table` is now generic over item type
 
 ADC:
 - feat: stm32/adc: add `VrefInt::calibrated_value()` for additional chips

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2643,6 +2643,10 @@ fn main() {
 
         g.extend(quote!(dma_channel_impl!(#name, #irq_type);));
 
+        if ch.supports_2d.unwrap_or(false) {
+            g.extend(quote!(dma_channel_2d_impl!(#name);));
+        }
+
         let dma = format_ident!("{}", ch.dma);
         let ch_num = ch.channel as usize;
         let bi = dma_peri.registers.as_ref().unwrap();
@@ -2674,11 +2678,20 @@ fn main() {
             quote!()
         };
 
+        let supports_2d_field = match bi.kind {
+            "gpdma" | "lpdma" => {
+                let supports_2d = ch.supports_2d.unwrap_or(false);
+                quote!(supports_2d: #supports_2d,)
+            }
+            _ => quote!(),
+        };
+
         #[cfg(not(feature = "_dual-core"))]
         dmas.extend(quote! {
             crate::dma::ChannelInfo {
                 dma: #dma_info,
                 num: #ch_num,
+                #supports_2d_field
                 #[cfg(feature = "low-power")]
                 stop_mode: crate::rcc::StopMode::#stop_mode,
                 #dmamux
@@ -2689,6 +2702,7 @@ fn main() {
             crate::dma::ChannelInfo {
                 dma: #dma_info,
                 num: #ch_num,
+                #supports_2d_field
                 irq: #irq_pac,
                 #[cfg(feature = "low-power")]
                 stop_mode: crate::rcc::StopMode::#stop_mode,

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -166,6 +166,9 @@ fn main() {
         cfgs.enable("sdmmc_dlyb");
     }
 
+    // GPDMA 2D support: enabled when at least one GPDMA channel supports 2D addressing.
+    cfgs.declare("gpdma2d");
+
     // compile a map of peripherals with registers
     let peripheral_map: HashMap<&str, (&Peripheral, &PeripheralRegisters)> = METADATA
         .peripherals
@@ -2614,6 +2617,8 @@ fn main() {
         }
     }
 
+    let mut has_gpdma_2d = false;
+
     for ch in METADATA.dma_channels.iter() {
         let (dma_peri, _) = peripheral_map.get(ch.dma).unwrap();
         let stop_mode = dma_peri
@@ -2651,6 +2656,10 @@ fn main() {
         let ch_num = ch.channel as usize;
         let bi = dma_peri.registers.as_ref().unwrap();
 
+        if ch.supports_2d.unwrap_or(false) && bi.kind == "gpdma" {
+            has_gpdma_2d = true;
+        }
+
         let dma_info = match bi.kind {
             "dma" => quote!(crate::dma::DmaInfo::Dma(crate::pac::#dma)),
             "bdma" => quote!(crate::dma::DmaInfo::Bdma(crate::pac::#dma)),
@@ -2681,7 +2690,7 @@ fn main() {
         let supports_2d_field = match bi.kind {
             "gpdma" | "lpdma" => {
                 let supports_2d = ch.supports_2d.unwrap_or(false);
-                quote!(supports_2d: #supports_2d,)
+                quote!(#[cfg(gpdma2d)] supports_2d: #supports_2d,)
             }
             _ => quote!(),
         };
@@ -2709,6 +2718,10 @@ fn main() {
                 #dmamux
             },
         });
+    }
+
+    if has_gpdma_2d {
+        cfgs.enable("gpdma2d");
     }
 
     g.extend(quote! {

--- a/embassy-stm32/src/dma/gpdma/linked_list.rs
+++ b/embassy-stm32/src/dma/gpdma/linked_list.rs
@@ -24,12 +24,75 @@ pub enum RunMode {
     Circular,
 }
 
-/// A linked-list item for linear GPDMA transfers.
+/// Configuration common to all linked-list item types.
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub struct ItemConfig {
+    /// Transfer complete event mode for this item.
+    pub transfer_complete_mode: super::TransferCompleteMode,
+}
+
+impl Default for ItemConfig {
+    fn default() -> Self {
+        Self {
+            transfer_complete_mode: super::TransferCompleteMode::EachBlock,
+        }
+    }
+}
+
+/// Backwards-compatible alias.
+pub type LinearItemConfig = ItemConfig;
+
+/// Trait for linked-list item types usable in a generic [`Table`].
+pub trait LinkedListItem: Copy + Default + Sized {
+    /// Per-item configuration passed at construction time.
+    type Config: Default + Copy;
+
+    /// Whether this item type requires a 2D-capable channel.
+    const IS_2D: bool;
+
+    /// Create a new read DMA transfer item (peripheral to memory).
+    ///
+    /// # Safety
+    /// The caller must ensure addresses and buffer remain valid for the transfer duration.
+    unsafe fn new_read<MW: Word, PW: Word>(
+        request: Request,
+        peri_addr: *mut PW,
+        buf: &mut [MW],
+        config: Self::Config,
+    ) -> Self;
+
+    /// Create a new write DMA transfer item (memory to peripheral).
+    ///
+    /// # Safety
+    /// The caller must ensure addresses and buffer remain valid for the transfer duration.
+    unsafe fn new_write<MW: Word, PW: Word>(
+        request: Request,
+        buf: &[MW],
+        peri_addr: *mut PW,
+        config: Self::Config,
+    ) -> Self;
+
+    /// Link to the next item at the given offset address.
+    fn link_to(&mut self, next: u16);
+
+    /// Unlink the next item (disables channel update bits).
+    fn unlink(&mut self);
+
+    /// The item's transfer count in number of destination words.
+    fn transfer_count(&self) -> usize;
+}
+
+/// The common fields shared by all linked-list item types (TR1, TR2, BR1, SAR, DAR).
 ///
-/// Also works for 2D-capable GPDMA channels, but does not use 2D capabilities.
+/// This is the first 5 words of every GPDMA linked-list descriptor.
+/// Both [`LinearItem`] and [`TwoDItem`](super::two_d::TwoDItem) embed
+/// this as their first field so the `#[repr(C)]` hardware layout is preserved.
 #[derive(Debug, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
-pub struct LinearItem {
+pub struct Item {
     /// Transfer register 1.
     pub tr1: regs::ChTr1,
     /// Transfer register 2.
@@ -40,40 +103,15 @@ pub struct LinearItem {
     pub sar: u32,
     /// Destination address register.
     pub dar: u32,
-    /// Linked-list address register.
-    pub llr: regs::ChLlr,
 }
 
-impl LinearItem {
-    /// Create a new read DMA transfer (peripheral to memory).
-    pub unsafe fn new_read<'d, MW: Word, PW: Word>(request: Request, peri_addr: *mut PW, buf: &'d mut [MW]) -> Self {
-        Self::new_inner(
-            request,
-            Dir::PeripheralToMemory,
-            peri_addr as *const u32,
-            buf as *mut [MW] as *mut MW as *mut u32,
-            buf.len(),
-            true,
-            PW::size(),
-            MW::size(),
-        )
-    }
-
-    /// Create a new write DMA transfer (memory to peripheral).
-    pub unsafe fn new_write<'d, MW: Word, PW: Word>(request: Request, buf: &'d [MW], peri_addr: *mut PW) -> Self {
-        Self::new_inner(
-            request,
-            Dir::MemoryToPeripheral,
-            peri_addr as *const u32,
-            buf as *const [MW] as *const MW as *mut u32,
-            buf.len(),
-            true,
-            MW::size(),
-            PW::size(),
-        )
-    }
-
-    unsafe fn new_inner(
+impl Item {
+    /// Build a new item from raw transfer parameters.
+    ///
+    /// # Safety
+    /// The caller must ensure `peri_addr` and `mem_addr` are valid for the transfer.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) unsafe fn new(
         request: Request,
         dir: Dir,
         peri_addr: *const u32,
@@ -83,9 +121,47 @@ impl LinearItem {
         data_size: WordSize,
         dst_size: WordSize,
     ) -> Self {
-        let (tr1, tr2, br1, sar, dar) = build_common_fields(
-            request, dir, peri_addr, mem_addr, mem_len, incr_mem, data_size, dst_size,
-        );
+        let Ok(bndt) = (mem_len * data_size.bytes()).try_into() else {
+            panic!("DMA transfers may not be larger than 65535 bytes.");
+        };
+
+        let mut br1 = regs::ChBr1(0);
+        br1.set_bndt(bndt);
+
+        let mut tr1 = regs::ChTr1(0);
+        tr1.set_sdw(data_size.into());
+        tr1.set_ddw(dst_size.into());
+        tr1.set_sinc(dir == Dir::MemoryToPeripheral && incr_mem);
+        tr1.set_dinc(dir == Dir::PeripheralToMemory && incr_mem);
+
+        #[cfg(gpdma)]
+        {
+            use stm32_metapac::gpdma::vals::Ap;
+            tr1.set_sap(match dir {
+                Dir::MemoryToPeripheral => Ap::Port0,
+                Dir::PeripheralToMemory => Ap::Port1,
+                Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+            });
+            tr1.set_dap(match dir {
+                Dir::MemoryToPeripheral => Ap::Port1,
+                Dir::PeripheralToMemory => Ap::Port0,
+                Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+            });
+        }
+
+        let mut tr2 = regs::ChTr2(0);
+        tr2.set_dreq(match dir {
+            Dir::MemoryToPeripheral => Dreq::DestinationPeripheral,
+            Dir::PeripheralToMemory => Dreq::SourcePeripheral,
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+        });
+        tr2.set_reqsel(request);
+
+        let (sar, dar) = match dir {
+            Dir::MemoryToPeripheral => (mem_addr as _, peri_addr as _),
+            Dir::PeripheralToMemory => (peri_addr as _, mem_addr as _),
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+        };
 
         Self {
             tr1,
@@ -93,14 +169,79 @@ impl LinearItem {
             br1,
             sar,
             dar,
-            llr: regs::ChLlr(0),
         }
     }
 
-    /// Link to the next linear item at the given offset address.
+    /// Apply the common item configuration fields.
     ///
-    /// Enables update bits for all 6 linear-LLI fields (UT1, UT2, UB1, USA, UDA, ULL).
-    pub fn link_to(&mut self, next: u16) {
+    /// This is the single place to expand when new common config fields are added.
+    pub(super) fn apply_config(&mut self, config: &ItemConfig) {
+        self.tr2.set_tcem(config.transfer_complete_mode.into());
+    }
+
+    /// The item's transfer count in number of destination words.
+    pub fn transfer_count(&self) -> usize {
+        let word_size: WordSize = self.tr1.ddw().into();
+        self.br1.bndt() as usize / word_size.bytes()
+    }
+}
+
+/// A linked-list item for linear GPDMA transfers.
+///
+/// Also works for 2D-capable GPDMA channels, but does not use 2D capabilities.
+#[derive(Debug, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
+pub struct LinearItem {
+    /// Common item fields (TR1, TR2, BR1, SAR, DAR).
+    pub item: Item,
+    /// Linked-list address register.
+    pub llr: regs::ChLlr,
+}
+
+impl LinkedListItem for LinearItem {
+    type Config = ItemConfig;
+    const IS_2D: bool = false;
+
+    unsafe fn new_read<MW: Word, PW: Word>(
+        request: Request,
+        peri_addr: *mut PW,
+        buf: &mut [MW],
+        config: Self::Config,
+    ) -> Self {
+        Self::new_inner(
+            request,
+            Dir::PeripheralToMemory,
+            peri_addr as *const u32,
+            buf as *mut [MW] as *mut MW as *mut u32,
+            buf.len(),
+            true,
+            PW::size(),
+            MW::size(),
+            config,
+        )
+    }
+
+    unsafe fn new_write<MW: Word, PW: Word>(
+        request: Request,
+        buf: &[MW],
+        peri_addr: *mut PW,
+        config: Self::Config,
+    ) -> Self {
+        Self::new_inner(
+            request,
+            Dir::MemoryToPeripheral,
+            peri_addr as *const u32,
+            buf as *const [MW] as *const MW as *mut u32,
+            buf.len(),
+            true,
+            MW::size(),
+            PW::size(),
+            config,
+        )
+    }
+
+    fn link_to(&mut self, next: u16) {
         let mut llr = regs::ChLlr(0);
 
         llr.set_ut1(true);
@@ -116,98 +257,51 @@ impl LinearItem {
         self.llr = llr;
     }
 
-    /// Unlink the next linear item.
-    ///
-    /// Disables channel update bits.
-    pub fn unlink(&mut self) {
+    fn unlink(&mut self) {
         self.llr = regs::ChLlr(0);
     }
 
-    /// Set the transfer complete event mode (`TR2.TCEM`) for this item.
-    ///
-    /// In linked-list mode, the channel's TR2 register is overwritten by
-    /// each LLI when `UT2` is set, so TCEM must be configured per-item.
-    ///
-    /// See [`TransferCompleteMode`](super::TransferCompleteMode) for details.
-    pub fn set_transfer_complete_mode(&mut self, mode: super::TransferCompleteMode) {
-        self.tr2.set_tcem(mode.into());
-    }
-
-    /// The item's transfer count in number of destination words.
-    pub fn transfer_count(&self) -> usize {
-        let word_size: WordSize = self.tr1.ddw().into();
-        self.br1.bndt() as usize / word_size.bytes()
+    fn transfer_count(&self) -> usize {
+        self.item.transfer_count()
     }
 }
 
-/// Build the fields common to both linear and 2D items (TR1, TR2, BR1, SAR, DAR).
-#[allow(clippy::too_many_arguments)]
-pub(super) unsafe fn build_common_fields(
-    request: Request,
-    dir: Dir,
-    peri_addr: *const u32,
-    mem_addr: *mut u32,
-    mem_len: usize,
-    incr_mem: bool,
-    data_size: WordSize,
-    dst_size: WordSize,
-) -> (regs::ChTr1, regs::ChTr2, regs::ChBr1, u32, u32) {
-    let Ok(bndt) = (mem_len * data_size.bytes()).try_into() else {
-        panic!("DMA transfers may not be larger than 65535 bytes.");
-    };
+impl LinearItem {
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn new_inner(
+        request: Request,
+        dir: Dir,
+        peri_addr: *const u32,
+        mem_addr: *mut u32,
+        mem_len: usize,
+        incr_mem: bool,
+        data_size: WordSize,
+        dst_size: WordSize,
+        config: ItemConfig,
+    ) -> Self {
+        let mut item = Item::new(
+            request, dir, peri_addr, mem_addr, mem_len, incr_mem, data_size, dst_size,
+        );
+        item.apply_config(&config);
 
-    let mut br1 = regs::ChBr1(0);
-    br1.set_bndt(bndt);
-
-    let mut tr1 = regs::ChTr1(0);
-    tr1.set_sdw(data_size.into());
-    tr1.set_ddw(dst_size.into());
-    tr1.set_sinc(dir == Dir::MemoryToPeripheral && incr_mem);
-    tr1.set_dinc(dir == Dir::PeripheralToMemory && incr_mem);
-
-    #[cfg(gpdma)]
-    {
-        use stm32_metapac::gpdma::vals::Ap;
-        tr1.set_sap(match dir {
-            Dir::MemoryToPeripheral => Ap::Port0,
-            Dir::PeripheralToMemory => Ap::Port1,
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
-        });
-        tr1.set_dap(match dir {
-            Dir::MemoryToPeripheral => Ap::Port1,
-            Dir::PeripheralToMemory => Ap::Port0,
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
-        });
+        Self {
+            item,
+            llr: regs::ChLlr(0),
+        }
     }
-
-    let mut tr2 = regs::ChTr2(0);
-    tr2.set_dreq(match dir {
-        Dir::MemoryToPeripheral => Dreq::DestinationPeripheral,
-        Dir::PeripheralToMemory => Dreq::SourcePeripheral,
-        Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
-    });
-    tr2.set_reqsel(request);
-
-    let (sar, dar) = match dir {
-        Dir::MemoryToPeripheral => (mem_addr as _, peri_addr as _),
-        Dir::PeripheralToMemory => (peri_addr as _, mem_addr as _),
-        Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
-    };
-
-    (tr1, tr2, br1, sar, dar)
 }
 
-/// A table of linear linked list items.
+/// A table of linked list items.
 #[repr(C)]
-pub struct Table<const ITEM_COUNT: usize> {
+pub struct Table<T: LinkedListItem, const N: usize> {
     /// The items.
-    pub items: [LinearItem; ITEM_COUNT],
+    pub items: [T; N],
 }
 
-impl<const ITEM_COUNT: usize> Table<ITEM_COUNT> {
+impl<T: LinkedListItem, const N: usize> Table<T, N> {
     /// Create a new table.
-    pub fn new(items: [LinearItem; ITEM_COUNT]) -> Self {
-        assert!(!items.is_empty());
+    pub fn new(items: [T; N]) -> Self {
+        assert!(N > 0);
 
         Self { items }
     }
@@ -222,11 +316,12 @@ impl<const ITEM_COUNT: usize> Table<ITEM_COUNT> {
         peri_addr: *mut PW,
         buffer: &mut [MW],
         direction: Dir,
-    ) -> Table<1> {
+        config: T::Config,
+    ) -> Table<T, 1> {
         let item = match direction {
-            Dir::MemoryToPeripheral => LinearItem::new_write(request, &buffer[..], peri_addr),
-            Dir::PeripheralToMemory => LinearItem::new_read(request, peri_addr, &mut buffer[..]),
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
+            Dir::MemoryToPeripheral => T::new_write(request, &buffer[..], peri_addr, config),
+            Dir::PeripheralToMemory => T::new_read(request, peri_addr, &mut buffer[..], config),
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
         };
 
         Table::new([item])
@@ -240,21 +335,21 @@ impl<const ITEM_COUNT: usize> Table<ITEM_COUNT> {
         peri_addr: *mut PW,
         buffer: &mut [MW],
         direction: Dir,
-    ) -> Table<2> {
-        // Buffer halves should be the same length.
+        config: T::Config,
+    ) -> Table<T, 2> {
         let half_len = buffer.len() / 2;
         assert_eq!(half_len * 2, buffer.len());
 
         let items = match direction {
             Dir::MemoryToPeripheral => [
-                LinearItem::new_write(request, &mut buffer[..half_len], peri_addr),
-                LinearItem::new_write(request, &mut buffer[half_len..], peri_addr),
+                T::new_write(request, &mut buffer[..half_len], peri_addr, config),
+                T::new_write(request, &mut buffer[half_len..], peri_addr, config),
             ],
             Dir::PeripheralToMemory => [
-                LinearItem::new_read(request, peri_addr, &mut buffer[..half_len]),
-                LinearItem::new_read(request, peri_addr, &mut buffer[half_len..]),
+                T::new_read(request, peri_addr, &mut buffer[..half_len], config),
+                T::new_read(request, peri_addr, &mut buffer[half_len..], config),
             ],
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
         };
 
         Table::new(items)

--- a/embassy-stm32/src/dma/gpdma/linked_list.rs
+++ b/embassy-stm32/src/dma/gpdma/linked_list.rs
@@ -34,7 +34,7 @@ pub struct LinearItem {
     pub tr1: regs::ChTr1,
     /// Transfer register 2.
     pub tr2: regs::ChTr2,
-    /// Block register 2.
+    /// Block register 1.
     pub br1: regs::ChBr1,
     /// Source address register.
     pub sar: u32,
@@ -83,53 +83,9 @@ impl LinearItem {
         data_size: WordSize,
         dst_size: WordSize,
     ) -> Self {
-        // BNDT is specified as bytes, not as number of transfers.
-        let Ok(bndt) = (mem_len * data_size.bytes()).try_into() else {
-            panic!("DMA transfers may not be larger than 65535 bytes.");
-        };
-
-        let mut br1 = regs::ChBr1(0);
-        br1.set_bndt(bndt);
-
-        let mut tr1 = regs::ChTr1(0);
-        tr1.set_sdw(data_size.into());
-        tr1.set_ddw(dst_size.into());
-        tr1.set_sinc(dir == Dir::MemoryToPeripheral && incr_mem);
-        tr1.set_dinc(dir == Dir::PeripheralToMemory && incr_mem);
-
-        // Set AHB port assignments for GPDMA (LPDMA does not have SAP/DAP).
-        // This matches the logic in Channel::configure() for non-linked-list
-        // transfers: memory is on Port0 (AXI), peripheral is on Port1 (AHB).
-        #[cfg(gpdma)]
-        {
-            use stm32_metapac::gpdma::vals::Ap;
-            tr1.set_sap(match dir {
-                Dir::MemoryToPeripheral => Ap::Port0, // Source is memory on AXI
-                Dir::PeripheralToMemory => Ap::Port1, // Source is peripheral on AHB
-                Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
-            });
-            tr1.set_dap(match dir {
-                Dir::MemoryToPeripheral => Ap::Port1, // Destination is peripheral on AHB
-                Dir::PeripheralToMemory => Ap::Port0, // Destination is memory on AXI
-                Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
-            });
-        }
-
-        let mut tr2 = regs::ChTr2(0);
-        tr2.set_dreq(match dir {
-            Dir::MemoryToPeripheral => Dreq::DestinationPeripheral,
-            Dir::PeripheralToMemory => Dreq::SourcePeripheral,
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
-        });
-        tr2.set_reqsel(request);
-
-        let (sar, dar) = match dir {
-            Dir::MemoryToPeripheral => (mem_addr as _, peri_addr as _),
-            Dir::PeripheralToMemory => (peri_addr as _, mem_addr as _),
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for LinearItem"),
-        };
-
-        let llr = regs::ChLlr(0);
+        let (tr1, tr2, br1, sar, dar) = build_common_fields(
+            request, dir, peri_addr, mem_addr, mem_len, incr_mem, data_size, dst_size,
+        );
 
         Self {
             tr1,
@@ -137,13 +93,13 @@ impl LinearItem {
             br1,
             sar,
             dar,
-            llr,
+            llr: regs::ChLlr(0),
         }
     }
 
-    /// Link to the next linear item at the given address.
+    /// Link to the next linear item at the given offset address.
     ///
-    /// Enables channel update bits.
+    /// Enables update bits for all 6 linear-LLI fields (UT1, UT2, UB1, USA, UDA, ULL).
     pub fn link_to(&mut self, next: u16) {
         let mut llr = regs::ChLlr(0);
 
@@ -177,14 +133,71 @@ impl LinearItem {
         self.tr2.set_tcem(mode.into());
     }
 
-    /// The item's transfer count in number of words.
+    /// The item's transfer count in number of destination words.
     pub fn transfer_count(&self) -> usize {
         let word_size: WordSize = self.tr1.ddw().into();
         self.br1.bndt() as usize / word_size.bytes()
     }
 }
 
-/// A table of linked list items.
+/// Build the fields common to both linear and 2D items (TR1, TR2, BR1, SAR, DAR).
+#[allow(clippy::too_many_arguments)]
+pub(super) unsafe fn build_common_fields(
+    request: Request,
+    dir: Dir,
+    peri_addr: *const u32,
+    mem_addr: *mut u32,
+    mem_len: usize,
+    incr_mem: bool,
+    data_size: WordSize,
+    dst_size: WordSize,
+) -> (regs::ChTr1, regs::ChTr2, regs::ChBr1, u32, u32) {
+    let Ok(bndt) = (mem_len * data_size.bytes()).try_into() else {
+        panic!("DMA transfers may not be larger than 65535 bytes.");
+    };
+
+    let mut br1 = regs::ChBr1(0);
+    br1.set_bndt(bndt);
+
+    let mut tr1 = regs::ChTr1(0);
+    tr1.set_sdw(data_size.into());
+    tr1.set_ddw(dst_size.into());
+    tr1.set_sinc(dir == Dir::MemoryToPeripheral && incr_mem);
+    tr1.set_dinc(dir == Dir::PeripheralToMemory && incr_mem);
+
+    #[cfg(gpdma)]
+    {
+        use stm32_metapac::gpdma::vals::Ap;
+        tr1.set_sap(match dir {
+            Dir::MemoryToPeripheral => Ap::Port0,
+            Dir::PeripheralToMemory => Ap::Port1,
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+        });
+        tr1.set_dap(match dir {
+            Dir::MemoryToPeripheral => Ap::Port1,
+            Dir::PeripheralToMemory => Ap::Port0,
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+        });
+    }
+
+    let mut tr2 = regs::ChTr2(0);
+    tr2.set_dreq(match dir {
+        Dir::MemoryToPeripheral => Dreq::DestinationPeripheral,
+        Dir::PeripheralToMemory => Dreq::SourcePeripheral,
+        Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+    });
+    tr2.set_reqsel(request);
+
+    let (sar, dar) = match dir {
+        Dir::MemoryToPeripheral => (mem_addr as _, peri_addr as _),
+        Dir::PeripheralToMemory => (peri_addr as _, mem_addr as _),
+        Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for linked-list items"),
+    };
+
+    (tr1, tr2, br1, sar, dar)
+}
+
+/// A table of linear linked list items.
 #[repr(C)]
 pub struct Table<const ITEM_COUNT: usize> {
     /// The items.

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -6,7 +6,7 @@ use core::sync::atomic::{AtomicUsize, Ordering, compiler_fence, fence};
 use core::task::{Context, Poll};
 
 use embassy_sync::waitqueue::AtomicWaker;
-use linked_list::Table;
+use linked_list::{LinkedListItem, Table};
 #[cfg(not(lpdma))]
 use pac::gpdma::{Channel as BaseChannel, Gpdma as BaseRegs, vals};
 #[cfg(lpdma)]
@@ -393,9 +393,9 @@ pub struct TransferOptions {
     pub request_mode: RequestMode,
     /// Transfer complete event mode. Default `EachBlock`.
     ///
-    /// For linked-list transfers, set this on each `LinearItem` via
-    /// [`LinearItem::set_transfer_complete_mode`](linked_list::LinearItem::set_transfer_complete_mode)
-    /// since the channel TR2 is overwritten by the first LLI when `UT2` is set.
+    /// For linked-list transfers, this is configured per-item via the item's
+    /// config (e.g. [`LinearItemConfig`](linked_list::LinearItemConfig)) since
+    /// the channel TR2 register is overwritten by each LLI when `UT2` is set.
     pub transfer_complete_mode: TransferCompleteMode,
     /// Optional trigger-gated transfer configuration.
     pub trigger: Option<TriggerConfig>,
@@ -1020,48 +1020,30 @@ impl<'d> Channel<'d> {
     }
 
     /// Create a linked-list DMA transfer.
-    pub unsafe fn linked_list<'a, const N: usize>(
-        &'a mut self,
-        table: &'a Table<N>,
-        options: TransferOptions,
-    ) -> LinkedListTransfer<'a> {
-        self.configure_linked_list_raw(
-            table.base_address(),
-            table.offset_address(0),
-            N,
-            table.transfer_count(),
-            options,
-            false,
-        );
-        self.start();
-
-        LinkedListTransfer {
-            _wake_guard: self.info().wake_guard(),
-            channel: self.reborrow(),
-        }
-    }
-
-    /// Create a 2D linked-list DMA transfer.
     ///
-    /// Requires a channel that supports 2D addressing. Panics if the
-    /// channel does not have 2D capability.
-    #[cfg(gpdma2d)]
-    pub unsafe fn linked_list_2d<'a, const N: usize>(
+    /// Works with both linear (`Table<LinearItem, N>`) and 2D
+    /// (`Table<TwoDItem, N>`) tables. When a 2D table is used, the channel
+    /// must support 2D addressing or this will panic.
+    pub unsafe fn linked_list<'a, T: LinkedListItem, const N: usize>(
         &'a mut self,
-        table: &'a two_d::TwoDTable<N>,
+        table: &'a Table<T, N>,
         options: TransferOptions,
     ) -> LinkedListTransfer<'a> {
-        assert!(
-            self.info().supports_2d,
-            "2D linked-list transfers require a 2D-capable channel (check RM for your chip)"
-        );
+        #[cfg(gpdma2d)]
+        if T::IS_2D {
+            assert!(
+                self.info().supports_2d,
+                "2D linked-list transfers require a 2D-capable channel (check RM for your chip)"
+            );
+        }
+
         self.configure_linked_list_raw(
             table.base_address(),
             table.offset_address(0),
             N,
             table.transfer_count(),
             options,
-            true,
+            T::IS_2D,
         );
         self.start();
 
@@ -1078,46 +1060,34 @@ impl<'d> Channel<'d> {
     /// intended for use cases that need to restart the same linked-list
     /// chain from the beginning.
     ///
+    /// Works with both linear and 2D tables. When a 2D table is used, the
+    /// channel must support 2D addressing or this will panic.
+    ///
     /// # Safety
     ///
     /// The caller must ensure that no other code is concurrently accessing
     /// the channel registers, and that the `table` remains valid for the
     /// duration of the transfer.
-    pub unsafe fn restart_linked_list<const N: usize>(&self, table: &Table<N>, options: TransferOptions) {
-        self.configure_linked_list_raw(
-            table.base_address(),
-            table.offset_address(0),
-            N,
-            table.transfer_count(),
-            options,
-            false,
-        );
-        self.start();
-    }
+    pub unsafe fn restart_linked_list<T: LinkedListItem, const N: usize>(
+        &self,
+        table: &Table<T, N>,
+        options: TransferOptions,
+    ) {
+        #[cfg(gpdma2d)]
+        if T::IS_2D {
+            assert!(
+                self.info().supports_2d,
+                "2D linked-list transfers require a 2D-capable channel (check RM for your chip)"
+            );
+        }
 
-    /// Reconfigure and restart a 2D linked-list transfer from item[0].
-    ///
-    /// Requires a channel that supports 2D addressing. Panics if the
-    /// channel does not have 2D capability.
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that no other code is concurrently accessing
-    /// the channel registers, and that the `table` remains valid for the
-    /// duration of the transfer.
-    #[cfg(gpdma2d)]
-    pub unsafe fn restart_linked_list_2d<const N: usize>(&self, table: &two_d::TwoDTable<N>, options: TransferOptions) {
-        assert!(
-            self.info().supports_2d,
-            "2D linked-list transfers require a 2D-capable channel (check RM for your chip)"
-        );
         self.configure_linked_list_raw(
             table.base_address(),
             table.offset_address(0),
             N,
             table.transfer_count(),
             options,
-            true,
+            T::IS_2D,
         );
         self.start();
     }

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -21,7 +21,7 @@ use crate::rcc::WakeGuard;
 
 pub mod linked_list;
 pub mod ringbuffered;
-#[cfg(gpdma)]
+#[cfg(gpdma2d)]
 pub mod two_d;
 
 pub use vals::Pam as Packing;
@@ -60,6 +60,7 @@ impl DmaInfo {
 pub(crate) struct ChannelInfo {
     pub(crate) dma: DmaInfo,
     pub(crate) num: usize,
+    #[cfg(gpdma2d)]
     pub(crate) supports_2d: bool,
     #[cfg(feature = "_dual-core")]
     pub(crate) irq: pac::Interrupt,
@@ -1044,7 +1045,7 @@ impl<'d> Channel<'d> {
     ///
     /// Requires a channel that supports 2D addressing. Panics if the
     /// channel does not have 2D capability.
-    #[cfg(gpdma)]
+    #[cfg(gpdma2d)]
     pub unsafe fn linked_list_2d<'a, const N: usize>(
         &'a mut self,
         table: &'a two_d::TwoDTable<N>,
@@ -1104,7 +1105,7 @@ impl<'d> Channel<'d> {
     /// The caller must ensure that no other code is concurrently accessing
     /// the channel registers, and that the `table` remains valid for the
     /// duration of the transfer.
-    #[cfg(gpdma)]
+    #[cfg(gpdma2d)]
     pub unsafe fn restart_linked_list_2d<const N: usize>(&self, table: &two_d::TwoDTable<N>, options: TransferOptions) {
         assert!(
             self.info().supports_2d,

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -21,6 +21,8 @@ use crate::rcc::WakeGuard;
 
 pub mod linked_list;
 pub mod ringbuffered;
+#[cfg(gpdma)]
+pub mod two_d;
 
 pub use vals::Pam as Packing;
 
@@ -58,6 +60,7 @@ impl DmaInfo {
 pub(crate) struct ChannelInfo {
     pub(crate) dma: DmaInfo,
     pub(crate) num: usize,
+    pub(crate) supports_2d: bool,
     #[cfg(feature = "_dual-core")]
     pub(crate) irq: pac::Interrupt,
     #[cfg(feature = "low-power")]
@@ -746,8 +749,20 @@ impl<'d> Channel<'d> {
         state.lli_state.transfer_count.store(0, Ordering::Relaxed)
     }
 
-    /// Configure a linked-list transfer.
-    unsafe fn configure_linked_list<const N: usize>(&self, table: &Table<N>, options: TransferOptions) {
+    /// Internal helper: configure the channel for a linked-list transfer.
+    ///
+    /// Accepts the raw table-derived values so that both `Table` and
+    /// `TwoDTable` can share the same channel setup logic.
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn configure_linked_list_raw(
+        &self,
+        base_address: u16,
+        first_offset: u16,
+        item_count: usize,
+        total_transfer_count: usize,
+        options: TransferOptions,
+        is_2d: bool,
+    ) {
         let info = self.info();
         let ch = info.dma.ch(info.num);
 
@@ -765,22 +780,28 @@ impl<'d> Channel<'d> {
             w.set_ulef(true);
             w.set_usef(true);
         });
-        ch.lbar().write(|reg| reg.set_lba(table.base_address()));
+        ch.lbar().write(|reg| reg.set_lba(base_address));
 
         // Empty LLI0.
         ch.br1().write(|w| w.set_bndt(0));
 
-        // Enable all linked-list field updates.
+        // Enable linked-list field updates. For 2D items the DMA must also
+        // load TR3 and BR2, so UT3/UB2 must be set in the initial LLR to
+        // match the 8-word TwoDItem layout (vs the 6-word LinearItem layout).
         ch.llr().write(|w| {
             w.set_ut1(true);
             w.set_ut2(true);
             w.set_ub1(true);
             w.set_usa(true);
             w.set_uda(true);
+            if is_2d {
+                w.set_ut3(true);
+                w.set_ub2(true);
+            }
             w.set_ull(true);
 
             // Lower two bits are ignored: 32 bit aligned.
-            w.set_la(table.offset_address(0) >> 2);
+            w.set_la(first_offset >> 2);
         });
 
         ch.tr3().write(|_| {}); // no address offsets.
@@ -796,12 +817,12 @@ impl<'d> Channel<'d> {
         });
 
         let state = &STATE[self.channel as usize];
-        state.lli_state.count.store(N, Ordering::Relaxed);
+        state.lli_state.count.store(item_count, Ordering::Relaxed);
         state.lli_state.index.store(0, Ordering::Relaxed);
         state
             .lli_state
             .transfer_count
-            .store(table.transfer_count(), Ordering::Relaxed)
+            .store(total_transfer_count, Ordering::Relaxed)
     }
 
     fn start(&self) {
@@ -1003,7 +1024,44 @@ impl<'d> Channel<'d> {
         table: &'a Table<N>,
         options: TransferOptions,
     ) -> LinkedListTransfer<'a> {
-        self.configure_linked_list(table, options);
+        self.configure_linked_list_raw(
+            table.base_address(),
+            table.offset_address(0),
+            N,
+            table.transfer_count(),
+            options,
+            false,
+        );
+        self.start();
+
+        LinkedListTransfer {
+            _wake_guard: self.info().wake_guard(),
+            channel: self.reborrow(),
+        }
+    }
+
+    /// Create a 2D linked-list DMA transfer.
+    ///
+    /// Requires a channel that supports 2D addressing. Panics if the
+    /// channel does not have 2D capability.
+    #[cfg(gpdma)]
+    pub unsafe fn linked_list_2d<'a, const N: usize>(
+        &'a mut self,
+        table: &'a two_d::TwoDTable<N>,
+        options: TransferOptions,
+    ) -> LinkedListTransfer<'a> {
+        assert!(
+            self.info().supports_2d,
+            "2D linked-list transfers require a 2D-capable channel (check RM for your chip)"
+        );
+        self.configure_linked_list_raw(
+            table.base_address(),
+            table.offset_address(0),
+            N,
+            table.transfer_count(),
+            options,
+            true,
+        );
         self.start();
 
         LinkedListTransfer {
@@ -1025,7 +1083,41 @@ impl<'d> Channel<'d> {
     /// the channel registers, and that the `table` remains valid for the
     /// duration of the transfer.
     pub unsafe fn restart_linked_list<const N: usize>(&self, table: &Table<N>, options: TransferOptions) {
-        self.configure_linked_list(table, options);
+        self.configure_linked_list_raw(
+            table.base_address(),
+            table.offset_address(0),
+            N,
+            table.transfer_count(),
+            options,
+            false,
+        );
+        self.start();
+    }
+
+    /// Reconfigure and restart a 2D linked-list transfer from item[0].
+    ///
+    /// Requires a channel that supports 2D addressing. Panics if the
+    /// channel does not have 2D capability.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that no other code is concurrently accessing
+    /// the channel registers, and that the `table` remains valid for the
+    /// duration of the transfer.
+    #[cfg(gpdma)]
+    pub unsafe fn restart_linked_list_2d<const N: usize>(&self, table: &two_d::TwoDTable<N>, options: TransferOptions) {
+        assert!(
+            self.info().supports_2d,
+            "2D linked-list transfers require a 2D-capable channel (check RM for your chip)"
+        );
+        self.configure_linked_list_raw(
+            table.base_address(),
+            table.offset_address(0),
+            N,
+            table.transfer_count(),
+            options,
+            true,
+        );
         self.start();
     }
 }

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -118,8 +118,16 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
 
     /// Start the ring buffer operation.
     pub fn start(&mut self) {
-        // Apply the default configuration to the channel.
-        unsafe { self.channel.configure_linked_list(&self.table, self.options) };
+        unsafe {
+            self.channel.configure_linked_list_raw(
+                self.table.base_address(),
+                self.table.offset_address(0),
+                1,
+                self.table.transfer_count(),
+                self.options,
+                false,
+            );
+        }
         self.table.link(RunMode::Circular);
         self.channel.start();
     }
@@ -284,8 +292,16 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
 
     /// Start the ring buffer operation.
     pub fn start(&mut self) {
-        // Apply the default configuration to the channel.
-        unsafe { self.channel.configure_linked_list(&self.table, self.options) };
+        unsafe {
+            self.channel.configure_linked_list_raw(
+                self.table.base_address(),
+                self.table.offset_address(0),
+                1,
+                self.table.transfer_count(),
+                self.options,
+                false,
+            );
+        }
         self.table.link(RunMode::Circular);
 
         self.channel.start();

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -7,7 +7,7 @@ use core::sync::atomic::{Ordering, fence};
 use core::task::Waker;
 
 use super::{Channel, STATE, TransferOptions};
-use crate::dma::gpdma::linked_list::{RunMode, Table};
+use crate::dma::gpdma::linked_list::{LinearItem, RunMode, Table};
 use crate::dma::ringbuffer::{DmaCtrl, Error, ReadableDmaRingBuffer, WritableDmaRingBuffer};
 use crate::dma::word::Word;
 use crate::dma::{Dir, Request};
@@ -85,7 +85,7 @@ pub struct ReadableRingBuffer<'a, W: Word> {
     channel: Channel<'a>,
     _wake_guard: WakeGuard,
     ringbuf: ReadableDmaRingBuffer<'a, W>,
-    table: Table<1>,
+    table: Table<LinearItem, 1>,
     options: TransferOptions,
 }
 
@@ -105,7 +105,13 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
         options.half_transfer_ir = true;
         options.complete_transfer_ir = true;
 
-        let table = Table::<1>::new_circular::<W, PW>(request, peri_addr, buffer, Dir::PeripheralToMemory);
+        let table = Table::<LinearItem, 1>::new_circular::<W, PW>(
+            request,
+            peri_addr,
+            buffer,
+            Dir::PeripheralToMemory,
+            Default::default(),
+        );
 
         Self {
             _wake_guard: channel.info().wake_guard(),
@@ -259,7 +265,7 @@ pub struct WritableRingBuffer<'a, W: Word> {
     channel: Channel<'a>,
     _wake_guard: WakeGuard,
     ringbuf: WritableDmaRingBuffer<'a, W>,
-    table: Table<1>,
+    table: Table<LinearItem, 1>,
     options: TransferOptions,
 }
 
@@ -279,7 +285,13 @@ impl<'a, W: Word> WritableRingBuffer<'a, W> {
         options.half_transfer_ir = true;
         options.complete_transfer_ir = true;
 
-        let table = Table::<1>::new_circular::<W, PW>(request, peri_addr, buffer, Dir::MemoryToPeripheral);
+        let table = Table::<LinearItem, 1>::new_circular::<W, PW>(
+            request,
+            peri_addr,
+            buffer,
+            Dir::MemoryToPeripheral,
+            Default::default(),
+        );
 
         Self {
             _wake_guard: channel.info().wake_guard(),

--- a/embassy-stm32/src/dma/gpdma/two_d.rs
+++ b/embassy-stm32/src/dma/gpdma/two_d.rs
@@ -1,0 +1,358 @@
+//! 2D GPDMA linked-list items and tables.
+//!
+//! Provides [`TwoDItem`] and [`TwoDTable`] for GPDMA channels that support
+//! 2D addressing (block repeat with per-burst and per-block address offsets).
+
+use core::mem::size_of;
+
+use stm32_metapac::gpdma::regs;
+use stm32_metapac::gpdma::vals::Dec;
+
+use super::linked_list::{RunMode, build_common_fields};
+use crate::dma::word::{Word, WordSize};
+use crate::dma::{Dir, Request};
+
+/// Configuration for 2D (block-repeat with address offsets) DMA transfers.
+///
+/// These parameters control how addresses are stepped after each burst
+/// and each block repeat.
+#[derive(Debug, Copy, Clone)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TwoDConfig {
+    /// Number of block repeats (0 = single block, no repeat).
+    pub block_repeat_count: u16,
+    /// Per-burst source address offset (13-bit signed, in bytes).
+    pub src_addr_offset: i16,
+    /// Per-burst destination address offset (13-bit signed, in bytes).
+    pub dst_addr_offset: i16,
+    /// Per-block-repeat source address offset (range: -65535..=65535, in bytes).
+    /// Applied at the end of each block.
+    pub block_src_addr_offset: i32,
+    /// Per-block-repeat destination address offset (range: -65535..=65535, in bytes).
+    /// Applied at the end of each block.
+    pub block_dst_addr_offset: i32,
+}
+
+/// A linked-list item for 2D GPDMA transfers (block repeat with address offsets).
+///
+/// This is an 8-word (32 byte) descriptor that includes TR3 and BR2
+/// registers for per-burst and per-block-repeat address stepping.
+/// Only usable on GPDMA channels that support 2D addressing.
+#[derive(Debug, Copy, Clone, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(C)]
+pub struct TwoDItem {
+    /// Transfer register 1.
+    pub tr1: regs::ChTr1,
+    /// Transfer register 2.
+    pub tr2: regs::ChTr2,
+    /// Block register 1.
+    pub br1: regs::ChBr1,
+    /// Source address register.
+    pub sar: u32,
+    /// Destination address register.
+    pub dar: u32,
+    /// Transfer register 3 (per-burst address offsets).
+    pub tr3: regs::ChTr3,
+    /// Block register 2 (per-block-repeat address offsets).
+    pub br2: regs::ChBr2,
+    /// Linked-list address register.
+    pub llr: regs::ChLlr,
+}
+
+const _: () = core::assert!(size_of::<TwoDItem>() == 32);
+
+impl TwoDItem {
+    /// Create a new 2D read DMA transfer (peripheral to memory).
+    pub unsafe fn new_read<'d, MW: Word, PW: Word>(
+        request: Request,
+        peri_addr: *mut PW,
+        buf: &'d mut [MW],
+        config: TwoDConfig,
+    ) -> Self {
+        Self::new_inner(
+            request,
+            Dir::PeripheralToMemory,
+            peri_addr as *const u32,
+            buf as *mut [MW] as *mut MW as *mut u32,
+            buf.len(),
+            true,
+            PW::size(),
+            MW::size(),
+            config,
+        )
+    }
+
+    /// Create a new 2D write DMA transfer (memory to peripheral).
+    pub unsafe fn new_write<'d, MW: Word, PW: Word>(
+        request: Request,
+        buf: &'d [MW],
+        peri_addr: *mut PW,
+        config: TwoDConfig,
+    ) -> Self {
+        Self::new_inner(
+            request,
+            Dir::MemoryToPeripheral,
+            peri_addr as *const u32,
+            buf as *const [MW] as *const MW as *mut u32,
+            buf.len(),
+            true,
+            MW::size(),
+            PW::size(),
+            config,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    unsafe fn new_inner(
+        request: Request,
+        dir: Dir,
+        peri_addr: *const u32,
+        mem_addr: *mut u32,
+        mem_len: usize,
+        incr_mem: bool,
+        data_size: WordSize,
+        dst_size: WordSize,
+        config: TwoDConfig,
+    ) -> Self {
+        let (tr1, tr2, mut br1, sar, dar) = build_common_fields(
+            request, dir, peri_addr, mem_addr, mem_len, incr_mem, data_size, dst_size,
+        );
+
+        assert!(
+            config.block_repeat_count <= 0x7FF,
+            "block_repeat_count must fit in 11 bits (0..=2047)"
+        );
+        assert!(
+            config.src_addr_offset.unsigned_abs() <= 0x1FFF,
+            "src_addr_offset magnitude must fit in 13 bits (0..=8191)"
+        );
+        assert!(
+            config.dst_addr_offset.unsigned_abs() <= 0x1FFF,
+            "dst_addr_offset magnitude must fit in 13 bits (0..=8191)"
+        );
+        assert!(
+            config.block_src_addr_offset.unsigned_abs() <= 0xFFFF,
+            "block_src_addr_offset magnitude must fit in 16 bits (0..=65535)"
+        );
+        assert!(
+            config.block_dst_addr_offset.unsigned_abs() <= 0xFFFF,
+            "block_dst_addr_offset magnitude must fit in 16 bits (0..=65535)"
+        );
+
+        br1.set_brc(config.block_repeat_count);
+
+        let dec = |negative: bool| if negative { Dec::Subtract } else { Dec::Add };
+
+        br1.set_sdec(dec(config.src_addr_offset < 0));
+        br1.set_ddec(dec(config.dst_addr_offset < 0));
+        br1.set_brsdec(dec(config.block_src_addr_offset < 0));
+        br1.set_brddec(dec(config.block_dst_addr_offset < 0));
+
+        let mut tr3 = regs::ChTr3(0);
+        tr3.set_sao(config.src_addr_offset.unsigned_abs());
+        tr3.set_dao(config.dst_addr_offset.unsigned_abs());
+
+        let mut br2 = regs::ChBr2(0);
+        br2.set_brsao(config.block_src_addr_offset.unsigned_abs() as u16);
+        br2.set_brdao(config.block_dst_addr_offset.unsigned_abs() as u16);
+
+        Self {
+            tr1,
+            tr2,
+            br1,
+            sar,
+            dar,
+            tr3,
+            br2,
+            llr: regs::ChLlr(0),
+        }
+    }
+
+    /// Link to the next 2D item at the given offset address.
+    ///
+    /// Enables update bits for all 8 fields (UT1, UT2, UB1, USA, UDA, UT3, UB2, ULL).
+    pub fn link_to(&mut self, next: u16) {
+        let mut llr = regs::ChLlr(0);
+
+        llr.set_ut1(true);
+        llr.set_ut2(true);
+        llr.set_ub1(true);
+        llr.set_usa(true);
+        llr.set_uda(true);
+        llr.set_ut3(true);
+        llr.set_ub2(true);
+        llr.set_ull(true);
+
+        // Lower two bits are ignored: 32 bit aligned.
+        llr.set_la(next >> 2);
+
+        self.llr = llr;
+    }
+
+    /// Unlink the next 2D item.
+    ///
+    /// Disables channel update bits.
+    pub fn unlink(&mut self) {
+        self.llr = regs::ChLlr(0);
+    }
+
+    /// Set the transfer complete event mode (`TR2.TCEM`) for this item.
+    ///
+    /// In linked-list mode, the channel's TR2 register is overwritten by
+    /// each LLI when `UT2` is set, so TCEM must be configured per-item.
+    ///
+    /// See [`TransferCompleteMode`](super::TransferCompleteMode) for details.
+    pub fn set_transfer_complete_mode(&mut self, mode: super::TransferCompleteMode) {
+        self.tr2.set_tcem(mode.into());
+    }
+
+    /// The item's transfer count in number of destination words.
+    pub fn transfer_count(&self) -> usize {
+        let word_size: WordSize = self.tr1.ddw().into();
+        self.br1.bndt() as usize / word_size.bytes()
+    }
+}
+
+/// A table of 2D linked list items.
+#[repr(C)]
+pub struct TwoDTable<const ITEM_COUNT: usize> {
+    /// The items.
+    pub items: [TwoDItem; ITEM_COUNT],
+}
+
+impl<const ITEM_COUNT: usize> TwoDTable<ITEM_COUNT> {
+    /// Create a new table.
+    pub fn new(items: [TwoDItem; ITEM_COUNT]) -> Self {
+        assert!(!items.is_empty());
+
+        Self { items }
+    }
+
+    /// Create a single-LLI circular 2D linked-list table.
+    ///
+    /// Uses one 2D item covering the entire buffer, linked to itself.
+    pub unsafe fn new_circular<MW: Word, PW: Word>(
+        request: Request,
+        peri_addr: *mut PW,
+        buffer: &mut [MW],
+        direction: Dir,
+        config: TwoDConfig,
+    ) -> TwoDTable<1> {
+        let item = match direction {
+            Dir::MemoryToPeripheral => TwoDItem::new_write(request, &buffer[..], peri_addr, config),
+            Dir::PeripheralToMemory => TwoDItem::new_read(request, peri_addr, &mut buffer[..], config),
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for TwoDItem"),
+        };
+
+        TwoDTable::new([item])
+    }
+
+    /// Create a ping-pong 2D linked-list table.
+    ///
+    /// This uses two 2D items, one for each half of the buffer.
+    pub unsafe fn new_ping_pong<MW: Word, PW: Word>(
+        request: Request,
+        peri_addr: *mut PW,
+        buffer: &mut [MW],
+        direction: Dir,
+        config: TwoDConfig,
+    ) -> TwoDTable<2> {
+        let half_len = buffer.len() / 2;
+        assert_eq!(half_len * 2, buffer.len());
+
+        let items = match direction {
+            Dir::MemoryToPeripheral => [
+                TwoDItem::new_write(request, &mut buffer[..half_len], peri_addr, config),
+                TwoDItem::new_write(request, &mut buffer[half_len..], peri_addr, config),
+            ],
+            Dir::PeripheralToMemory => [
+                TwoDItem::new_read(request, peri_addr, &mut buffer[..half_len], config),
+                TwoDItem::new_read(request, peri_addr, &mut buffer[half_len..], config),
+            ],
+            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for TwoDItem"),
+        };
+
+        TwoDTable::new(items)
+    }
+
+    /// Link the table as given by the run mode.
+    pub fn link(&mut self, run_mode: RunMode) {
+        if matches!(run_mode, RunMode::Once | RunMode::Circular) {
+            self.link_sequential();
+        }
+
+        if matches!(run_mode, RunMode::Circular) {
+            self.link_repeat();
+        }
+    }
+
+    /// The number of linked list items.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Whether the table is empty.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// The total transfer count of the table in number of words.
+    pub fn transfer_count(&self) -> usize {
+        let mut count = 0;
+        for item in self.items {
+            count += item.transfer_count() as usize
+        }
+
+        count
+    }
+
+    /// Link items of given indices together: first -> second.
+    pub fn link_indices(&mut self, first: usize, second: usize) {
+        assert!(first < self.len());
+        assert!(second < self.len());
+
+        let second_item = self.offset_address(second);
+        self.items[first].link_to(second_item);
+    }
+
+    /// Link items sequentially.
+    pub fn link_sequential(&mut self) {
+        if self.len() > 1 {
+            for index in 0..(self.items.len() - 1) {
+                let next = self.offset_address(index + 1);
+                self.items[index].link_to(next);
+            }
+        }
+    }
+
+    /// Link last to first item.
+    pub fn link_repeat(&mut self) {
+        let first_address = self.offset_address(0);
+        self.items.last_mut().unwrap().link_to(first_address);
+    }
+
+    /// Unlink all items.
+    pub fn unlink(&mut self) {
+        for item in self.items.iter_mut() {
+            item.unlink();
+        }
+    }
+
+    /// Linked list base address (upper 16 address bits).
+    pub fn base_address(&self) -> u16 {
+        ((&raw const self.items as u32) >> 16) as _
+    }
+
+    /// Linked list offset address (lower 16 address bits) at the selected index.
+    pub fn offset_address(&self, index: usize) -> u16 {
+        assert!(self.items.len() > index);
+
+        let address = &raw const self.items[index] as _;
+
+        // Ensure 32 bit address alignment.
+        assert_eq!(address & 0b11, 0);
+
+        address
+    }
+}

--- a/embassy-stm32/src/dma/gpdma/two_d.rs
+++ b/embassy-stm32/src/dma/gpdma/two_d.rs
@@ -1,6 +1,6 @@
-//! 2D GPDMA linked-list items and tables.
+//! 2D GPDMA linked-list items.
 //!
-//! Provides [`TwoDItem`] and [`TwoDTable`] for GPDMA channels that support
+//! Provides [`TwoDItem`] and [`TwoDConfig`] for GPDMA channels that support
 //! 2D addressing (block repeat with per-burst and per-block address offsets).
 
 use core::mem::size_of;
@@ -8,7 +8,7 @@ use core::mem::size_of;
 use stm32_metapac::gpdma::regs;
 use stm32_metapac::gpdma::vals::Dec;
 
-use super::linked_list::{RunMode, build_common_fields};
+use super::linked_list::{Item, ItemConfig, LinkedListItem};
 use crate::dma::word::{Word, WordSize};
 use crate::dma::{Dir, Request};
 
@@ -18,7 +18,10 @@ use crate::dma::{Dir, Request};
 /// and each block repeat.
 #[derive(Debug, Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub struct TwoDConfig {
+    /// Base linear configuration (transfer complete mode, etc.).
+    pub linear: ItemConfig,
     /// Number of block repeats (0 = single block, no repeat).
     pub block_repeat_count: u16,
     /// Per-burst source address offset (13-bit signed, in bytes).
@@ -33,6 +36,19 @@ pub struct TwoDConfig {
     pub block_dst_addr_offset: i32,
 }
 
+impl Default for TwoDConfig {
+    fn default() -> Self {
+        Self {
+            linear: ItemConfig::default(),
+            block_repeat_count: 0,
+            src_addr_offset: 0,
+            dst_addr_offset: 0,
+            block_src_addr_offset: 0,
+            block_dst_addr_offset: 0,
+        }
+    }
+}
+
 /// A linked-list item for 2D GPDMA transfers (block repeat with address offsets).
 ///
 /// This is an 8-word (32 byte) descriptor that includes TR3 and BR2
@@ -42,16 +58,8 @@ pub struct TwoDConfig {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[repr(C)]
 pub struct TwoDItem {
-    /// Transfer register 1.
-    pub tr1: regs::ChTr1,
-    /// Transfer register 2.
-    pub tr2: regs::ChTr2,
-    /// Block register 1.
-    pub br1: regs::ChBr1,
-    /// Source address register.
-    pub sar: u32,
-    /// Destination address register.
-    pub dar: u32,
+    /// Common item fields (TR1, TR2, BR1, SAR, DAR).
+    pub item: Item,
     /// Transfer register 3 (per-burst address offsets).
     pub tr3: regs::ChTr3,
     /// Block register 2 (per-block-repeat address offsets).
@@ -62,13 +70,15 @@ pub struct TwoDItem {
 
 const _: () = core::assert!(size_of::<TwoDItem>() == 32);
 
-impl TwoDItem {
-    /// Create a new 2D read DMA transfer (peripheral to memory).
-    pub unsafe fn new_read<'d, MW: Word, PW: Word>(
+impl LinkedListItem for TwoDItem {
+    type Config = TwoDConfig;
+    const IS_2D: bool = true;
+
+    unsafe fn new_read<MW: Word, PW: Word>(
         request: Request,
         peri_addr: *mut PW,
-        buf: &'d mut [MW],
-        config: TwoDConfig,
+        buf: &mut [MW],
+        config: Self::Config,
     ) -> Self {
         Self::new_inner(
             request,
@@ -83,12 +93,11 @@ impl TwoDItem {
         )
     }
 
-    /// Create a new 2D write DMA transfer (memory to peripheral).
-    pub unsafe fn new_write<'d, MW: Word, PW: Word>(
+    unsafe fn new_write<MW: Word, PW: Word>(
         request: Request,
-        buf: &'d [MW],
+        buf: &[MW],
         peri_addr: *mut PW,
-        config: TwoDConfig,
+        config: Self::Config,
     ) -> Self {
         Self::new_inner(
             request,
@@ -103,6 +112,34 @@ impl TwoDItem {
         )
     }
 
+    fn link_to(&mut self, next: u16) {
+        let mut llr = regs::ChLlr(0);
+
+        llr.set_ut1(true);
+        llr.set_ut2(true);
+        llr.set_ub1(true);
+        llr.set_usa(true);
+        llr.set_uda(true);
+        llr.set_ut3(true);
+        llr.set_ub2(true);
+        llr.set_ull(true);
+
+        // Lower two bits are ignored: 32 bit aligned.
+        llr.set_la(next >> 2);
+
+        self.llr = llr;
+    }
+
+    fn unlink(&mut self) {
+        self.llr = regs::ChLlr(0);
+    }
+
+    fn transfer_count(&self) -> usize {
+        self.item.transfer_count()
+    }
+}
+
+impl TwoDItem {
     #[allow(clippy::too_many_arguments)]
     unsafe fn new_inner(
         request: Request,
@@ -115,9 +152,10 @@ impl TwoDItem {
         dst_size: WordSize,
         config: TwoDConfig,
     ) -> Self {
-        let (tr1, tr2, mut br1, sar, dar) = build_common_fields(
+        let mut item = Item::new(
             request, dir, peri_addr, mem_addr, mem_len, incr_mem, data_size, dst_size,
         );
+        item.apply_config(&config.linear);
 
         assert!(
             config.block_repeat_count <= 0x7FF,
@@ -140,14 +178,14 @@ impl TwoDItem {
             "block_dst_addr_offset magnitude must fit in 16 bits (0..=65535)"
         );
 
-        br1.set_brc(config.block_repeat_count);
+        item.br1.set_brc(config.block_repeat_count);
 
         let dec = |negative: bool| if negative { Dec::Subtract } else { Dec::Add };
 
-        br1.set_sdec(dec(config.src_addr_offset < 0));
-        br1.set_ddec(dec(config.dst_addr_offset < 0));
-        br1.set_brsdec(dec(config.block_src_addr_offset < 0));
-        br1.set_brddec(dec(config.block_dst_addr_offset < 0));
+        item.br1.set_sdec(dec(config.src_addr_offset < 0));
+        item.br1.set_ddec(dec(config.dst_addr_offset < 0));
+        item.br1.set_brsdec(dec(config.block_src_addr_offset < 0));
+        item.br1.set_brddec(dec(config.block_dst_addr_offset < 0));
 
         let mut tr3 = regs::ChTr3(0);
         tr3.set_sao(config.src_addr_offset.unsigned_abs());
@@ -158,201 +196,10 @@ impl TwoDItem {
         br2.set_brdao(config.block_dst_addr_offset.unsigned_abs() as u16);
 
         Self {
-            tr1,
-            tr2,
-            br1,
-            sar,
-            dar,
+            item,
             tr3,
             br2,
             llr: regs::ChLlr(0),
         }
-    }
-
-    /// Link to the next 2D item at the given offset address.
-    ///
-    /// Enables update bits for all 8 fields (UT1, UT2, UB1, USA, UDA, UT3, UB2, ULL).
-    pub fn link_to(&mut self, next: u16) {
-        let mut llr = regs::ChLlr(0);
-
-        llr.set_ut1(true);
-        llr.set_ut2(true);
-        llr.set_ub1(true);
-        llr.set_usa(true);
-        llr.set_uda(true);
-        llr.set_ut3(true);
-        llr.set_ub2(true);
-        llr.set_ull(true);
-
-        // Lower two bits are ignored: 32 bit aligned.
-        llr.set_la(next >> 2);
-
-        self.llr = llr;
-    }
-
-    /// Unlink the next 2D item.
-    ///
-    /// Disables channel update bits.
-    pub fn unlink(&mut self) {
-        self.llr = regs::ChLlr(0);
-    }
-
-    /// Set the transfer complete event mode (`TR2.TCEM`) for this item.
-    ///
-    /// In linked-list mode, the channel's TR2 register is overwritten by
-    /// each LLI when `UT2` is set, so TCEM must be configured per-item.
-    ///
-    /// See [`TransferCompleteMode`](super::TransferCompleteMode) for details.
-    pub fn set_transfer_complete_mode(&mut self, mode: super::TransferCompleteMode) {
-        self.tr2.set_tcem(mode.into());
-    }
-
-    /// The item's transfer count in number of destination words.
-    pub fn transfer_count(&self) -> usize {
-        let word_size: WordSize = self.tr1.ddw().into();
-        self.br1.bndt() as usize / word_size.bytes()
-    }
-}
-
-/// A table of 2D linked list items.
-#[repr(C)]
-pub struct TwoDTable<const ITEM_COUNT: usize> {
-    /// The items.
-    pub items: [TwoDItem; ITEM_COUNT],
-}
-
-impl<const ITEM_COUNT: usize> TwoDTable<ITEM_COUNT> {
-    /// Create a new table.
-    pub fn new(items: [TwoDItem; ITEM_COUNT]) -> Self {
-        assert!(!items.is_empty());
-
-        Self { items }
-    }
-
-    /// Create a single-LLI circular 2D linked-list table.
-    ///
-    /// Uses one 2D item covering the entire buffer, linked to itself.
-    pub unsafe fn new_circular<MW: Word, PW: Word>(
-        request: Request,
-        peri_addr: *mut PW,
-        buffer: &mut [MW],
-        direction: Dir,
-        config: TwoDConfig,
-    ) -> TwoDTable<1> {
-        let item = match direction {
-            Dir::MemoryToPeripheral => TwoDItem::new_write(request, &buffer[..], peri_addr, config),
-            Dir::PeripheralToMemory => TwoDItem::new_read(request, peri_addr, &mut buffer[..], config),
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for TwoDItem"),
-        };
-
-        TwoDTable::new([item])
-    }
-
-    /// Create a ping-pong 2D linked-list table.
-    ///
-    /// This uses two 2D items, one for each half of the buffer.
-    pub unsafe fn new_ping_pong<MW: Word, PW: Word>(
-        request: Request,
-        peri_addr: *mut PW,
-        buffer: &mut [MW],
-        direction: Dir,
-        config: TwoDConfig,
-    ) -> TwoDTable<2> {
-        let half_len = buffer.len() / 2;
-        assert_eq!(half_len * 2, buffer.len());
-
-        let items = match direction {
-            Dir::MemoryToPeripheral => [
-                TwoDItem::new_write(request, &mut buffer[..half_len], peri_addr, config),
-                TwoDItem::new_write(request, &mut buffer[half_len..], peri_addr, config),
-            ],
-            Dir::PeripheralToMemory => [
-                TwoDItem::new_read(request, peri_addr, &mut buffer[..half_len], config),
-                TwoDItem::new_read(request, peri_addr, &mut buffer[half_len..], config),
-            ],
-            Dir::MemoryToMemory => panic!("memory-to-memory transfers are not valid for TwoDItem"),
-        };
-
-        TwoDTable::new(items)
-    }
-
-    /// Link the table as given by the run mode.
-    pub fn link(&mut self, run_mode: RunMode) {
-        if matches!(run_mode, RunMode::Once | RunMode::Circular) {
-            self.link_sequential();
-        }
-
-        if matches!(run_mode, RunMode::Circular) {
-            self.link_repeat();
-        }
-    }
-
-    /// The number of linked list items.
-    pub fn len(&self) -> usize {
-        self.items.len()
-    }
-
-    /// Whether the table is empty.
-    pub fn is_empty(&self) -> bool {
-        self.items.is_empty()
-    }
-
-    /// The total transfer count of the table in number of words.
-    pub fn transfer_count(&self) -> usize {
-        let mut count = 0;
-        for item in self.items {
-            count += item.transfer_count() as usize
-        }
-
-        count
-    }
-
-    /// Link items of given indices together: first -> second.
-    pub fn link_indices(&mut self, first: usize, second: usize) {
-        assert!(first < self.len());
-        assert!(second < self.len());
-
-        let second_item = self.offset_address(second);
-        self.items[first].link_to(second_item);
-    }
-
-    /// Link items sequentially.
-    pub fn link_sequential(&mut self) {
-        if self.len() > 1 {
-            for index in 0..(self.items.len() - 1) {
-                let next = self.offset_address(index + 1);
-                self.items[index].link_to(next);
-            }
-        }
-    }
-
-    /// Link last to first item.
-    pub fn link_repeat(&mut self) {
-        let first_address = self.offset_address(0);
-        self.items.last_mut().unwrap().link_to(first_address);
-    }
-
-    /// Unlink all items.
-    pub fn unlink(&mut self) {
-        for item in self.items.iter_mut() {
-            item.unlink();
-        }
-    }
-
-    /// Linked list base address (upper 16 address bits).
-    pub fn base_address(&self) -> u16 {
-        ((&raw const self.items as u32) >> 16) as _
-    }
-
-    /// Linked list offset address (lower 16 address bits) at the selected index.
-    pub fn offset_address(&self, index: usize) -> u16 {
-        assert!(self.items.len() > index);
-
-        let address = &raw const self.items[index] as _;
-
-        // Ensure 32 bit address alignment.
-        assert_eq!(address & 0b11, 0);
-
-        address
     }
 }

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -10,11 +10,11 @@ pub use dma_bdma::*;
 #[cfg(any(gpdma, lpdma))]
 pub(crate) mod gpdma;
 #[cfg(any(gpdma, lpdma))]
-pub use gpdma::linked_list::{LinearItem, RunMode, Table};
+pub use gpdma::linked_list::{Item, ItemConfig, LinearItem, LinearItemConfig, LinkedListItem, RunMode, Table};
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::ringbuffered::*;
 #[cfg(gpdma2d)]
-pub use gpdma::two_d::{TwoDConfig, TwoDItem, TwoDTable};
+pub use gpdma::two_d::{TwoDConfig, TwoDItem};
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::*;
 

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod gpdma;
 pub use gpdma::linked_list::{LinearItem, RunMode, Table};
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::ringbuffered::*;
-#[cfg(gpdma)]
+#[cfg(gpdma2d)]
 pub use gpdma::two_d::{TwoDConfig, TwoDItem, TwoDTable};
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::*;
@@ -114,14 +114,14 @@ pub trait ChannelInstance: SealedChannelInstance + PeripheralType + 'static {
     type Interrupt: interrupt::typelevel::Interrupt;
 }
 
-#[cfg(gpdma)]
+#[cfg(gpdma2d)]
 pub(crate) trait SealedTwoDChannelInstance {}
 
 /// DMA channel with 2D addressing capability (block repeat with address offsets).
 ///
 /// This trait is only implemented for GPDMA channels that support 2D transfers.
 /// Use it as a bound to require a 2D-capable channel at compile time.
-#[cfg(gpdma)]
+#[cfg(gpdma2d)]
 #[allow(private_bounds)]
 pub trait TwoDChannelInstance: ChannelInstance + SealedTwoDChannelInstance {}
 
@@ -149,7 +149,7 @@ macro_rules! dma_channel_impl {
     };
 }
 
-#[cfg(gpdma)]
+#[cfg(gpdma2d)]
 macro_rules! dma_channel_2d_impl {
     ($channel_peri:ident) => {
         impl crate::dma::SealedTwoDChannelInstance for crate::peripherals::$channel_peri {}

--- a/embassy-stm32/src/dma/mod.rs
+++ b/embassy-stm32/src/dma/mod.rs
@@ -13,6 +13,8 @@ pub(crate) mod gpdma;
 pub use gpdma::linked_list::{LinearItem, RunMode, Table};
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::ringbuffered::*;
+#[cfg(gpdma)]
+pub use gpdma::two_d::{TwoDConfig, TwoDItem, TwoDTable};
 #[cfg(any(gpdma, lpdma))]
 pub use gpdma::*;
 
@@ -112,6 +114,17 @@ pub trait ChannelInstance: SealedChannelInstance + PeripheralType + 'static {
     type Interrupt: interrupt::typelevel::Interrupt;
 }
 
+#[cfg(gpdma)]
+pub(crate) trait SealedTwoDChannelInstance {}
+
+/// DMA channel with 2D addressing capability (block repeat with address offsets).
+///
+/// This trait is only implemented for GPDMA channels that support 2D transfers.
+/// Use it as a bound to require a 2D-capable channel at compile time.
+#[cfg(gpdma)]
+#[allow(private_bounds)]
+pub trait TwoDChannelInstance: ChannelInstance + SealedTwoDChannelInstance {}
+
 /// DMA interrupt handler.
 #[allow(private_bounds)]
 pub struct InterruptHandler<T: ChannelInstance> {
@@ -133,6 +146,14 @@ macro_rules! dma_channel_impl {
         impl crate::dma::ChannelInstance for crate::peripherals::$channel_peri {
             type Interrupt = $irq;
         }
+    };
+}
+
+#[cfg(gpdma)]
+macro_rules! dma_channel_2d_impl {
+    ($channel_peri:ident) => {
+        impl crate::dma::SealedTwoDChannelInstance for crate::peripherals::$channel_peri {}
+        impl crate::dma::TwoDChannelInstance for crate::peripherals::$channel_peri {}
     };
 }
 


### PR DESCRIPTION
Adds support for GPDMA 2D addressing (block repeat with per-burst and per-block address offsets) through a new `TwoDItem` descriptor and `TwoDConfig`, gated behind a `gpdma2d` cfg that build.rs enables when any DMA channel has `supports_2d`.

The main structural change: `LinearItem` was previously a concrete struct with its own `Table`. Now there's a `LinkedListItem` trait that both `LinearItem` and `TwoDItem` implement, and `Table<T, N>` is generic over the item type. This lets the same table/linking infrastructure work for both linear and 2D transfers without duplication.

The common 5-word descriptor prefix (TR1, TR2, BR1, SAR, DAR) is factored into a shared `Item` struct that both item types embed as their first #[repr(C)] field, preserving the hardware-required memory layout. `Item` owns construction (Item::new), config application (apply_config), and transfer_count -- so when new common config knobs are added, there's one place to handle them.

On the channel side, `configure_linked_list_raw` replaces the old `configure_linked_list` to accept raw table parameters (base address, offset, count, transfer count, is_2d flag), so both item types can share the same channel setup without the channel needing to know the concrete item type. 2D items set UT3/UB2 in the initial LLR so the DMA loads the extra TR3/BR2 words.

Build.rs picks up `supports_2d` from stm32-data's DMA channel metadata and emits `dma_channel_2d_impl!` for those channels, implementing the new `TwoDChannelInstance` marker trait for compile-time 2D capability checking.
