### PR TITLE
stm32: lptim fixes redux

### DIFF
--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -372,8 +372,11 @@ fn configure_pwr(cs: CriticalSection) -> bool {
 pub unsafe fn sleep(cs: CriticalSection) {
     let stop = configure_pwr(cs);
 
+    // Only flush defmt if we are actually going into Stop. Avoids flush on every tiny WFE
     #[cfg(feature = "low-power-defmt-flush")]
-    defmt::flush();
+    if stop {
+        defmt::flush();
+    }
 
     cortex_m::asm::dsb();
     cortex_m::asm::wfi();

--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -207,7 +207,7 @@ mod platform {
                 // GPTIM timer state is lost in Stop2/Stop3, needs re-init.
                 // LPTIM (_lp-time-driver) survives all STOP modes autonomously.
                 #[cfg(not(feature = "_lp-time-driver"))]
-                if lpms >= 2 {
+                if lpms.to_bits() >= 2 {
                     trace!("low power: re-initializing timer (STOP2+, GPTIM)");
                     super::get_driver().init_timer(_cs);
                 }

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -5,7 +5,7 @@ use core::cell::Cell;
 use core::cell::RefCell;
 #[cfg(feature = "low-power")]
 use core::sync::atomic::AtomicBool;
-use core::sync::atomic::{AtomicU32, Ordering, compiler_fence};
+use core::sync::atomic::{AtomicU32, Ordering};
 
 use critical_section::CriticalSection;
 use embassy_sync::blocking_mutex::Mutex;
@@ -375,16 +375,35 @@ impl super::LPTimeDriver for RtcDriver {
 impl Driver for RtcDriver {
     fn now(&self) -> u64 {
         let r = regs_lptim();
-        loop {
-            let period = self.period.load(Ordering::Relaxed);
-            compiler_fence(Ordering::Acquire);
-            let counter = r.cnt().read().cnt();
-            let now = ((period as u64) << 16) + (counter as u64);
 
-            if self.period.load(Ordering::Relaxed) == period {
-                break now;
+        // This CS is needed to prevent race conditions that cause time to go backwards when now()
+        // is called at the exact instant the LPTIM_CNT register overflows. When an overflow
+        // happens, `period` is advanced by the update-event interrupt, so period and LPTIM_CNT
+        // must be sampled atomically, i.e. with that interrupt masked. Otherwise, the counter can
+        // wrap while `period` still has the previous value, and composing them yields a timestamp
+        // a whole period in the past, causing time to go backwards, and any
+        // `Instant::duration_since` spanning that window panics.
+        critical_section::with(|_| {
+            // RM0456 says: "When the LPTIM is running, reading the LPTIM_CNT register may return
+            // unreliable values. In this case it is necessary to perform consecutive reads until
+            // two returned values are identical."
+            let mut counter = r.cnt().read().cnt();
+            loop {
+                let again = r.cnt().read().cnt();
+                if again == counter {
+                    break;
+                }
+                counter = again;
             }
-        }
+
+            // With the period-incrementing, a pending update event unambiguously means
+            // the counter has wrapped and `next_period` has not yet accounted for it. NB: we DO
+            // NOT clear the ue bit, that (and consequently incrementing self.period) is for the
+            // ISR to do once we release this CS.
+            let period = self.period.load(Ordering::Relaxed) + r.isr().read().ue() as u32;
+
+            ((period as u64) << 16) + counter as u64
+        })
     }
 
     fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {


### PR DESCRIPTION
Three more small fixes to stm32 time-driver-lptimX and low-power:

1) Fix a bug I introduced in #6603, doing int comparison on an enum (sorry!)
2) with the  `low-power-defmt-flush` feature, only flush if we're actually entering stop. Because calling low_power::sleep() does not imply we'll enter stop, we were calling defmt::flush() even on tiny delays e.g. during driver code. The resulting delay from defmt::flush() reliably broke SAI->SDMMC transfers causing DMA overruns for me (and probably any other timing-senstive code, even if using min_stop_pause/WakeGuard)
3) Fix a race condition in the lptim time driver that did not atomically sample both the LPTIM_CNT regiter AND the timer's period, which caused time to go backwards by 2 seconds on the rare occasion when .now() was called during an overflow (causing a hard panic within an hour or two of operation)

RE the new AI disclosure policy: I found and wrote 1 & 2, a model (K3) found & mostly-fixed 3, though I wrote the final code & comments.


best,
K