### PR TITLE
mcxa: support clock configuration for all I3C instances

### DIFF
--- a/embassy-mcxa/src/clocks/periph_helpers.rs
+++ b/embassy-mcxa/src/clocks/periph_helpers.rs
@@ -691,6 +691,24 @@ pub enum I3cClockSel {
     None,
 }
 
+/// Which instance of the `I3c` is this?
+///
+/// Should not be directly selectable by end-users.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum I3cInstance {
+    /// Instance 0
+    I3c0,
+    #[cfg(feature = "mcxa5xx")]
+    /// Instance 1
+    I3c1,
+    #[cfg(feature = "mcxa5xx")]
+    /// Instance 2
+    I3c2,
+    #[cfg(feature = "mcxa5xx")]
+    /// Instance 3
+    I3c3,
+}
+
 /// Top level configuration for `I3c` instances.
 pub struct I3cConfig {
     /// Power state required for this peripheral
@@ -699,6 +717,9 @@ pub struct I3cConfig {
     pub source: I3cClockSel,
     /// Clock divisor
     pub div: Div4,
+    /// Which instance is this?
+    // NOTE: should not be user settable
+    pub(crate) instance: I3cInstance,
 }
 
 impl SPConfHelper for I3cConfig {
@@ -714,7 +735,15 @@ impl SPConfHelper for I3cConfig {
         // check that source is suitable
         let mrcc0 = crate::pac::MRCC0;
 
-        let (clkdiv, clksel) = (mrcc0.mrcc_i3c0_fclk_clkdiv(), mrcc0.mrcc_i3c0_fclk_clksel());
+        let (clkdiv, clksel) = match self.instance {
+            I3cInstance::I3c0 => (mrcc0.mrcc_i3c0_fclk_clkdiv(), mrcc0.mrcc_i3c0_fclk_clksel()),
+            #[cfg(feature = "mcxa5xx")]
+            I3cInstance::I3c1 => (mrcc0.mrcc_i3c1_fclk_clkdiv(), mrcc0.mrcc_i3c1_fclk_clksel()),
+            #[cfg(feature = "mcxa5xx")]
+            I3cInstance::I3c2 => (mrcc0.mrcc_i3c2_fclk_clkdiv(), mrcc0.mrcc_i3c2_fclk_clksel()),
+            #[cfg(feature = "mcxa5xx")]
+            I3cInstance::I3c3 => (mrcc0.mrcc_i3c3_fclk_clkdiv(), mrcc0.mrcc_i3c3_fclk_clksel()),
+        };
 
         let (freq, variant) = match self.source {
             I3cClockSel::FroLfDiv => {

--- a/embassy-mcxa/src/i3c/controller.rs
+++ b/embassy-mcxa/src/i3c/controller.rs
@@ -310,7 +310,12 @@ impl<'d, M: Mode> I3c<'d, M> {
         let ClockConfig { power, source, div } = config.clock_config;
 
         // Enable clocks
-        let conf = I3cConfig { power, source, div };
+        let conf = I3cConfig {
+            power,
+            source,
+            div,
+            instance: T::CLOCK_INSTANCE,
+        };
 
         let parts = unsafe { enable_and_reset::<T>(&conf).map_err(SetupError::ClockSetup)? };
 

--- a/embassy-mcxa/src/i3c/mod.rs
+++ b/embassy-mcxa/src/i3c/mod.rs
@@ -20,6 +20,7 @@ pub(crate) mod sealed {
 pub(crate) trait SealedInstance: Gate<MrccPeriphConfig = I3cConfig> {
     fn info() -> &'static Info;
 
+    const CLOCK_INSTANCE: crate::clocks::periph_helpers::I3cInstance;
     const PERF_INT_INCR: fn();
     const PERF_INT_WAKE_INCR: fn();
     const TX_DMA_REQUEST: DmaRequest;
@@ -74,6 +75,7 @@ macro_rules! impl_i3c_instance {
 
                 const TX_DMA_REQUEST: DmaRequest = DmaRequest::[<I3C $n Tx>];
                 const RX_DMA_REQUEST: DmaRequest = DmaRequest::[<I3C $n Rx>];
+                const CLOCK_INSTANCE: crate::clocks::periph_helpers::I3cInstance = crate::clocks::periph_helpers::I3cInstance::[<I3c $n>];
                 const PERF_INT_INCR: fn() = crate::perf_counters::[<incr_interrupt_i3c $n>];
                 const PERF_INT_WAKE_INCR: fn() = crate::perf_counters::[<incr_interrupt_i3c $n _wake>];
 

--- a/embassy-mcxa/src/i3c/target.rs
+++ b/embassy-mcxa/src/i3c/target.rs
@@ -283,7 +283,12 @@ impl<'d> I3c<'d> {
         let ClockConfig { power, source, div } = config.clock_config;
 
         // Enable clocks
-        let conf = I3cConfig { power, source, div };
+        let conf = I3cConfig {
+            power,
+            source,
+            div,
+            instance: T::CLOCK_INSTANCE,
+        };
 
         let parts = unsafe { enable_and_reset::<T>(&conf).map_err(SetupError::ClockSetup)? };
 


### PR DESCRIPTION
`I3cConfig::pre_enable_config()` was hard-coded to I3C0's MRCC registers, so
instantiating the driver on I3C1-I3C3 programmed instance 0's clock and left the
intended peripheral unclocked.

Adds an `I3cInstance` enum carried on `I3cConfig`, selected by `match` instead of
hard-coding instance 0. The instance is declared at the type level via
`SealedInstance::CLOCK_INSTANCE` and populated by the `impl_i3c_instance!` macro, so
the application never sets it (`I3cConfig::instance` is `pub(crate)`).