### PR TITLE
C5: Fix ADC_DAC limits panic for all examples

### DIFF
--- a/embassy-stm32/src/rcc/c5.rs
+++ b/embassy-stm32/src/rcc/c5.rs
@@ -64,7 +64,7 @@ impl Config {
             apb1_pre: APBPrescaler::Div1,
             apb2_pre: APBPrescaler::Div1,
             apb3_pre: APBPrescaler::Div1,
-            adcdac_pre: Adcdacpre::Div1,
+            adcdac_pre: Adcdacpre::Div4,
             mux: super::mux::ClockMux::default(),
         }
     }


### PR DESCRIPTION
Set ADC_DAC prescaler to a safer default to prevent every single example except `adc` (which was fine) from panicking (sorry my bad)