### PR TITLE
stm32: low-power fixes for u5/u3

### DIFF
--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -971,6 +971,8 @@ fn init_hw(config: Config) -> Peripherals {
             // must be after time-driver init
             #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
             rtc::init_rtc(cs, config.rtc, config.min_stop_pause);
+            #[cfg(all(feature = "low-power", feature = "_lp-time-driver"))]
+            crate::time_driver::LPTimeDriver::set_min_stop_pause(crate::time_driver::get_driver(), cs, config.min_stop_pause);
         }
 
         p

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -972,7 +972,11 @@ fn init_hw(config: Config) -> Peripherals {
             #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]
             rtc::init_rtc(cs, config.rtc, config.min_stop_pause);
             #[cfg(all(feature = "low-power", feature = "_lp-time-driver"))]
-            crate::time_driver::LPTimeDriver::set_min_stop_pause(crate::time_driver::get_driver(), cs, config.min_stop_pause);
+            crate::time_driver::LPTimeDriver::set_min_stop_pause(
+                crate::time_driver::get_driver(),
+                cs,
+                config.min_stop_pause,
+            );
         }
 
         p

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -207,6 +207,30 @@ mod platform {
 
     /// Exit stop mode, reinitializing timer and rcc if required
     pub fn exit_stop(_cs: CriticalSection) {
+        #[cfg(any(stm32u5, stm32u3))]
+        {
+            let sr = crate::pac::PWR.sr().read();
+            if sr.stopf() {
+                let lpms = crate::pac::PWR.cr1().read().lpms();
+                debug!("low power: U5/U3 woke from STOP (LPMS={})", lpms);
+
+                // HSE and all PLLs stop in any STOP mode on U5/U3.
+                // Full RCC restore from saved config on every STOP exit.
+                crate::rcc::reinit_saved(_cs);
+
+                // GPTIM timer state is lost in Stop2/Stop3, needs re-init.
+                // LPTIM (_lp-time-driver) survives all STOP modes autonomously.
+                #[cfg(not(feature = "_lp-time-driver"))]
+                if lpms >= 2 {
+                    trace!("low power: re-initializing timer (STOP2+, GPTIM)");
+                    super::get_driver().init_timer(_cs);
+                }
+            }
+
+            // Clear STOPF by writing CSSF
+            crate::pac::PWR.sr().modify(|w| w.set_cssf(true));
+        }
+
         #[cfg(any(stm32wl, stm32wb, stm32wba))]
         {
             // stm32wl5x is dual core and we don't want BOTH cores to re-initialize RCC so we hold a lock

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -365,6 +365,11 @@ impl super::LPTimeDriver for RtcDriver {
         trace!("resume_time");
         self.is_stopped.store(false, Ordering::Relaxed);
     }
+
+    fn set_min_stop_pause(&self, cs: CriticalSection, min_stop_pause: embassy_time::Duration) {
+        trace!("set_min_stop_pause: {} ticks", min_stop_pause.as_ticks());
+        self.min_stop_pause.borrow(cs).replace(min_stop_pause);
+    }
 }
 
 impl Driver for RtcDriver {

--- a/embassy-stm32/src/time_driver/mod.rs
+++ b/embassy-stm32/src/time_driver/mod.rs
@@ -24,7 +24,6 @@ pub(crate) trait LPTimeDriver {
     fn time_until_next_alarm(&self, cs: CriticalSection) -> embassy_time::Duration;
 
     /// Set the minimum pause time beyond which the executor will enter a low-power state.
-    #[cfg(not(feature = "_lp-time-driver"))]
     fn set_min_stop_pause(&self, cs: CriticalSection, min_stop_pause: embassy_time::Duration);
 
     /// Set the rtc but panic if it's already been set


### PR DESCRIPTION
This fixes two related issues preventing correct `low-power` operation with stm32u5.

1) stm32::low_power::platform::exit_stop() did not reinit RCC for u5/u3 chips, meaning the default RCC was used on wake, which obviously breaks most non-trivial firmwares (see bbe95325fce8c5ec611a22daebad62e83c5a6d09)

2) `config.min_stop_pause` was only used to configure `low-power` timers that operate via the RTC, whereas lptim is independent, and therefore effectively hard-coded `min_stop_pause = 0`. ee43b2a2ae70e5039fd905d1880d040173a384ed passes `min_stop_pause` to the `LPTimDriver`, ensuring the config value is respected


As noted in commits: these have only been tested on stm32u5, as I have no u3 around, however I have done some rather cursory cross-checking of the RMs that indicated u3 behaves identically in these respects. Would be happy to be proven wrong by someone with a u3 in hand :)

best,
K