### PR TITLE
embassy-nxp: migrate to nxp-pac 8512ece

### DIFF
--- a/embassy-nxp/Cargo.toml
+++ b/embassy-nxp/Cargo.toml
@@ -40,13 +40,13 @@ embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-ut
 embedded-io = { version = "0.7.1" }
 embedded-hal-02 = { package = "embedded-hal", version = "0.2.6", features = ["unproven"] }
 ## Chip dependencies
-nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "47dada0976da4114c348ea16f5ead31f38f36eea" }
+nxp-pac = { version = "0.1.0", optional = true, git = "https://github.com/embassy-rs/nxp-pac", rev = "8512ecedcd0fe9c2713d06f3bbd1b7f93805f306" }
 
 imxrt-rt = { version = "0.1.7", optional = true, features = ["device"] }
 
 [build-dependencies]
 cfg_aliases = "0.2.1"
-nxp-pac = { version = "0.1.0", git = "https://github.com/embassy-rs/nxp-pac", rev = "47dada0976da4114c348ea16f5ead31f38f36eea", features = ["metadata"] }
+nxp-pac = { version = "0.1.0", git = "https://github.com/embassy-rs/nxp-pac", rev = "8512ecedcd0fe9c2713d06f3bbd1b7f93805f306", default-features = false, features = ["metadata"] }
 proc-macro2 = "1.0.95"
 quote = "1.0.15"
 

--- a/embassy-nxp/build.rs
+++ b/embassy-nxp/build.rs
@@ -240,7 +240,7 @@ fn generate_code(cfgs: &mut common::CfgSet, singletons: &[Singleton]) {
 }
 
 fn interrupts() -> TokenStream {
-    let interrupts = METADATA.interrupts.iter().map(|interrupt| format_ident!("{interrupt}"));
+    let interrupts = METADATA.interrupts.iter().map(|(name, _)| format_ident!("{name}"));
 
     quote! {
         embassy_hal_internal::interrupt_mod!(#(#interrupts),*);
@@ -342,7 +342,7 @@ fn impl_usart(cfgs: &mut common::CfgSet, impls: &mut Vec<TokenStream>, periphera
         };
 
         for pin in signal.pins {
-            let alt = format_ident!("ALT{}", pin.alt);
+            let alt = format_ident!("Alt{}", pin.alt);
             let pin = format_ident!("{}", pin.pin);
 
             impls.push(quote! {
@@ -388,7 +388,7 @@ fn impl_sct(impls: &mut Vec<TokenStream>, peripheral: &Peripheral) {
             if signal.name.starts_with("OUT") {
                 for pin in signal.pins {
                     let pin_name = format_ident!("{}", pin.pin);
-                    let alt = format_ident!("ALT{}", pin.alt);
+                    let alt = format_ident!("Alt{}", pin.alt);
 
                     impls.push(quote! {
                         impl_sct_output_pin!(#instance, #channel_name, #pin_name, #alt);

--- a/embassy-nxp/src/dma/lpc55.rs
+++ b/embassy-nxp/src/dma/lpc55.rs
@@ -49,10 +49,10 @@ pub(crate) fn init() {
     // Reset DMA
     SYSCON
         .presetctrl0()
-        .modify(|w| w.set_dma0_rst(syscon::vals::Dma0Rst::ASSERTED));
+        .modify(|w| w.set_dma0_rst(syscon::vals::Dma0Rst::Asserted));
     SYSCON
         .presetctrl0()
-        .modify(|w| w.set_dma0_rst(syscon::vals::Dma0Rst::RELEASED));
+        .modify(|w| w.set_dma0_rst(syscon::vals::Dma0Rst::Released));
 
     // Address bits 31:9 of the beginning of the DMA descriptor table
     critical_section::with(|cs| {
@@ -180,14 +180,14 @@ fn copy_inner<'a, C: Channel>(
         w.set_setintb(false);
         w.set_width(data_size);
         w.set_srcinc(if incr_src {
-            dma::vals::Srcinc::WIDTH_X_1
+            dma::vals::Srcinc::WidthX1
         } else {
-            dma::vals::Srcinc::NO_INCREMENT
+            dma::vals::Srcinc::NoIncrement
         });
         w.set_dstinc(if incr_dest {
-            dma::vals::Dstinc::WIDTH_X_1
+            dma::vals::Dstinc::WidthX1
         } else {
-            dma::vals::Dstinc::NO_INCREMENT
+            dma::vals::Dstinc::NoIncrement
         });
         // Total number of transfers to be performed, minus 1 encoded.
         w.set_xfercount((len as u16) - 1);
@@ -308,21 +308,21 @@ pub trait Word: SealedWord {
 impl SealedWord for u8 {}
 impl Word for u8 {
     fn size() -> crate::pac::dma::vals::Width {
-        crate::pac::dma::vals::Width::BIT_8
+        crate::pac::dma::vals::Width::Bit8
     }
 }
 
 impl SealedWord for u16 {}
 impl Word for u16 {
     fn size() -> crate::pac::dma::vals::Width {
-        crate::pac::dma::vals::Width::BIT_16
+        crate::pac::dma::vals::Width::Bit16
     }
 }
 
 impl SealedWord for u32 {}
 impl Word for u32 {
     fn size() -> crate::pac::dma::vals::Width {
-        crate::pac::dma::vals::Width::BIT_32
+        crate::pac::dma::vals::Width::Bit32
     }
 }
 

--- a/embassy-nxp/src/gpio/lpc55.rs
+++ b/embassy-nxp/src/gpio/lpc55.rs
@@ -193,9 +193,9 @@ impl<'d> Flex<'d> {
     /// Set the pull configuration for the pin. To disable the pull, use [Pull::None].
     pub fn set_pull(&mut self, pull: Pull) {
         self.pin.pio().modify(|w| match pull {
-            Pull::None => w.set_mode(PioMode::INACTIVE),
-            Pull::Up => w.set_mode(PioMode::PULL_UP),
-            Pull::Down => w.set_mode(PioMode::PULL_DOWN),
+            Pull::None => w.set_mode(PioMode::Inactive),
+            Pull::Up => w.set_mode(PioMode::PullUp),
+            Pull::Down => w.set_mode(PioMode::PullDown),
         });
     }
 
@@ -203,7 +203,7 @@ impl<'d> Flex<'d> {
     /// setting for pins is (usually) non-digital.
     fn set_as_digital(&mut self) {
         self.pin.pio().modify(|w| {
-            w.set_digimode(PioDigimode::DIGITAL);
+            w.set_digimode(PioDigimode::Digital);
         });
     }
 

--- a/embassy-nxp/src/gpio/rt1xxx.rs
+++ b/embassy-nxp/src/gpio/rt1xxx.rs
@@ -150,11 +150,11 @@ impl<'d> Flex<'d> {
     #[inline]
     pub fn set_pull(&mut self, pull: Pull) {
         let (pke, pue, pus) = match pull {
-            Pull::None => (false, true, Pus::PUS_0_100K_OHM_PULL_DOWN),
-            Pull::Up22K => (true, true, Pus::PUS_3_22K_OHM_PULL_UP),
-            Pull::Up47K => (true, true, Pus::PUS_1_47K_OHM_PULL_UP),
-            Pull::Up100K => (true, true, Pus::PUS_2_100K_OHM_PULL_UP),
-            Pull::Down100K => (true, true, Pus::PUS_0_100K_OHM_PULL_DOWN),
+            Pull::None => (false, true, Pus::Pus0100kOhmPullDown),
+            Pull::Up22K => (true, true, Pus::Pus322kOhmPullUp),
+            Pull::Up47K => (true, true, Pus::Pus147kOhmPullUp),
+            Pull::Up100K => (true, true, Pus::Pus2100kOhmPullUp),
+            Pull::Down100K => (true, true, Pus::Pus0100kOhmPullDown),
         };
 
         self.pin.pad().modify(|w| {
@@ -248,7 +248,7 @@ impl<'d> Flex<'d> {
             w.set_ode(false);
             w.set_pke(false);
             w.set_pue(false);
-            w.set_pus(Pus::PUS_0_100K_OHM_PULL_DOWN);
+            w.set_pus(Pus::Pus0100kOhmPullDown);
         });
     }
 
@@ -741,11 +741,11 @@ impl<'d> InputFuture<'d> {
         let block = pin.block();
 
         let (icr, edge_sel) = match config {
-            InterruptConfiguration::Low => (Icr::LOW_LEVEL, false),
-            InterruptConfiguration::High => (Icr::HIGH_LEVEL, false),
-            InterruptConfiguration::RisingEdge => (Icr::RISING_EDGE, false),
-            InterruptConfiguration::FallingEdge => (Icr::FALLING_EDGE, false),
-            InterruptConfiguration::AnyEdge => (Icr::FALLING_EDGE, true),
+            InterruptConfiguration::Low => (Icr::LowLevel, false),
+            InterruptConfiguration::High => (Icr::HighLevel, false),
+            InterruptConfiguration::RisingEdge => (Icr::RisingEdge, false),
+            InterruptConfiguration::FallingEdge => (Icr::FallingEdge, false),
+            InterruptConfiguration::AnyEdge => (Icr::FallingEdge, true),
         };
 
         let index = if pin.pin_number() > 15 { 1 } else { 0 };

--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -113,12 +113,12 @@ pub fn init(_config: config::Config) -> Peripherals {
         // The RT1010 Reference manual states that core clock root must be switched before
         // reprogramming PLL2.
         pac::CCM.cbcdr().modify(|w| {
-            w.set_periph_clk_sel(pac::ccm::vals::PeriphClkSel::PERIPH_CLK_SEL_1);
+            w.set_periph_clk_sel(pac::ccm::vals::PeriphClkSel::PeriphClkSel1);
         });
 
         while matches!(
             pac::CCM.cdhipr().read().periph_clk_sel_busy(),
-            pac::ccm::vals::PeriphClkSelBusy::PERIPH_CLK_SEL_BUSY_1
+            pac::ccm::vals::PeriphClkSelBusy::PeriphClkSelBusy1
         ) {}
 
         info!("Core clock root switched");
@@ -137,16 +137,16 @@ pub fn init(_config: config::Config) -> Peripherals {
         // Clock core clock with PLL 2.
         pac::CCM
             .cbcdr()
-            .modify(|x| x.set_periph_clk_sel(pac::ccm::vals::PeriphClkSel::PERIPH_CLK_SEL_0)); // false
+            .modify(|x| x.set_periph_clk_sel(pac::ccm::vals::PeriphClkSel::PeriphClkSel0)); // false
 
         while matches!(
             pac::CCM.cdhipr().read().periph_clk_sel_busy(),
-            pac::ccm::vals::PeriphClkSelBusy::PERIPH_CLK_SEL_BUSY_1
+            pac::ccm::vals::PeriphClkSelBusy::PeriphClkSelBusy1
         ) {}
 
         pac::CCM
             .cbcmr()
-            .write(|v| v.set_pre_periph_clk_sel(pac::ccm::vals::PrePeriphClkSel::PRE_PERIPH_CLK_SEL_0));
+            .write(|v| v.set_pre_periph_clk_sel(pac::ccm::vals::PrePeriphClkSel::PrePeriphClkSel0));
 
         // TODO: Some for USB PLLs
 

--- a/embassy-nxp/src/pwm/lpc55.rs
+++ b/embassy-nxp/src/pwm/lpc55.rs
@@ -75,8 +75,8 @@ impl<'d> Pwm<'d> {
     pub(crate) fn reset() {
         // Reset SCTimer => Reset counter and halt it.
         // It should be done only once during the initialization of the board.
-        SYSCON.presetctrl1().modify(|w| w.set_sct_rst(SctRst::ASSERTED));
-        SYSCON.presetctrl1().modify(|w| w.set_sct_rst(SctRst::RELEASED));
+        SYSCON.presetctrl1().modify(|w| w.set_sct_rst(SctRst::Asserted));
+        SYSCON.presetctrl1().modify(|w| w.set_sct_rst(SctRst::Released));
     }
     fn new_inner<T: sct::Instance, O: sct::Output<T>>(
         output: usize,
@@ -94,16 +94,16 @@ impl<'d> Pwm<'d> {
         });
 
         // Choose the clock for PWM.
-        SYSCON.sctclksel().modify(|w| w.set_sel(SctclkselSel::ENUM_0X3));
+        SYSCON.sctclksel().modify(|w| w.set_sel(SctclkselSel::Enum0x3));
         // For now, 96 MHz.
 
         // IOCON Setup
         channel.pio().modify(|w| {
             w.set_func(channel.pin_func());
-            w.set_digimode(PioDigimode::DIGITAL);
-            w.set_slew(PioSlew::STANDARD);
-            w.set_mode(PioMode::INACTIVE);
-            w.set_od(PioOd::NORMAL);
+            w.set_digimode(PioDigimode::Digital);
+            w.set_slew(PioSlew::Standard);
+            w.set_mode(PioMode::Inactive);
+            w.set_od(PioOd::Normal);
         });
 
         Self::configure(output, &config);
@@ -133,9 +133,9 @@ impl<'d> Pwm<'d> {
         // Stop and reset the counter
         SCT0.ctrl().modify(|w| {
             if config.phase_correct {
-                w.set_bidir_l(vals::Bidir::UP_DOWN);
+                w.set_bidir_l(vals::Bidir::UpDown);
             } else {
-                w.set_bidir_l(vals::Bidir::UP);
+                w.set_bidir_l(vals::Bidir::Up);
             }
             w.set_halt_l(true); // halt the counter to make new changes
             w.set_clrctr_l(true); // clear the counter
@@ -144,8 +144,8 @@ impl<'d> Pwm<'d> {
         SYSCON.sctclkdiv().modify(|w| w.set_div(config.divider));
 
         SCT0.config().modify(|w| {
-            w.set_unify(vals::Unify::UNIFIED_COUNTER);
-            w.set_clkmode(vals::Clkmode::SYSTEM_CLOCK_MODE);
+            w.set_unify(vals::Unify::UnifiedCounter);
+            w.set_clkmode(vals::Clkmode::SystemClockMode);
             w.set_noreload_l(true);
             w.set_autolimit_l(true);
         });
@@ -157,21 +157,21 @@ impl<'d> Pwm<'d> {
         if TOP_VALUE.load(Ordering::Relaxed) == 0 {
             // Match 0 will reset the timer using TOP value
             SCT0.match_(0).modify(|w| {
-                w.set_matchn_l((config.top & 0xFFFF) as u16);
-                w.set_matchn_h((config.top >> 16) as u16);
+                w.set_matc_hn_l((config.top & 0xFFFF) as u16);
+                w.set_matc_hn_h((config.top >> 16) as u16);
             });
         } else {
             panic!("The top value cannot be changed after the initialization.");
         }
         // The actual matches that are used for event logic
         SCT0.match_(output_number + 1).modify(|w| {
-            w.set_matchn_l((config.compare & 0xFFFF) as u16);
-            w.set_matchn_h((config.compare >> 16) as u16);
+            w.set_matc_hn_l((config.compare & 0xFFFF) as u16);
+            w.set_matc_hn_h((config.compare >> 16) as u16);
         });
 
         SCT0.match_(15).modify(|w| {
-            w.set_matchn_l(0);
-            w.set_matchn_h(0);
+            w.set_matc_hn_l(0);
+            w.set_matc_hn_h(0);
         });
 
         // Event configuration
@@ -180,26 +180,26 @@ impl<'d> Pwm<'d> {
             if SCT0.ev(0).ev_ctrl().read().matchsel() != 15 {
                 SCT0.ev(0).ev_ctrl().modify(|w| {
                     w.set_matchsel(15);
-                    w.set_combmode(vals::Combmode::MATCH);
+                    w.set_combmode(vals::Combmode::Match);
                     // STATE + statev, where STATE is a on-board variable.
-                    w.set_stateld(vals::Stateld::ADD);
+                    w.set_stateld(vals::Stateld::Add);
                     w.set_statev(0);
                 });
             }
         });
         SCT0.ev(output_number + 1).ev_ctrl().modify(|w| {
             w.set_matchsel((output_number + 1) as u8);
-            w.set_combmode(vals::Combmode::MATCH);
-            w.set_stateld(vals::Stateld::ADD);
+            w.set_combmode(vals::Combmode::Match);
+            w.set_stateld(vals::Stateld::Add);
             // STATE + statev, where STATE is a on-board variable.
             w.set_statev(0);
         });
 
         // Assign events to states
-        SCT0.ev(0).ev_state().modify(|w| w.set_statemskn(1 << 0));
+        SCT0.ev(0).ev_state().modify(|w| w.set_statems_kn(1 << 0));
         SCT0.ev(output_number + 1)
             .ev_state()
-            .modify(|w| w.set_statemskn(1 << 0));
+            .modify(|w| w.set_statems_kn(1 << 0));
         // TODO(frihetselsker): optimize nxp-pac so that `set_clr` and `set_set` are turned into a bit array.
         if config.invert {
             // Low when event 0 is active
@@ -220,7 +220,7 @@ impl<'d> Pwm<'d> {
         if config.phase_correct {
             // Take into account the set matches and reverse their actions while counting back.
             SCT0.outputdirctrl()
-                .modify(|w| w.set_setclr(output_number, vals::Setclr::L_REVERSED));
+                .modify(|w| w.set_setclr(output_number, vals::Setclr::LReversed));
         }
 
         // State 0 by default

--- a/embassy-nxp/src/time_driver/pit.rs
+++ b/embassy-nxp/src/time_driver/pit.rs
@@ -69,8 +69,8 @@ impl Driver {
         // could divide the clock root by up to 64.
         pac::CCM.cscmr1().modify(|r| {
             // 1 MHz
-            r.set_perclk_podf(pac::ccm::vals::PerclkPodf::DIVIDE_24);
-            r.set_perclk_clk_sel(pac::ccm::vals::PerclkClkSel::PERCLK_CLK_SEL_1);
+            r.set_perclk_podf(pac::ccm::vals::PerclkPodf::Divide24);
+            r.set_perclk_clk_sel(pac::ccm::vals::PerclkClkSel::PerclkClkSel1);
         });
 
         pac::CCM.ccgr1().modify(|r| r.set_cg6(0b11));

--- a/embassy-nxp/src/time_driver/rtc.rs
+++ b/embassy-nxp/src/time_driver/rtc.rs
@@ -47,10 +47,10 @@ impl RtcDriver {
 
         // Select clock source - either XTAL or FRO
         // pmc.rtcosc32k().write(|w| w.set_sel(pmc::vals::Sel::XTAL32K));
-        pmc.rtcosc32k().write(|w| w.set_sel(pmc::vals::Sel::FRO32K));
+        pmc.rtcosc32k().write(|w| w.set_sel(pmc::vals::Sel::Fro32k));
 
         // Start the RTC peripheral
-        rtc.ctrl().modify(|w| w.set_rtc_osc_pd(rtc::vals::RtcOscPd::POWER_UP));
+        rtc.ctrl().modify(|w| w.set_rtc_osc_pd(rtc::vals::RtcOscPd::PowerUp));
 
         //reset/clear(?) counter
         rtc.count().modify(|w| w.set_val(0));
@@ -59,7 +59,7 @@ impl RtcDriver {
         rtc.ctrl().modify(|w| w.set_rtc1khz_en(true));
         // subsec counter enable
         rtc.ctrl()
-            .modify(|w| w.set_rtc_subsec_ena(rtc::vals::RtcSubsecEna::POWER_UP));
+            .modify(|w| w.set_rtc_subsec_ena(rtc::vals::RtcSubsecEna::PowerUp));
 
         // enable irq
         unsafe {
@@ -100,7 +100,7 @@ impl RtcDriver {
 
         rtc.ctrl().modify(|w| {
             w.set_alarm1hz(false);
-            w.set_wake1khz(rtc::vals::Wake1khz::RUN)
+            w.set_wake1khz(rtc::vals::Wake1khz::Run)
         });
         true
     }
@@ -114,8 +114,8 @@ impl RtcDriver {
                 self.trigger_alarm(cs);
             }
 
-            if flags.wake1khz() == rtc::vals::Wake1khz::RUN {
-                rtc.ctrl().modify(|w| w.set_wake1khz(rtc::vals::Wake1khz::TIMEOUT));
+            if flags.wake1khz() == rtc::vals::Wake1khz::Run {
+                rtc.ctrl().modify(|w| w.set_wake1khz(rtc::vals::Wake1khz::Timeout));
                 self.trigger_alarm(cs);
             }
         });

--- a/embassy-nxp/src/usart/lpc55.rs
+++ b/embassy-nxp/src/usart/lpc55.rs
@@ -506,19 +506,19 @@ impl<'d, M: Mode> Usart<'d, M> {
             750_001..=6_000_000 => {
                 SYSCON
                     .fcclksel(T::instance_number())
-                    .modify(|w| w.set_sel(syscon::vals::FcclkselSel::ENUM_0X3)); // 96 MHz
+                    .modify(|w| w.set_sel(syscon::vals::FcclkselSel::Enum0x3)); // 96 MHz
                 96_000_000
             }
             1501..=750_000 => {
                 SYSCON
                     .fcclksel(T::instance_number())
-                    .modify(|w| w.set_sel(syscon::vals::FcclkselSel::ENUM_0X2)); // 12 MHz
+                    .modify(|w| w.set_sel(syscon::vals::FcclkselSel::Enum0x2)); // 12 MHz
                 12_000_000
             }
             121..=1500 => {
                 SYSCON
                     .fcclksel(T::instance_number())
-                    .modify(|w| w.set_sel(syscon::vals::FcclkselSel::ENUM_0X4)); // 1 MHz
+                    .modify(|w| w.set_sel(syscon::vals::FcclkselSel::Enum0x4)); // 1 MHz
                 1_000_000
             }
             _ => {
@@ -586,22 +586,22 @@ impl<'d, M: Mode> Usart<'d, M> {
         if let Some((tx_pin, func)) = tx {
             tx_pin.pio().modify(|w| {
                 w.set_func(func);
-                w.set_mode(iocon::vals::PioMode::INACTIVE);
-                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_mode(iocon::vals::PioMode::Inactive);
+                w.set_slew(iocon::vals::PioSlew::Standard);
                 w.set_invert(false);
-                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-                w.set_od(iocon::vals::PioOd::NORMAL);
+                w.set_digimode(iocon::vals::PioDigimode::Digital);
+                w.set_od(iocon::vals::PioOd::Normal);
             });
         }
 
         if let Some((rx_pin, func)) = rx {
             rx_pin.pio().modify(|w| {
                 w.set_func(func);
-                w.set_mode(iocon::vals::PioMode::INACTIVE);
-                w.set_slew(iocon::vals::PioSlew::STANDARD);
+                w.set_mode(iocon::vals::PioMode::Inactive);
+                w.set_slew(iocon::vals::PioSlew::Standard);
                 w.set_invert(false);
-                w.set_digimode(iocon::vals::PioDigimode::DIGITAL);
-                w.set_od(iocon::vals::PioOd::NORMAL);
+                w.set_digimode(iocon::vals::PioDigimode::Digital);
+                w.set_od(iocon::vals::PioOd::Normal);
             });
         };
     }
@@ -619,12 +619,12 @@ impl<'d, M: Mode> Usart<'d, M> {
         });
         SYSCON
             .presetctrl1()
-            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::ASSERTED));
+            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::Asserted));
         SYSCON
             .presetctrl1()
-            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::RELEASED));
+            .modify(|w| w.set_fc_rst(instance_number, syscon::vals::FcRst::Released));
         flexcomm_register.pselid().modify(|w| {
-            w.set_persel(flexcomm::vals::Persel::USART);
+            w.set_persel(flexcomm::vals::Persel::Usart);
             // This will lock the peripheral PERSEL and will not allow any changes until the board is reset.
             w.set_lock(true);
         });
@@ -642,21 +642,21 @@ impl<'d, M: Mode> Usart<'d, M> {
             // No flow control. The transmitter does not receive any automatic flow control signal.
             w.set_ctsen(false);
             // Selects synchronous or asynchronous operation.
-            w.set_syncen(usart::vals::Syncen::ASYNCHRONOUS_MODE);
+            w.set_syncen(usart::vals::Syncen::AsynchronousMode);
             // Selects the clock polarity and sampling edge of received data in synchronous mode.
-            w.set_clkpol(usart::vals::Clkpol::RISING_EDGE);
+            w.set_clkpol(usart::vals::Clkpol::RisingEdge);
             // Synchronous mode Master select.
             // When synchronous mode is enabled, the USART is a master.
-            w.set_syncmst(usart::vals::Syncmst::MASTER);
+            w.set_syncmst(usart::vals::Syncmst::Master);
             // Selects data loopback mode
-            w.set_loop_(usart::vals::Loop::NORMAL);
+            w.set_loop_(usart::vals::Loop::Normal);
             // Output Enable Turnaround time enable for RS-485 operation.
             // Disabled. If selected by OESEL, the Output Enable signal deasserted at the end of
             // the last stop bit of a transmission.
             w.set_oeta(false);
             // Output enable select.
             // Standard. The RTS signal is used as the standard flow control function.
-            w.set_oesel(usart::vals::Oesel::STANDARD);
+            w.set_oesel(usart::vals::Oesel::Standard);
             // Automatic address matching enable.
             // Disabled. When addressing is enabled by ADDRDET, address matching is done by
             // software. This provides the possibility of versatile addressing (e.g. respond to more
@@ -664,32 +664,32 @@ impl<'d, M: Mode> Usart<'d, M> {
             w.set_autoaddr(false);
             // Output enable polarity.
             // Low. If selected by OESEL, the output enable is active low.
-            w.set_oepol(usart::vals::Oepol::LOW);
+            w.set_oepol(usart::vals::Oepol::Low);
         });
 
         // Configurations based on the config written by a user
         registers.cfg().modify(|w| {
             w.set_datalen(match config.data_bits {
-                DataBits::DataBits7 => usart::vals::Datalen::BIT_7,
-                DataBits::DataBits8 => usart::vals::Datalen::BIT_8,
-                DataBits::DataBits9 => usart::vals::Datalen::BIT_9,
+                DataBits::DataBits7 => usart::vals::Datalen::Bit7,
+                DataBits::DataBits8 => usart::vals::Datalen::Bit8,
+                DataBits::DataBits9 => usart::vals::Datalen::Bit9,
             });
             w.set_paritysel(match config.parity {
-                Parity::ParityNone => usart::vals::Paritysel::NO_PARITY,
-                Parity::ParityEven => usart::vals::Paritysel::EVEN_PARITY,
-                Parity::ParityOdd => usart::vals::Paritysel::ODD_PARITY,
+                Parity::ParityNone => usart::vals::Paritysel::NoParity,
+                Parity::ParityEven => usart::vals::Paritysel::EvenParity,
+                Parity::ParityOdd => usart::vals::Paritysel::OddParity,
             });
             w.set_stoplen(match config.stop_bits {
-                StopBits::Stop1 => usart::vals::Stoplen::BIT_1,
-                StopBits::Stop2 => usart::vals::Stoplen::BITS_2,
+                StopBits::Stop1 => usart::vals::Stoplen::Bit1,
+                StopBits::Stop2 => usart::vals::Stoplen::Bits2,
             });
             w.set_rxpol(match config.invert_rx {
-                false => usart::vals::Rxpol::STANDARD,
-                true => usart::vals::Rxpol::INVERTED,
+                false => usart::vals::Rxpol::Standard,
+                true => usart::vals::Rxpol::Inverted,
             });
             w.set_txpol(match config.invert_tx {
-                false => usart::vals::Txpol::STANDARD,
-                true => usart::vals::Txpol::INVERTED,
+                false => usart::vals::Txpol::Standard,
+                true => usart::vals::Txpol::Inverted,
             });
         });
 


### PR DESCRIPTION
Migrates embassy-nxp to the latest revision of nxp-pac (8512ece). This entails the following changes:

 - METADATA.interrupts now has the type: (&str, u32) (build.rs was modified to accommodate this change)
 - enum constants became PascalCase instead of SCREAMING_CASE
 - a few methods have been renamed since the previous rev ex: set_matchn_l become set_matc_hn_l
 - in Cargo.toml, all dependencies were bumped to the rev = "8512ece...". Also the build dep was changed to have default-features = "false" (overlap with pr: #6585), to take advantage of the lib.rs file in the new rev, so the build works on non ELF hosts (MacOS and Windows)
 
Tested on LPCXpresso55S69-EVK dev-board, with the official examples: blinky_nop, blinky_embassy_time, button_executor, pwm, usart_blocking, usart_async, which all work properly.