### PR TITLE
Update stm32-metapac to stm32-data-75cfa09

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.3"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-81a0691bb74668219b39408222a1c9a607033084" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-75cfa09e93a6c7275d14ecb5c8b5e95b2ab2dae2" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-81a0691bb74668219b39408222a1c9a607033084" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-75cfa09e93a6c7275d14ecb5c8b5e95b2ab2dae2" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.107"
 quote = "1.0.47"

--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -513,7 +513,7 @@ fn enable_low_power_peripherals() {
         w.set_eth1rxlpen(true);
         w.set_eth1txlpen(true);
         w.set_eth1maclpen(true);
-        w.set_gpulpen(true);
+        w.set_gpu2dlpen(true);
         w.set_gfxmmulpen(true);
         w.set_mce4lpen(true);
         w.set_xspi3lpen(true);


### PR DESCRIPTION
## Summary
- Bumps `stm32-metapac` to `stm32-data-75cfa09e93a6c7275d14ecb5c8b5e95b2ab2dae2`
- Adapts N6 RCC low-power clock enable for the renamed `gpu2dlpen` field (previously `gpulpen`) in the new PAC