### PR TITLE
stm32/timer: support distinct buffer to timer sizes

### DIFF
--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -1022,13 +1022,14 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
                 fifo_threshold: Some(FifoThreshold::Full),
                 #[cfg(not(any(bdma, gpdma, lpdma)))]
                 mburst: Burst::Incr8,
+                packing: crate::dma::Packing::ZeroExtendOrLeftTruncate,
                 ..Default::default()
             };
 
             WritableRingBuffer::new(
                 dma::Channel::new(dma, irq),
                 req,
-                self.regs_1ch().ccr(channel.index()).as_ptr() as *mut W,
+                self.regs_1ch().ccr(channel.index()).as_ptr() as *mut T::Word,
                 dma_buf,
                 dma_transfer_option,
             )
@@ -1081,6 +1082,7 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
                 fifo_threshold: Some(FifoThreshold::Full),
                 #[cfg(not(any(bdma, gpdma, lpdma)))]
                 mburst: Burst::Incr8,
+                packing: crate::dma::Packing::ZeroExtendOrLeftTruncate,
                 ..Default::default()
             };
 
@@ -1089,7 +1091,7 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
                 .write(
                     request,
                     duty,
-                    self.regs_gp16().ccr(channel.index()).as_ptr() as *mut W,
+                    self.regs_gp16().ccr(channel.index()).as_ptr() as *mut T::Word,
                     dma_transfer_option,
                 )
                 .unchecked_extend_lifetime()


### PR DESCRIPTION
`setup_ring_buffer` and `setup_update_dma_inner` cast the CCR pointer to `*mut W`, the caller-supplied buffer element type, instead of `*mut T::Word`, the timer's actual register width. This forced the DMA transfer's peripheral-side word size to match the memory-side size, preventing callers from storing a narrower type (e.g. u8) in memory while relying on the DMA controller to widen each element to the timer's real CCR width on write.

Packing is set to `ZeroExetendOrLeftTruncate` to expand each element individually into the peripheral register, rather than packing multiple entries.

This change is sufficient to use smaller input types as the timer size is. An example where this can use is `stm32f4/src/bin/ws2812_pwm.rs`. The on and off times `n0` and `n1` can be forced to u8, resulting in significant memory reduction, retaining the same behaviour.

I have tested this with a custom, yet similar ws2812 implementtion on a stm32l433.