### PR TITLE
[MCXA] lpuart: add RTS/CTS flow control to DMA and BBQ drivers

### DIFF
--- a/embassy-mcxa/src/lpuart/bbq.rs
+++ b/embassy-mcxa/src/lpuart/bbq.rs
@@ -16,13 +16,14 @@ use grounded::uninit::GroundedCell;
 use maitake_sync::WaitCell;
 use nxp_pac::lpuart::Tc;
 
-use super::{DataBits, IdleConfig, Info, MsbFirst, Parity, RxPin, StopBits, TxPin, TxPins};
+use super::{CtsPin, DataBits, IdleConfig, Info, MsbFirst, Parity, RtsPin, RxPin, StopBits, TxPin, TxPins};
 use crate::clocks::periph_helpers::{Div4, LpuartClockSel};
 use crate::clocks::{PoweredClock, WakeGuard};
 use crate::dma::{DMA_MAX_TRANSFER_SIZE, DmaChannel, DmaRequest, InvalidParameters, TransferOptions};
 use crate::gpio::{AnyPin, HasGpioInstance, PeriGpioExt};
 use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
 use crate::lpuart::{Instance, RxPins};
+use crate::pac::lpuart::{Txctsc as TxCtsConfig, Txctssrc as TxCtsSource};
 
 /// Error Type
 #[derive(Debug, PartialEq)]
@@ -113,6 +114,10 @@ pub struct BbqConfig {
     pub stop_bits_count: StopBits,
     /// RX IDLE configuration
     pub rx_idle_config: IdleConfig,
+    /// TX CTS source
+    pub tx_cts_source: TxCtsSource,
+    /// TX CTS configuration
+    pub tx_cts_config: TxCtsConfig,
 }
 
 impl Default for BbqConfig {
@@ -127,6 +132,8 @@ impl Default for BbqConfig {
             power: PoweredClock::AlwaysEnabled,
             source: LpuartClockSel::FroLfDiv,
             div: Div4::no_div(),
+            tx_cts_source: TxCtsSource::Cts,
+            tx_cts_config: TxCtsConfig::Start,
         }
     }
 }
@@ -144,6 +151,8 @@ impl From<BbqConfig> for super::Config {
             msb_first,
             stop_bits_count,
             rx_idle_config,
+            tx_cts_source,
+            tx_cts_config,
         } = value;
 
         // User selectable
@@ -156,6 +165,8 @@ impl From<BbqConfig> for super::Config {
         cfg.msb_first = msb_first;
         cfg.stop_bits_count = stop_bits_count;
         cfg.rx_idle_config = rx_idle_config;
+        cfg.tx_cts_source = tx_cts_source;
+        cfg.tx_cts_config = tx_cts_config;
 
         // Manually set
         cfg.tx_fifo_watermark = 0;
@@ -216,6 +227,10 @@ pub struct BbqHalfParts {
     info: &'static Info,
     state: &'static BbqState,
     vtable: BbqVtable,
+
+    // flow control (optional)
+    flow_pin: Option<Peri<'static, AnyPin>>,
+    flow_mux: Option<crate::pac::port::Mux>,
 }
 
 pub struct BbqParts {
@@ -235,6 +250,12 @@ pub struct BbqParts {
     info: &'static Info,
     state: &'static BbqState,
     vtable: BbqVtable,
+
+    // flow control (optional)
+    cts_pin: Option<Peri<'static, AnyPin>>,
+    cts_mux: Option<crate::pac::port::Mux>,
+    rts_pin: Option<Peri<'static, AnyPin>>,
+    rts_mux: Option<crate::pac::port::Mux>,
 }
 
 impl BbqParts {
@@ -262,6 +283,45 @@ impl BbqParts {
             info: T::info(),
             state: T::bbq_state(),
             vtable: BbqVtable::for_lpuart::<T>(),
+            cts_pin: None,
+            cts_mux: None,
+            rts_pin: None,
+            rts_mux: None,
+        })
+    }
+
+    /// Create a full-duplex `BbqParts` with RTS/CTS hardware flow control.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_rtscts<T: BbqInstance, Tx: TxPin<T>, Rx: RxPin<T>, Cts: CtsPin<T>, Rts: RtsPin<T>>(
+        _inner: Peri<'static, T>,
+        _irq: impl Binding<T::Interrupt, BbqInterruptHandler<T>> + 'static,
+        tx_pin: Peri<'static, Tx>,
+        tx_buffer: &'static mut [u8],
+        tx_dma_ch: impl Into<DmaChannel<'static>>,
+        rx_pin: Peri<'static, Rx>,
+        rx_buffer: &'static mut [u8],
+        rx_dma_ch: impl Into<DmaChannel<'static>>,
+        cts_pin: Peri<'static, Cts>,
+        rts_pin: Peri<'static, Rts>,
+    ) -> Result<Self, BbqError> {
+        Ok(Self {
+            tx_buffer,
+            tx_dma_ch: tx_dma_ch.into(),
+            tx_pin: tx_pin.into(),
+            rx_buffer,
+            rx_dma_ch: rx_dma_ch.into(),
+            rx_pin: rx_pin.into(),
+            tx_dma_req: T::TX_DMA_REQUEST.number(),
+            tx_mux: Tx::MUX,
+            rx_dma_req: T::RX_DMA_REQUEST.number(),
+            rx_mux: Rx::MUX,
+            info: T::info(),
+            state: T::bbq_state(),
+            vtable: BbqVtable::for_lpuart::<T>(),
+            cts_pin: Some(cts_pin.into()),
+            cts_mux: Some(Cts::MUX),
+            rts_pin: Some(rts_pin.into()),
+            rts_mux: Some(Rts::MUX),
         })
     }
 
@@ -304,6 +364,32 @@ impl BbqHalfParts {
             dma_req: T::TX_DMA_REQUEST.number(),
             vtable: BbqVtable::for_lpuart::<T>(),
             which: WhichHalf::Tx,
+            flow_pin: None,
+            flow_mux: None,
+        }
+    }
+
+    /// Create a TX-only `BbqHalfParts` with CTS hardware flow control.
+    pub fn new_tx_half_with_cts<T: BbqInstance, P: TxPin<T>, C: CtsPin<T>>(
+        _inner: Peri<'static, T>,
+        _irq: impl Binding<T::Interrupt, BbqInterruptHandler<T>> + 'static,
+        tx_pin: Peri<'static, P>,
+        buffer: &'static mut [u8],
+        dma_ch: impl Into<DmaChannel<'static>>,
+        cts_pin: Peri<'static, C>,
+    ) -> Self {
+        Self {
+            buffer,
+            dma_ch: dma_ch.into(),
+            pin: tx_pin.into(),
+            mux: P::MUX,
+            info: T::info(),
+            state: T::bbq_state(),
+            dma_req: T::TX_DMA_REQUEST.number(),
+            vtable: BbqVtable::for_lpuart::<T>(),
+            which: WhichHalf::Tx,
+            flow_pin: Some(cts_pin.into()),
+            flow_mux: Some(C::MUX),
         }
     }
 
@@ -324,6 +410,32 @@ impl BbqHalfParts {
             dma_req: T::RX_DMA_REQUEST.number(),
             vtable: BbqVtable::for_lpuart::<T>(),
             which: WhichHalf::Rx,
+            flow_pin: None,
+            flow_mux: None,
+        }
+    }
+
+    /// Create an RX-only `BbqHalfParts` with RTS hardware flow control.
+    pub fn new_rx_half_with_rts<T: BbqInstance, P: RxPin<T>, R: RtsPin<T>>(
+        _inner: Peri<'static, T>,
+        _irq: impl Binding<T::Interrupt, BbqInterruptHandler<T>> + 'static,
+        rx_pin: Peri<'static, P>,
+        buffer: &'static mut [u8],
+        dma_ch: impl Into<DmaChannel<'static>>,
+        rts_pin: Peri<'static, R>,
+    ) -> Self {
+        Self {
+            buffer,
+            dma_ch: dma_ch.into(),
+            pin: rx_pin.into(),
+            mux: P::MUX,
+            info: T::info(),
+            state: T::bbq_state(),
+            dma_req: T::RX_DMA_REQUEST.number(),
+            vtable: BbqVtable::for_lpuart::<T>(),
+            which: WhichHalf::Rx,
+            flow_pin: Some(rts_pin.into()),
+            flow_mux: Some(R::MUX),
         }
     }
 
@@ -348,6 +460,35 @@ impl BbqHalfParts {
             dma_req: T::RX_DMA_REQUEST.number(),
             vtable: BbqVtable::for_lpuart::<T>(),
             which: WhichHalf::Rx,
+            flow_pin: None,
+            flow_mux: None,
+        }
+    }
+
+    /// Setup an RX-only half with RTS flow control while binding GPIO to the RX pin.
+    /// This allows later use of async functions on the RX pin.
+    pub fn new_rx_half_with_rts_async<T: BbqInstance, P: RxPin<T> + HasGpioInstance, R: RtsPin<T>>(
+        _inner: Peri<'static, T>,
+        irq: impl Binding<T::Interrupt, BbqInterruptHandler<T>>
+        + Binding<<P::Instance as crate::gpio::Instance>::Interrupt, crate::gpio::InterruptHandler<P::Instance>>
+        + 'static,
+        rx_pin: Peri<'static, P>,
+        buffer: &'static mut [u8],
+        dma_ch: impl Into<DmaChannel<'static>>,
+        rts_pin: Peri<'static, R>,
+    ) -> Self {
+        Self {
+            buffer,
+            dma_ch: dma_ch.into(),
+            pin: rx_pin.degrade_async(irq),
+            mux: P::MUX,
+            info: T::info(),
+            state: T::bbq_state(),
+            dma_req: T::RX_DMA_REQUEST.number(),
+            vtable: BbqVtable::for_lpuart::<T>(),
+            which: WhichHalf::Rx,
+            flow_pin: Some(rts_pin.into()),
+            flow_mux: Some(R::MUX),
         }
     }
 }
@@ -362,11 +503,22 @@ impl LpuartBbq {
         any_as_tx(&parts.tx_pin, parts.tx_mux);
         any_as_rx(&parts.rx_pin, parts.rx_mux);
 
+        // Configure optional flow-control pins (only when a mux is present; a
+        // teardown-reclaimed pin arrives already configured with mux == None).
+        if let (Some(cts), Some(mux)) = (&parts.cts_pin, parts.cts_mux) {
+            any_as_cts(cts, mux);
+        }
+        if let (Some(rts), Some(mux)) = (&parts.rts_pin, parts.rts_mux) {
+            any_as_rts(rts, mux);
+        }
+        let enable_cts = parts.cts_pin.is_some();
+        let enable_rts = parts.rts_pin.is_some();
+
         // Configure UART peripheral
         // TODO make this a specific Bbq mode instead of using blocking
-        // TODO support CTS/RTS pins?
 
-        let _wg = (parts.vtable.lpuart_init)(true, true, false, false, config.into()).map_err(BbqError::Basic)?;
+        let _wg =
+            (parts.vtable.lpuart_init)(true, true, enable_cts, enable_rts, config.into()).map_err(BbqError::Basic)?;
 
         // Setup the TX state
         //
@@ -427,7 +579,7 @@ impl LpuartBbq {
                 mux: parts.tx_mux,
                 _tx_pins: TxPins {
                     tx_pin: parts.tx_pin,
-                    cts_pin: None,
+                    cts_pin: parts.cts_pin,
                 },
                 _wg: _wg.clone(),
             },
@@ -438,7 +590,7 @@ impl LpuartBbq {
                 mux: parts.rx_mux,
                 _rx_pins: RxPins {
                     rx_pin: parts.rx_pin,
-                    rts_pin: None,
+                    rts_pin: parts.rts_pin,
                 },
                 _wg,
             },
@@ -499,6 +651,10 @@ impl LpuartBbq {
             info: tx_parts.info,
             state: tx_parts.state,
             vtable: tx_parts.vtable,
+            cts_pin: tx_parts.flow_pin,
+            cts_mux: tx_parts.flow_mux,
+            rts_pin: rx_parts.flow_pin,
+            rts_mux: rx_parts.flow_mux,
         }
     }
 }
@@ -585,10 +741,15 @@ impl LpuartBbqTx {
         // Set as TX pin mode
         any_as_tx(&parts.pin, parts.mux);
 
+        // Configure optional CTS pin (skip reconfig for a teardown-reclaimed pin, mux == None).
+        if let (Some(cts), Some(mux)) = (&parts.flow_pin, parts.flow_mux) {
+            any_as_cts(cts, mux);
+        }
+        let enable_cts = parts.flow_pin.is_some();
+
         // Configure UART peripheral
         // TODO make this a specific Bbq mode instead of using blocking
-        // TODO support CTS pin?
-        let _wg = (parts.vtable.lpuart_init)(true, false, false, false, config.into()).map_err(BbqError::Basic)?;
+        let _wg = (parts.vtable.lpuart_init)(true, false, enable_cts, false, config.into()).map_err(BbqError::Basic)?;
 
         // Setup the TX Half state
         //
@@ -619,7 +780,7 @@ impl LpuartBbqTx {
             vtable: parts.vtable,
             _tx_pins: TxPins {
                 tx_pin: parts.pin,
-                cts_pin: None,
+                cts_pin: parts.flow_pin,
             },
             _wg,
             mux: parts.mux,
@@ -769,16 +930,23 @@ impl LpuartBbqTx {
         // SAFETY: see above.
         let _wg: Option<WakeGuard> = unsafe { core::ptr::read(&self._wg) };
 
+        // Reclaim the data pin and (already-configured) CTS pin. The flow mux is
+        // intentionally None: the reclaimed pin stays configured across a
+        // teardown->rebuild cycle (take() forgets, so Drop never disabled it).
+        let (data_pin, cts_pin) = tx_pins.take();
+
         let parts = BbqHalfParts {
             buffer: tx_buffer,
             dma_ch: tx_dma,
-            pin: tx_pins.take().0,
+            pin: data_pin,
             dma_req: self.state.txdma_num.load(Ordering::Relaxed),
             mux: self.mux,
             info: self.info,
             state: self.state,
             vtable: self.vtable,
             which: WhichHalf::Tx,
+            flow_pin: cts_pin,
+            flow_mux: None,
         };
 
         // Prevent Drop::drop from re-running teardown_inner (which would re-enter the
@@ -917,10 +1085,15 @@ impl LpuartBbqRx {
         // Set RX pin mode
         any_as_rx(&parts.pin, parts.mux);
 
+        // Configure optional RTS pin (skip reconfig for a teardown-reclaimed pin, mux == None).
+        if let (Some(rts), Some(mux)) = (&parts.flow_pin, parts.flow_mux) {
+            any_as_rts(rts, mux);
+        }
+        let enable_rts = parts.flow_pin.is_some();
+
         // Configure UART peripheral
         // TODO make this a specific Bbq mode instead of using blocking
-        // TODO support RTS pin?
-        let _wg = (parts.vtable.lpuart_init)(false, true, false, false, config.into()).map_err(BbqError::Basic)?;
+        let _wg = (parts.vtable.lpuart_init)(false, true, false, enable_rts, config.into()).map_err(BbqError::Basic)?;
 
         // Setup the RX half state
         let len = parts.buffer.len();
@@ -974,7 +1147,7 @@ impl LpuartBbqRx {
             mux: parts.mux,
             _rx_pins: RxPins {
                 rx_pin: parts.pin,
-                rts_pin: None,
+                rts_pin: parts.flow_pin,
             },
             _wg,
         })
@@ -1119,16 +1292,23 @@ impl LpuartBbqRx {
         // SAFETY: see above.
         let _wg: Option<WakeGuard> = unsafe { core::ptr::read(&self._wg) };
 
+        // Reclaim the data pin and (already-configured) RTS pin. The flow mux is
+        // intentionally None: the reclaimed pin stays configured across a
+        // teardown->rebuild cycle (take() forgets, so Drop never disabled it).
+        let (data_pin, rts_pin) = rx_pins.take();
+
         let parts = BbqHalfParts {
             buffer: rx_buffer,
             dma_ch: rx_dma,
-            pin: rx_pins.take().0,
+            pin: data_pin,
             dma_req: self.state.rxdma_num.load(Ordering::Relaxed),
             mux: self.mux,
             info: self.info,
             state: self.state,
             vtable: self.vtable,
             which: WhichHalf::Rx,
+            flow_pin: rts_pin,
+            flow_mux: None,
         };
 
         // Prevent Drop::drop from re-running teardown_inner (which would re-enter the
@@ -1682,4 +1862,18 @@ fn any_as_rx(pin: &Peri<'_, AnyPin>, mux: crate::pac::port::Mux) {
     pin.set_pull(crate::gpio::Pull::Disabled);
     pin.set_function(mux);
     pin.set_enable_input_buffer(true);
+}
+
+fn any_as_cts(pin: &Peri<'_, AnyPin>, mux: crate::pac::port::Mux) {
+    pin.set_pull(crate::gpio::Pull::Disabled);
+    pin.set_function(mux);
+    pin.set_enable_input_buffer(true);
+}
+
+fn any_as_rts(pin: &Peri<'_, AnyPin>, mux: crate::pac::port::Mux) {
+    pin.set_pull(crate::gpio::Pull::Disabled);
+    pin.set_slew_rate(crate::gpio::SlewRate::Fast.into());
+    pin.set_drive_strength(crate::gpio::DriveStrength::Normal.into());
+    pin.set_function(mux);
+    pin.set_enable_input_buffer(false);
 }

--- a/embassy-mcxa/src/lpuart/dma.rs
+++ b/embassy-mcxa/src/lpuart/dma.rs
@@ -128,6 +128,38 @@ impl<'a> LpuartTx<'a, Dma<'a>> {
         ))
     }
 
+    /// Create a new LPUART TX driver with DMA support and CTS flow control.
+    ///
+    /// Any external pin will be placed into Disabled state upon Drop.
+    pub fn new_async_with_dma_cts<T: Instance>(
+        _inner: Peri<'a, T>,
+        tx_pin: Peri<'a, impl TxPin<T>>,
+        cts_pin: Peri<'a, impl CtsPin<T>>,
+        tx_dma_ch: Peri<'a, impl Channel>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        tx_pin.as_tx();
+        cts_pin.as_cts();
+        let tx_pin: Peri<'a, AnyPin> = tx_pin.into();
+        let cts_pin: Peri<'a, AnyPin> = cts_pin.into();
+
+        // Initialize LPUART with TX enabled, RX disabled, CTS flow control enabled
+        let wg = Lpuart::<Dma<'_>>::init::<T>(true, false, true, false, config)?;
+
+        let dma = DmaChannel::new(tx_dma_ch);
+        dma.enable_interrupt();
+
+        Ok(Self::new_inner::<T>(
+            tx_pin,
+            Some(cts_pin),
+            Dma {
+                dma,
+                request: T::TX_DMA_REQUEST,
+            },
+            wg,
+        ))
+    }
+
     /// Write data using DMA.
     ///
     /// This configures the DMA channel for a memory-to-peripheral transfer
@@ -247,6 +279,38 @@ impl<'a> LpuartRx<'a, Dma<'a>> {
                 request: T::RX_DMA_REQUEST,
             },
             _wg,
+        ))
+    }
+
+    /// Create a new LPUART RX driver with DMA support and RTS flow control.
+    ///
+    /// Any external pin will be placed into Disabled state upon Drop.
+    pub fn new_async_with_dma_rts<T: Instance>(
+        _inner: Peri<'a, T>,
+        rx_pin: Peri<'a, impl RxPin<T>>,
+        rts_pin: Peri<'a, impl RtsPin<T>>,
+        rx_dma_ch: Peri<'a, impl Channel>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        rx_pin.as_rx();
+        rts_pin.as_rts();
+        let rx_pin: Peri<'a, AnyPin> = rx_pin.into();
+        let rts_pin: Peri<'a, AnyPin> = rts_pin.into();
+
+        // Initialize LPUART with TX disabled, RX enabled, RTS flow control enabled
+        let wg = Lpuart::<Dma<'_>>::init::<T>(false, true, false, true, config)?;
+
+        let dma = DmaChannel::new(rx_dma_ch);
+        dma.enable_interrupt();
+
+        Ok(Self::new_inner::<T>(
+            rx_pin,
+            Some(rts_pin),
+            Dma {
+                dma,
+                request: T::RX_DMA_REQUEST,
+            },
+            wg,
         ))
     }
 
@@ -497,6 +561,59 @@ impl<'a> Lpuart<'a, Dma<'a>> {
             rx: LpuartRx::new_inner::<T>(
                 rx_pin,
                 None,
+                Dma {
+                    dma: rx_dma,
+                    request: T::RX_DMA_REQUEST,
+                },
+                wg,
+            ),
+        })
+    }
+
+    /// Create a new full-duplex LPUART DMA driver with RTS/CTS flow control.
+    ///
+    /// Any external pin will be placed into Disabled state upon Drop.
+    pub fn new_async_with_dma_rtscts<T: Instance>(
+        _inner: Peri<'a, T>,
+        tx_pin: Peri<'a, impl TxPin<T>>,
+        rx_pin: Peri<'a, impl RxPin<T>>,
+        cts_pin: Peri<'a, impl CtsPin<T>>,
+        rts_pin: Peri<'a, impl RtsPin<T>>,
+        tx_dma_ch: Peri<'a, impl Channel>,
+        rx_dma_ch: Peri<'a, impl Channel>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        tx_pin.as_tx();
+        rx_pin.as_rx();
+        cts_pin.as_cts();
+        rts_pin.as_rts();
+
+        let tx_pin: Peri<'a, AnyPin> = tx_pin.into();
+        let rx_pin: Peri<'a, AnyPin> = rx_pin.into();
+        let cts_pin: Peri<'a, AnyPin> = cts_pin.into();
+        let rts_pin: Peri<'a, AnyPin> = rts_pin.into();
+
+        // Initialize LPUART with both TX and RX enabled, and both flow controls enabled
+        let wg = Lpuart::<Dma<'a>>::init::<T>(true, true, true, true, config)?;
+
+        let tx_dma = DmaChannel::new(tx_dma_ch);
+        let rx_dma = DmaChannel::new(rx_dma_ch);
+        tx_dma.enable_interrupt();
+        rx_dma.enable_interrupt();
+
+        Ok(Self {
+            tx: LpuartTx::new_inner::<T>(
+                tx_pin,
+                Some(cts_pin),
+                Dma {
+                    dma: tx_dma,
+                    request: T::TX_DMA_REQUEST,
+                },
+                wg.clone(),
+            ),
+            rx: LpuartRx::new_inner::<T>(
+                rx_pin,
+                Some(rts_pin),
                 Dma {
                     dma: rx_dma,
                     request: T::RX_DMA_REQUEST,

--- a/examples/mcxa2xx/src/bin/lpuart_bbq_rtscts.rs
+++ b/examples/mcxa2xx/src/bin/lpuart_bbq_rtscts.rs
@@ -1,0 +1,116 @@
+//! LPUART BBQueue example with RTS/CTS hardware flow control for MCXA2.
+//!
+//! Demonstrates hardware flow control by flooding the UART with more data than
+//! the receiver drains. The `LpuartBbq` is `split()` into a TX and RX half, and
+//! two concurrent futures are `join`ed:
+//!
+//! * the TX future floods a large payload as fast as it can,
+//! * the RX future drains slowly (small reads with delays between them).
+//!
+//! Because the RX side falls behind, its ring buffer fills, the peripheral
+//! deasserts RTS, and the connected CTS pauses the TX flood. The transfer only
+//! makes progress at the rate the slow reader consumes it, without losing data.
+//!
+//! Wire this as a self-loopback on a single board:
+//! * TX (P2_2)  -> RX (P2_3)
+//! * RTS (P2_5) -> CTS (P2_4)
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_mcxa::clocks::PoweredClock;
+use embassy_mcxa::clocks::config::Div8;
+use embassy_mcxa::clocks::periph_helpers::LpuartClockSel;
+use embassy_mcxa::dma::DmaChannel;
+use embassy_mcxa::lpuart::{BbqConfig, BbqParts, BbqRxMode, LpuartBbq};
+use embassy_mcxa::{bind_interrupts, lpuart};
+use embassy_time::Timer;
+use static_cell::ConstStaticCell;
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    LPUART2 => lpuart::BbqInterruptHandler::<hal::peripherals::LPUART2>;
+});
+
+const SIZE: usize = 1024;
+static TX_BUF: ConstStaticCell<[u8; SIZE]> = ConstStaticCell::new([0u8; SIZE]);
+static RX_BUF: ConstStaticCell<[u8; SIZE]> = ConstStaticCell::new([0u8; SIZE]);
+
+// Total number of bytes to flood through the link.
+const TOTAL: usize = 4096;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg = hal::config::Config::default();
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    let p = hal::init(cfg);
+
+    defmt::info!("LPUART BBQ RTS/CTS flood example starting...");
+
+    let mut config = BbqConfig::default();
+    config.baudrate_bps = 115_200;
+    config.power = PoweredClock::NormalEnabledDeepSleepDisabled;
+    config.source = LpuartClockSel::FroLfDiv;
+
+    let tx_buf = TX_BUF.take();
+    let rx_buf = RX_BUF.take();
+
+    let parts = BbqParts::new_with_rtscts(
+        p.LPUART2, // Instance
+        Irqs,
+        p.P2_2, // TX pin
+        tx_buf,
+        DmaChannel::new(p.DMA0_CH0), // TX DMA channel
+        p.P2_3,                      // RX pin
+        rx_buf,
+        DmaChannel::new(p.DMA0_CH1), // RX DMA channel
+        p.P2_4,                      // CTS pin
+        p.P2_5,                      // RTS pin
+    )
+    .unwrap();
+
+    let uart = LpuartBbq::new(parts, config, BbqRxMode::Efficiency).unwrap();
+
+    // Split into independent TX and RX halves so they can run concurrently.
+    let (mut tx, mut rx) = uart.split();
+
+    // TX future: flood a large payload as fast as the link allows. When the
+    // receiver falls behind, CTS (driven by the loopbacked RTS) will pause us.
+    let flood = async {
+        let payload = [0xA5u8; 256];
+        let mut sent = 0usize;
+        while sent < TOTAL {
+            // `write` may accept only part of the slice, so advance a window.
+            let mut window = payload.as_slice();
+            while !window.is_empty() && sent < TOTAL {
+                let n = tx.write(window).await.unwrap();
+                window = &window[n..];
+                sent += n;
+            }
+        }
+        tx.flush().await;
+        defmt::info!("TX flood complete: {} bytes sent", sent);
+    };
+
+    // RX future: drain slowly. The small buffer plus the delay between reads
+    // means the RX side cannot keep up, forcing hardware flow control to engage.
+    let drain = async {
+        let mut buf = [0u8; 16];
+        let mut received = 0usize;
+        while received < TOTAL {
+            let n = rx.read(&mut buf).await.unwrap();
+            received += n;
+            defmt::info!("RX drained {} bytes (total {})", n, received);
+            // Deliberately slow: let the RX ring fill and RTS deassert.
+            Timer::after_millis(10).await;
+        }
+        defmt::info!("RX drain complete: {} bytes received", received);
+    };
+
+    join(flood, drain).await;
+
+    defmt::info!("Example complete: flow control exercised over {} bytes", TOTAL);
+}

--- a/examples/mcxa2xx/src/bin/lpuart_dma_rtscts.rs
+++ b/examples/mcxa2xx/src/bin/lpuart_dma_rtscts.rs
@@ -1,0 +1,103 @@
+//! LPUART DMA example with RTS/CTS hardware flow control for MCXA2.
+//!
+//! Demonstrates hardware flow control by flooding the UART with more data than
+//! the receiver drains. The driver is `split()` into a TX and RX half, and two
+//! concurrent futures are `join`ed:
+//!
+//! * the TX future floods a large payload as fast as it can,
+//! * the RX future drains slowly (small reads with delays between them).
+//!
+//! Because the RX side falls behind, its RX FIFO fills, the peripheral deasserts
+//! RTS, and the connected CTS pauses the TX flood. The transfer therefore only
+//! makes progress at the rate the slow reader consumes it, without losing data.
+//!
+//! Wire this as a self-loopback on a single board:
+//! * TX (P2_2)  -> RX (P2_3)
+//! * RTS (P2_5) -> CTS (P2_4)
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_mcxa::clocks::config::Div8;
+use embassy_mcxa::lpuart::{Config, Error, Lpuart};
+use embassy_time::Timer;
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+// Total number of bytes to flood through the link.
+const TOTAL: usize = 4096;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg = hal::config::Config::default();
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    let p = hal::init(cfg);
+
+    defmt::info!("LPUART DMA RTS/CTS flood example starting...");
+
+    let config = Config {
+        baudrate_bps: 115_200,
+        ..Default::default()
+    };
+
+    let lpuart = Lpuart::new_async_with_dma_rtscts(
+        p.LPUART2,  // Instance
+        p.P2_2,     // TX pin
+        p.P2_3,     // RX pin
+        p.P2_4,     // CTS pin
+        p.P2_5,     // RTS pin
+        p.DMA0_CH0, // TX DMA channel
+        p.DMA0_CH1, // RX DMA channel
+        config,
+    )
+    .unwrap();
+
+    // Split into independent TX and RX halves so they can run concurrently.
+    let (mut tx, mut rx) = lpuart.split();
+
+    // TX future: flood a large payload as fast as the link allows. When the
+    // receiver falls behind, CTS (driven by the loopbacked RTS) will pause us.
+    let flood = async {
+        let payload = [0xA5u8; 256];
+        let mut sent = 0usize;
+        while sent < TOTAL {
+            let n = tx.write(&payload).await.unwrap();
+            sent += n;
+        }
+        defmt::info!("TX flood complete: {} bytes sent", sent);
+    };
+
+    // RX future: drain slowly. The small buffer plus the delay between reads
+    // means the RX side cannot keep up, forcing hardware flow control to engage.
+    let drain = async {
+        let mut buf = [0u8; 16];
+        let mut received = 0usize;
+        while received < TOTAL {
+            match rx.read(&mut buf).await {
+                Ok(n) => {
+                    received += n;
+                    defmt::info!("RX drained {} bytes (total {})", n, received);
+                }
+                // Before RTS backpressure fully engages on the very first burst,
+                // the RX FIFO can briefly overflow. This is a recoverable transient:
+                // log it and keep draining rather than aborting the demo.
+                Err(Error::Overrun) => {
+                    defmt::warn!("RX overrun (transient), continuing");
+                }
+                Err(e) => {
+                    defmt::error!("RX read error at total {}: {}", received, e);
+                    return;
+                }
+            }
+            // Deliberately slow: let the RX FIFO fill and RTS deassert.
+            Timer::after_millis(10).await;
+        }
+        defmt::info!("RX drain complete: {} bytes received", received);
+    };
+
+    join(flood, drain).await;
+
+    defmt::info!("Example complete: flow control exercised over {} bytes", TOTAL);
+}

--- a/examples/mcxa5xx/src/bin/lpuart_bbq_rtscts.rs
+++ b/examples/mcxa5xx/src/bin/lpuart_bbq_rtscts.rs
@@ -1,0 +1,116 @@
+//! LPUART BBQueue example with RTS/CTS hardware flow control for MCXA5.
+//!
+//! Demonstrates hardware flow control by flooding the UART with more data than
+//! the receiver drains. The `LpuartBbq` is `split()` into a TX and RX half, and
+//! two concurrent futures are `join`ed:
+//!
+//! * the TX future floods a large payload as fast as it can,
+//! * the RX future drains slowly (small reads with delays between them).
+//!
+//! Because the RX side falls behind, its ring buffer fills, the peripheral
+//! deasserts RTS, and the connected CTS pauses the TX flood. The transfer only
+//! makes progress at the rate the slow reader consumes it, without losing data.
+//!
+//! Wire this as a self-loopback on a single board:
+//! * TX (P2_2)  -> RX (P2_3)
+//! * RTS (P2_5) -> CTS (P2_4)
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_mcxa::clocks::PoweredClock;
+use embassy_mcxa::clocks::config::Div8;
+use embassy_mcxa::clocks::periph_helpers::LpuartClockSel;
+use embassy_mcxa::dma::DmaChannel;
+use embassy_mcxa::lpuart::{BbqConfig, BbqParts, BbqRxMode, LpuartBbq};
+use embassy_mcxa::{bind_interrupts, lpuart};
+use embassy_time::Timer;
+use static_cell::ConstStaticCell;
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+bind_interrupts!(struct Irqs {
+    LPUART2 => lpuart::BbqInterruptHandler::<hal::peripherals::LPUART2>;
+});
+
+const SIZE: usize = 1024;
+static TX_BUF: ConstStaticCell<[u8; SIZE]> = ConstStaticCell::new([0u8; SIZE]);
+static RX_BUF: ConstStaticCell<[u8; SIZE]> = ConstStaticCell::new([0u8; SIZE]);
+
+// Total number of bytes to flood through the link.
+const TOTAL: usize = 4096;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg = hal::config::Config::default();
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    let p = hal::init(cfg);
+
+    defmt::info!("LPUART BBQ RTS/CTS flood example starting...");
+
+    let mut config = BbqConfig::default();
+    config.baudrate_bps = 115_200;
+    config.power = PoweredClock::NormalEnabledDeepSleepDisabled;
+    config.source = LpuartClockSel::FroLfDiv;
+
+    let tx_buf = TX_BUF.take();
+    let rx_buf = RX_BUF.take();
+
+    let parts = BbqParts::new_with_rtscts(
+        p.LPUART2, // Instance
+        Irqs,
+        p.P2_2, // TX pin
+        tx_buf,
+        DmaChannel::new(p.DMA0_CH0), // TX DMA channel
+        p.P2_3,                      // RX pin
+        rx_buf,
+        DmaChannel::new(p.DMA0_CH1), // RX DMA channel
+        p.P2_4,                      // CTS pin
+        p.P2_5,                      // RTS pin
+    )
+    .unwrap();
+
+    let uart = LpuartBbq::new(parts, config, BbqRxMode::Efficiency).unwrap();
+
+    // Split into independent TX and RX halves so they can run concurrently.
+    let (mut tx, mut rx) = uart.split();
+
+    // TX future: flood a large payload as fast as the link allows. When the
+    // receiver falls behind, CTS (driven by the loopbacked RTS) will pause us.
+    let flood = async {
+        let payload = [0xA5u8; 256];
+        let mut sent = 0usize;
+        while sent < TOTAL {
+            // `write` may accept only part of the slice, so advance a window.
+            let mut window = payload.as_slice();
+            while !window.is_empty() && sent < TOTAL {
+                let n = tx.write(window).await.unwrap();
+                window = &window[n..];
+                sent += n;
+            }
+        }
+        tx.flush().await;
+        defmt::info!("TX flood complete: {} bytes sent", sent);
+    };
+
+    // RX future: drain slowly. The small buffer plus the delay between reads
+    // means the RX side cannot keep up, forcing hardware flow control to engage.
+    let drain = async {
+        let mut buf = [0u8; 16];
+        let mut received = 0usize;
+        while received < TOTAL {
+            let n = rx.read(&mut buf).await.unwrap();
+            received += n;
+            defmt::info!("RX drained {} bytes (total {})", n, received);
+            // Deliberately slow: let the RX ring fill and RTS deassert.
+            Timer::after_millis(10).await;
+        }
+        defmt::info!("RX drain complete: {} bytes received", received);
+    };
+
+    join(flood, drain).await;
+
+    defmt::info!("Example complete: flow control exercised over {} bytes", TOTAL);
+}

--- a/examples/mcxa5xx/src/bin/lpuart_dma_rtscts.rs
+++ b/examples/mcxa5xx/src/bin/lpuart_dma_rtscts.rs
@@ -1,0 +1,103 @@
+//! LPUART DMA example with RTS/CTS hardware flow control for MCXA5.
+//!
+//! Demonstrates hardware flow control by flooding the UART with more data than
+//! the receiver drains. The driver is `split()` into a TX and RX half, and two
+//! concurrent futures are `join`ed:
+//!
+//! * the TX future floods a large payload as fast as it can,
+//! * the RX future drains slowly (small reads with delays between them).
+//!
+//! Because the RX side falls behind, its RX FIFO fills, the peripheral deasserts
+//! RTS, and the connected CTS pauses the TX flood. The transfer therefore only
+//! makes progress at the rate the slow reader consumes it, without losing data.
+//!
+//! Wire this as a self-loopback on a single board:
+//! * TX (P2_2)  -> RX (P2_3)
+//! * RTS (P2_5) -> CTS (P2_4)
+
+#![no_std]
+#![no_main]
+
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_mcxa::clocks::config::Div8;
+use embassy_mcxa::lpuart::{Config, Error, Lpuart};
+use embassy_time::Timer;
+use {defmt_rtt as _, embassy_mcxa as hal, panic_probe as _};
+
+// Total number of bytes to flood through the link.
+const TOTAL: usize = 4096;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut cfg = hal::config::Config::default();
+    cfg.clock_cfg.sirc.fro_12m_enabled = true;
+    cfg.clock_cfg.sirc.fro_lf_div = Some(Div8::no_div());
+    let p = hal::init(cfg);
+
+    defmt::info!("LPUART DMA RTS/CTS flood example starting...");
+
+    let config = Config {
+        baudrate_bps: 115_200,
+        ..Default::default()
+    };
+
+    let lpuart = Lpuart::new_async_with_dma_rtscts(
+        p.LPUART2,  // Instance
+        p.P2_2,     // TX pin
+        p.P2_3,     // RX pin
+        p.P2_4,     // CTS pin
+        p.P2_5,     // RTS pin
+        p.DMA0_CH0, // TX DMA channel
+        p.DMA0_CH1, // RX DMA channel
+        config,
+    )
+    .unwrap();
+
+    // Split into independent TX and RX halves so they can run concurrently.
+    let (mut tx, mut rx) = lpuart.split();
+
+    // TX future: flood a large payload as fast as the link allows. When the
+    // receiver falls behind, CTS (driven by the loopbacked RTS) will pause us.
+    let flood = async {
+        let payload = [0xA5u8; 256];
+        let mut sent = 0usize;
+        while sent < TOTAL {
+            let n = tx.write(&payload).await.unwrap();
+            sent += n;
+        }
+        defmt::info!("TX flood complete: {} bytes sent", sent);
+    };
+
+    // RX future: drain slowly. The small buffer plus the delay between reads
+    // means the RX side cannot keep up, forcing hardware flow control to engage.
+    let drain = async {
+        let mut buf = [0u8; 16];
+        let mut received = 0usize;
+        while received < TOTAL {
+            match rx.read(&mut buf).await {
+                Ok(n) => {
+                    received += n;
+                    defmt::info!("RX drained {} bytes (total {})", n, received);
+                }
+                // Before RTS backpressure fully engages on the very first burst,
+                // the RX FIFO can briefly overflow. This is a recoverable transient:
+                // log it and keep draining rather than aborting the demo.
+                Err(Error::Overrun) => {
+                    defmt::warn!("RX overrun (transient), continuing");
+                }
+                Err(e) => {
+                    defmt::error!("RX read error at total {}: {}", received, e);
+                    return;
+                }
+            }
+            // Deliberately slow: let the RX FIFO fill and RTS deassert.
+            Timer::after_millis(10).await;
+        }
+        defmt::info!("RX drain complete: {} bytes received", received);
+    };
+
+    join(flood, drain).await;
+
+    defmt::info!("Example complete: flow control exercised over {} bytes", TOTAL);
+}


### PR DESCRIPTION
Add dedicated RTS/CTS hardware flow-control constructors to the LPUART DMA and BBQ drivers, which previously had no flow-control support.

DMA driver:

- LpuartTx::new_async_with_dma_cts (TX + CTS)
- LpuartRx::new_async_with_dma_rts (RX + RTS)
- Lpuart::new_async_with_dma_rtscts (full-duplex RTS/CTS)

BBQ driver:

- BbqConfig gains tx_cts_source / tx_cts_config fields
- BbqParts::new_with_rtscts and BbqHalfParts::new_tx_half_with_cts / new_rx_half_with_rts / new_rx_half_with_rts_async
- flow-control pins are configured, enabled via MODIR, and reclaimed on teardown

Add validation examples (DMA and BBQ, full-duplex RTS/CTS) for both MCXA2 and MCXA5.

Fixes https://github.com/OpenDevicePartnership/embassy-mcxa/issues/194