### PR TITLE
executor: support rtos-trace without pointer CAS

### DIFF
--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -40,6 +40,7 @@ build = [
     {target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32"]},
     {target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32", "executor-thread"]},
     {target = "riscv32imac-unknown-none-elf", features = ["platform-riscv32", "executor-thread", "trace"]},
+    {target = "riscv32imc-unknown-none-elf", features = ["platform-riscv32", "executor-thread", "rtos-trace"]},
     {target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64"]},
     {target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64", "executor-thread"]},
     {target = "riscv64imac-unknown-none-elf", features = ["platform-riscv64", "executor-thread", "trace"]},

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -122,14 +122,15 @@ impl TaskTracker {
     /// Adds a task to the tracker
     ///
     /// This method inserts a task at the head of the intrusive linked list.
-    /// The operation is thread-safe and lock-free, using atomic operations
-    /// to ensure consistency even when called from different contexts.
+    /// The operation is lock-free on targets with pointer compare-and-swap.
+    /// On targets without it, insertions are serialized by a critical section.
     ///
     /// # Arguments
     /// * `task` - The task reference to add to the tracker
     pub fn add(&self, task: TaskRef) {
         let task_ptr = task.as_ptr();
 
+        #[cfg(target_has_atomic = "ptr")]
         loop {
             let current_head = self.head.load(Ordering::Acquire);
             unsafe {
@@ -144,6 +145,15 @@ impl TaskTracker {
                 break;
             }
         }
+
+        #[cfg(not(target_has_atomic = "ptr"))]
+        critical_section::with(|_| {
+            let current_head = self.head.load(Ordering::Acquire);
+            unsafe {
+                (*task_ptr).all_tasks_next.store(current_head, Ordering::Relaxed);
+            }
+            self.head.store(task_ptr.cast_mut(), Ordering::Release);
+        });
     }
 
     /// Performs an operation on each task in the tracker

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,6 +8,7 @@ targets = [
     "thumbv7em-none-eabihf",
     "thumbv8m.main-none-eabihf",
     "riscv32imac-unknown-none-elf",
+    "riscv32imc-unknown-none-elf",
     "riscv64imac-unknown-none-elf",
     "riscv64gc-unknown-none-elf",
     "wasm32-unknown-unknown",


### PR DESCRIPTION
Fixes #5698.

## Summary

- Keep the existing lock-free `TaskTracker` insertion on targets with pointer compare-and-swap support.
- Serialize task-list insertion with `critical_section` on targets without pointer CAS support.
- Add `riscv32imc-unknown-none-elf` with `executor-thread,rtos-trace` to the executor build matrix and pinned toolchain targets so this configuration remains covered.

This keeps the fallback local to the trace task list and avoids adding a new atomic dependency for the rest of `embassy-executor`.

## Validation

- `rustfmt +nightly-2025-12-11 --check --skip-children --unstable-features --edition 2024 embassy-executor/src/raw/trace.rs`
- `$env:RUSTFLAGS='-Dwarnings'; cargo check --manifest-path embassy-executor/Cargo.toml --target riscv32imc-unknown-none-elf --no-default-features --features 'platform-riscv32,executor-thread,rtos-trace'`

## Development disclosure

OpenAI Codex assisted with the implementation and test setup. The fallback and existing CAS paths were independently cross-reviewed and compile-checked; no hardware testing was performed.
