### PR TITLE
MSPM0(I2C): Add FIFO flush for Sync I2C controller to prevent stale data on NACK/error paths

### DIFF
--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -25,3 +25,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add trng implementation (#5172)
 - fix: feature guard pins used for NRST and SWD (#5257)
 - feat: Move from GPIO waker arrays to maitake-sync wait map
+- fix: Add FIFO flush and bounded spin loops to I2C controller to prevent stale data on NACK/error paths

--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -25,4 +25,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - feat: Add trng implementation (#5172)
 - fix: feature guard pins used for NRST and SWD (#5257)
 - feat: Move from GPIO waker arrays to maitake-sync wait map
-- fix: Add FIFO flush and bounded spin loops to I2C controller to prevent stale data on NACK/error paths
+- fix: Flush the I2C controller FIFOs on the NACK/error paths, to prevent stale data

--- a/embassy-mspm0/src/i2c.rs
+++ b/embassy-mspm0/src/i2c.rs
@@ -18,22 +18,6 @@ use crate::mode::{Async, Blocking, Mode};
 use crate::pac::i2c::{I2c as Regs, vals};
 use crate::pac::{self};
 
-/// Max iterations waiting for BUSY/IDLE mode.
-const BUSY_IDLE_SPIN_LIMIT: u32 = 10_000;
-
-/// Max iterations waiting for a FIFO flush.
-const FLUSH_SPIN_LIMIT: u32 = 1_000;
-
-/// Spin until `cond` holds, giving up after `limit` iterations.
-fn spin_until(limit: u32, mut cond: impl FnMut() -> bool) -> Result<(), Error> {
-    for _ in 0..limit {
-        if cond() {
-            return Ok(());
-        }
-    }
-    Err(Error::Timeout)
-}
-
 /// The clock source for the I2C.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -555,41 +539,33 @@ impl<'d, M: Mode> I2c<'d, M> {
         }
         Ok(())
     }
+
+    /// Flush both controller FIFOs.
+    ///
+    /// A flush is only legal while the controller is IDLE (TRM §25.2.3.12), so wait for
+    /// that first.
+    fn flush_fifos(&mut self) {
+        let regs = self.info.regs.controller(0);
+
+        while !regs.csr().read().idle() {}
+
+        regs.cfifoctl().modify(|w| w.set_txflush(true));
+        while (regs.cfifosr().read().txfifocnt() as usize) < self.info.fifo_size {}
+        regs.cfifoctl().modify(|w| w.set_txflush(false));
+
+        regs.cfifoctl().modify(|w| w.set_rxflush(true));
+        while regs.cfifosr().read().rxfifocnt() != 0 {}
+        regs.cfifoctl().modify(|w| w.set_rxflush(false));
+    }
 }
 
 impl<'d> I2c<'d, Blocking> {
-    /// Empty both controller FIFOs.
-    ///
-    /// Only legal while IDLE (TRM §25.2.3.12). Skips if IDLE never comes.
-    fn flush_fifos(&mut self) {
-        let regs = self.info.regs.controller(0);
-        let size = self.info.fifo_size;
-        if spin_until(BUSY_IDLE_SPIN_LIMIT, || regs.csr().read().idle()).is_err() {
-            return;
-        }
-        regs.cfifoctl().modify(|w| {
-            w.set_txflush(true);
-            w.set_rxflush(true);
-        });
-        let _ = spin_until(FLUSH_SPIN_LIMIT, || {
-            let sr = regs.cfifosr().read();
-            sr.rxfifocnt() == 0 && sr.txfifocnt() as usize >= size
-        });
-        // Lower even if the wait gave up: left raised they discard every byte.
-        regs.cfifoctl().modify(|w| {
-            w.set_txflush(false);
-            w.set_rxflush(false);
-        });
-    }
-
     fn master_blocking_continue(&mut self, length: usize, send_ack_nack: bool, send_stop: bool) -> Result<(), Error> {
         // Perform transaction
         self.master_continue(length, send_ack_nack, send_stop)?;
 
         // Poll until the Controller process all bytes or NACK
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busy() {}
 
         Ok(())
     }
@@ -604,34 +580,26 @@ impl<'d> I2c<'d, Blocking> {
     ) -> Result<(), Error> {
         // unless restart, Wait for the controller to be idle,
         if !restart {
-            spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-                self.info.regs.controller(0).csr().read().idle()
-            })?;
+            while !self.info.regs.controller(0).csr().read().idle() {}
         }
 
         self.master_read(address, length, restart, send_ack_nack, send_stop)?;
 
         // Poll until the Controller process all bytes or NACK
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busy() {}
 
         Ok(())
     }
 
     fn master_blocking_write(&mut self, address: u8, length: usize, send_stop: bool) -> Result<(), Error> {
         // Wait for the controller to be idle
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            self.info.regs.controller(0).csr().read().idle()
-        })?;
+        while !self.info.regs.controller(0).csr().read().idle() {}
 
         // Perform writing
         self.master_write(address, length, send_stop)?;
 
         // Poll until the Controller writes all bytes or NACK
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busy() {}
 
         Ok(())
     }
@@ -648,11 +616,6 @@ impl<'d> I2c<'d, Blocking> {
         }
         if read.len() > self.info.fifo_size {
             return Err(Error::TransferLengthIsOverLimit);
-        }
-
-        // Stale bytes offset every transfer. Skipped on repeated START (not IDLE).
-        if !restart {
-            self.flush_fifos();
         }
 
         let read_len = read.len();
@@ -678,15 +641,6 @@ impl<'d> I2c<'d, Blocking> {
 
             // check errors
             if let Err(err) = self.check_error() {
-                self.master_stop();
-                self.flush_fifos();
-                return Err(err);
-            }
-
-            // BUSY clearing ≠ last byte in FIFO. Popping early returns stale data.
-            let want = chunk.len();
-            let regs = self.info.regs.controller(0);
-            if let Err(err) = spin_until(FLUSH_SPIN_LIMIT, || regs.cfifosr().read().rxfifocnt() as usize >= want) {
                 self.master_stop();
                 self.flush_fifos();
                 return Err(err);
@@ -727,8 +681,8 @@ impl<'d> I2c<'d, Blocking> {
             // check errors
             if let Err(err) = self.check_error() {
                 self.master_stop();
-                // NACK leaves queued bytes (TRM §25.2.3.14); flush so they don't
-                // go out ahead of the next write.
+                // A NACK leaves the bytes that were never sent queued (TRM §25.2.3.14);
+                // flush them so they don't go out ahead of the next write.
                 self.flush_fifos();
                 return Err(err);
             }
@@ -742,27 +696,21 @@ impl<'d> I2c<'d, Blocking> {
     /// Blocking read.
     pub fn blocking_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         self.read_blocking_internal(address, read, false, true)
     }
 
     /// Blocking write.
     pub fn blocking_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         self.write_blocking_internal(address, write, true)
     }
 
     /// Blocking write, restart, read.
     pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         let err = self.write_blocking_internal(address, write, false);
         if err != Ok(()) {
             return err;
@@ -899,25 +847,19 @@ impl<'d> I2c<'d, Async> {
 
     pub async fn async_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         self.write_async_internal(address, write, true).await
     }
 
     pub async fn async_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         self.read_async_internal(address, read, false, true).await
     }
 
     pub async fn async_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
 
         let err = self.write_async_internal(address, write, false).await;
         if err != Ok(()) {
@@ -960,9 +902,7 @@ impl<'d> embedded_hal_02::blocking::i2c::Transactional for I2c<'d, Blocking> {
         operations: &mut [embedded_hal_02::blocking::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         for i in 0..operations.len() {
             match &mut operations[i] {
                 embedded_hal_02::blocking::i2c::Operation::Read(buf) => {
@@ -1016,9 +956,7 @@ impl<'d> embedded_hal::i2c::I2c for I2c<'d, Blocking> {
         operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         for i in 0..operations.len() {
             match &mut operations[i] {
                 embedded_hal::i2c::Operation::Read(buf) => self.read_blocking_internal(address, buf, false, false)?,
@@ -1049,9 +987,7 @@ impl<'d> embedded_hal_async::i2c::I2c for I2c<'d, Async> {
         operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         // wait until bus is free
-        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
-            !self.info.regs.controller(0).csr().read().busbsy()
-        })?;
+        while self.info.regs.controller(0).csr().read().busbsy() {}
         for i in 0..operations.len() {
             match &mut operations[i] {
                 embedded_hal::i2c::Operation::Read(buf) => self.read_async_internal(address, buf, false, false).await?,

--- a/embassy-mspm0/src/i2c.rs
+++ b/embassy-mspm0/src/i2c.rs
@@ -18,6 +18,22 @@ use crate::mode::{Async, Blocking, Mode};
 use crate::pac::i2c::{I2c as Regs, vals};
 use crate::pac::{self};
 
+/// Max iterations waiting for BUSY/IDLE mode.
+const BUSY_IDLE_SPIN_LIMIT: u32 = 10_000;
+
+/// Max iterations waiting for a FIFO flush.
+const FLUSH_SPIN_LIMIT: u32 = 1_000;
+
+/// Spin until `cond` holds, giving up after `limit` iterations.
+fn spin_until(limit: u32, mut cond: impl FnMut() -> bool) -> Result<(), Error> {
+    for _ in 0..limit {
+        if cond() {
+            return Ok(());
+        }
+    }
+    Err(Error::Timeout)
+}
+
 /// The clock source for the I2C.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -542,12 +558,38 @@ impl<'d, M: Mode> I2c<'d, M> {
 }
 
 impl<'d> I2c<'d, Blocking> {
+    /// Empty both controller FIFOs.
+    ///
+    /// Only legal while IDLE (TRM §25.2.3.12). Skips if IDLE never comes.
+    fn flush_fifos(&mut self) {
+        let regs = self.info.regs.controller(0);
+        let size = self.info.fifo_size;
+        if spin_until(BUSY_IDLE_SPIN_LIMIT, || regs.csr().read().idle()).is_err() {
+            return;
+        }
+        regs.cfifoctl().modify(|w| {
+            w.set_txflush(true);
+            w.set_rxflush(true);
+        });
+        let _ = spin_until(FLUSH_SPIN_LIMIT, || {
+            let sr = regs.cfifosr().read();
+            sr.rxfifocnt() == 0 && sr.txfifocnt() as usize >= size
+        });
+        // Lower even if the wait gave up: left raised they discard every byte.
+        regs.cfifoctl().modify(|w| {
+            w.set_txflush(false);
+            w.set_rxflush(false);
+        });
+    }
+
     fn master_blocking_continue(&mut self, length: usize, send_ack_nack: bool, send_stop: bool) -> Result<(), Error> {
         // Perform transaction
         self.master_continue(length, send_ack_nack, send_stop)?;
 
         // Poll until the Controller process all bytes or NACK
-        while self.info.regs.controller(0).csr().read().busy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busy()
+        })?;
 
         Ok(())
     }
@@ -562,26 +604,34 @@ impl<'d> I2c<'d, Blocking> {
     ) -> Result<(), Error> {
         // unless restart, Wait for the controller to be idle,
         if !restart {
-            while !self.info.regs.controller(0).csr().read().idle() {}
+            spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+                self.info.regs.controller(0).csr().read().idle()
+            })?;
         }
 
         self.master_read(address, length, restart, send_ack_nack, send_stop)?;
 
         // Poll until the Controller process all bytes or NACK
-        while self.info.regs.controller(0).csr().read().busy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busy()
+        })?;
 
         Ok(())
     }
 
     fn master_blocking_write(&mut self, address: u8, length: usize, send_stop: bool) -> Result<(), Error> {
         // Wait for the controller to be idle
-        while !self.info.regs.controller(0).csr().read().idle() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            self.info.regs.controller(0).csr().read().idle()
+        })?;
 
         // Perform writing
         self.master_write(address, length, send_stop)?;
 
         // Poll until the Controller writes all bytes or NACK
-        while self.info.regs.controller(0).csr().read().busy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busy()
+        })?;
 
         Ok(())
     }
@@ -598,6 +648,11 @@ impl<'d> I2c<'d, Blocking> {
         }
         if read.len() > self.info.fifo_size {
             return Err(Error::TransferLengthIsOverLimit);
+        }
+
+        // Stale bytes offset every transfer. Skipped on repeated START (not IDLE).
+        if !restart {
+            self.flush_fifos();
         }
 
         let read_len = read.len();
@@ -624,6 +679,16 @@ impl<'d> I2c<'d, Blocking> {
             // check errors
             if let Err(err) = self.check_error() {
                 self.master_stop();
+                self.flush_fifos();
+                return Err(err);
+            }
+
+            // BUSY clearing ≠ last byte in FIFO. Popping early returns stale data.
+            let want = chunk.len();
+            let regs = self.info.regs.controller(0);
+            if let Err(err) = spin_until(FLUSH_SPIN_LIMIT, || regs.cfifosr().read().rxfifocnt() as usize >= want) {
+                self.master_stop();
+                self.flush_fifos();
                 return Err(err);
             }
 
@@ -662,6 +727,9 @@ impl<'d> I2c<'d, Blocking> {
             // check errors
             if let Err(err) = self.check_error() {
                 self.master_stop();
+                // NACK leaves queued bytes (TRM §25.2.3.14); flush so they don't
+                // go out ahead of the next write.
+                self.flush_fifos();
                 return Err(err);
             }
         }
@@ -674,21 +742,27 @@ impl<'d> I2c<'d, Blocking> {
     /// Blocking read.
     pub fn blocking_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         self.read_blocking_internal(address, read, false, true)
     }
 
     /// Blocking write.
     pub fn blocking_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         self.write_blocking_internal(address, write, true)
     }
 
     /// Blocking write, restart, read.
     pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         let err = self.write_blocking_internal(address, write, false);
         if err != Ok(()) {
             return err;
@@ -825,19 +899,25 @@ impl<'d> I2c<'d, Async> {
 
     pub async fn async_write(&mut self, address: u8, write: &[u8]) -> Result<(), Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         self.write_async_internal(address, write, true).await
     }
 
     pub async fn async_read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         self.read_async_internal(address, read, false, true).await
     }
 
     pub async fn async_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
 
         let err = self.write_async_internal(address, write, false).await;
         if err != Ok(()) {
@@ -880,7 +960,9 @@ impl<'d> embedded_hal_02::blocking::i2c::Transactional for I2c<'d, Blocking> {
         operations: &mut [embedded_hal_02::blocking::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         for i in 0..operations.len() {
             match &mut operations[i] {
                 embedded_hal_02::blocking::i2c::Operation::Read(buf) => {
@@ -934,7 +1016,9 @@ impl<'d> embedded_hal::i2c::I2c for I2c<'d, Blocking> {
         operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         for i in 0..operations.len() {
             match &mut operations[i] {
                 embedded_hal::i2c::Operation::Read(buf) => self.read_blocking_internal(address, buf, false, false)?,
@@ -965,7 +1049,9 @@ impl<'d> embedded_hal_async::i2c::I2c for I2c<'d, Async> {
         operations: &mut [embedded_hal::i2c::Operation<'_>],
     ) -> Result<(), Self::Error> {
         // wait until bus is free
-        while self.info.regs.controller(0).csr().read().busbsy() {}
+        spin_until(BUSY_IDLE_SPIN_LIMIT, || {
+            !self.info.regs.controller(0).csr().read().busbsy()
+        })?;
         for i in 0..operations.len() {
             match &mut operations[i] {
                 embedded_hal::i2c::Operation::Read(buf) => self.read_async_internal(address, buf, false, false).await?,

--- a/examples/mspm0g3507/src/bin/i2c.rs
+++ b/examples/mspm0g3507/src/bin/i2c.rs
@@ -1,7 +1,7 @@
 //! This example uses FIFO with polling, and the maximum FIFO size is 8.
 //! Refer to async example to handle larger packets.
 //!
-//! This example controls AD5171 digital potentiometer via I2C with the LP-MSPM0G3507 board.
+//! This example reads all registers (0-19) of DS3231 Real-Time Clock via I2C with the LP-MSPM0G3507 board.
 
 #![no_std]
 #![no_main]
@@ -13,7 +13,7 @@ use embassy_mspm0::i2c::{Config, I2c};
 use embassy_time::Timer;
 use panic_halt as _;
 
-const ADDRESS: u8 = 0x6a;
+const ADDRESS: u8 = 0x68;
 
 #[embassy_executor::main]
 async fn main(_spawner: Spawner) -> ! {
@@ -25,22 +25,18 @@ async fn main(_spawner: Spawner) -> ! {
 
     let mut i2c = unwrap!(I2c::new_blocking(instance, scl, sda, Config::default()));
 
-    let mut pot_value: u8 = 0;
-
     loop {
-        let to_write = [0u8, pot_value];
+        for reg in 0..20u8 {
+            let reg_addr = [reg];
+            let mut val = [0u8];
 
-        match i2c.blocking_write(ADDRESS, &to_write) {
-            Ok(()) => info!("New potentioemter value: {}", pot_value),
-            Err(e) => error!("I2c Error: {:?}", e),
+            match i2c.blocking_write_read(ADDRESS, &reg_addr, &mut val) {
+                Ok(()) => info!("reg {}: {}", reg, val[0]),
+                Err(e) => error!("I2c Error: {:?}", e),
+            }
+            Timer::after_millis(100).await;
         }
 
-        pot_value += 1;
-        // if reached 64th position (max)
-        // start over from lowest value
-        if pot_value == 64 {
-            pot_value = 0;
-        }
-        Timer::after_millis(500).await;
+        Timer::after_millis(2000).await;
     }
 }


### PR DESCRIPTION
### Changes


- Add flush_fifos() to empty both FIFOs for sync controller on error paths for (borrowed from TI driver), preventing stale data from corrupting subsequent transfers (TRM section 25.2.3.12, 25.2.3.14).
- Update example to read DS3231 RTC registers, exercising the blocking_write_read path to test the FIFO flush mechanism.

### Verification (tested on 6f62e7507f1c0c3404c238cebdd67f2617887f91)
- Arduino Uno I2C  target was used to mimic DS3231 Real-Time Clock
- I2C  target ping-pong's the same value as it was in the write-read request
- Verification steps: in the middle of transfer I reboot the Arduino, so few transactions get NACK. Check if the data is sent is equal to the received.

The logs before the fix:
```
[INFO ] reg 5: 5 (i2c src/bin/i2c.rs:33)
[INFO ] reg 6: 6 (i2c src/bin/i2c.rs:33)
[INFO ] reg 7: 7 (i2c src/bin/i2c.rs:33)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)  <------ Arduino RESET 
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[INFO ] reg 0: 8 (i2c src/bin/i2c.rs:33)   <------ Arduino Boot up 
[INFO ] reg 1: 9 (i2c src/bin/i2c.rs:33)
[INFO ] reg 2: 10 (i2c src/bin/i2c.rs:33)
```

The logs after the fix:
```
...
[INFO ] reg 18: 18 (i2c src/bin/i2c.rs:33)
[INFO ] reg 19: 19 (i2c src/bin/i2c.rs:33)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)  <------ Arduino RESET 
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[ERROR] I2c Error: Nack (i2c src/bin/i2c.rs:34)
[INFO ] reg 10: 10 (i2c src/bin/i2c.rs:33)   <------ Arduino Boot up
[INFO ] reg 11: 11 (i2c src/bin/i2c.rs:33)
[INFO ] reg 12: 12 (i2c src/bin/i2c.rs:33)
```