### PR TITLE
Remove unrequired generic from run_time_sampler

### DIFF
--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -65,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * added: expose uicr write functions
 * added: support for nrf54lm20a
 - added: support buffered rram for nrf54
+- changed: removed unused generic from `Saadc::run_timer_sample`
 
 ## 0.8.0 - 2025-09-30
 

--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -478,7 +478,7 @@ impl<'d> Saadc<'d, 1> {
     /// that the size of this buffer can be less than the original buffer's size.
     /// A command is return from the closure that indicates whether the sampling
     /// should continue or stop.
-    pub async fn run_timer_sampler<I, S, const N0: usize>(
+    pub async fn run_timer_sampler<S, const N0: usize>(
         &mut self,
         bufs: &mut [[[i16; 1]; N0]; 2],
         sample_rate_divisor: u16,


### PR DESCRIPTION
Generic `I` isn't required by the method

rebase of #4782
