### PR TITLE
stm32-wpan: fix ub due to bytecasting status codes from ipc.

### DIFF
--- a/embassy-stm32-wpan/src/net/macros.rs
+++ b/embassy-stm32-wpan/src/net/macros.rs
@@ -1,32 +1,78 @@
+/// Define a newtype over a primitive integer with a set of named values.
+///
+/// These types appear in the `#[repr(C)]` structs that are reinterpreted directly from the buffers
+/// shared with the radio coprocessor, so they must accept *every* bit pattern: a real `enum` with
+/// an out-of-range discriminant is instant UB. Hence a transparent newtype with associated
+/// constants instead of variants. Unknown values are preserved and printed numerically.
 #[macro_export]
 macro_rules! numeric_enum {
     (#[repr($repr:ident)]
      $(#$attrs:tt)* $vis:vis enum $name:ident {
-        $($(#$enum_attrs:tt)* $enum:ident = $constant:expr),* $(,)?
-    } ) => {
-        #[repr($repr)]
+        $($(#$value_attrs:tt)* $value:ident = $constant:expr),* $(,)?
+    }
+    $(default = $default:ident;)?
+    ) => {
         $(#$attrs)*
-        $vis enum $name {
-            $($(#$enum_attrs)* $enum = $constant),*
+        #[repr(transparent)]
+        #[derive(Clone, Copy, PartialEq, Eq)]
+        $vis struct $name(pub $repr);
+
+        #[allow(non_upper_case_globals)]
+        impl $name {
+            $($(#$value_attrs)* pub const $value: Self = Self($constant);)*
         }
 
-        impl ::core::convert::TryFrom<$repr> for $name {
-            type Error = ();
-
-            fn try_from(value: $repr) -> ::core::result::Result<Self, ()> {
-                match value {
-                    $($constant => Ok( $name :: $enum ),)*
-                    _ => Err(())
+        $(
+            impl ::core::default::Default for $name {
+                fn default() -> Self {
+                    Self::$default
                 }
+            }
+        )?
+
+        impl ::core::convert::From<$repr> for $name {
+            fn from(value: $repr) -> Self {
+                Self(value)
             }
         }
 
         impl ::core::convert::From<$name> for $repr {
             fn from(value: $name) -> $repr {
-                match value {
-                    $($name :: $enum => $constant,)*
+                value.0
+            }
+        }
+
+        impl ::core::fmt::Debug for $name {
+            fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+                match *self {
+                    $(Self::$value => f.write_str(::core::stringify!($value)),)*
+                    Self(other) => ::core::write!(f, "Unknown({})", other),
                 }
             }
         }
+
+        // Formatting goes through a shadow enum rather than writing the name as a `{=str}`
+        // argument: defmt propagates the enclosing `{=?}` hint into nested arguments, which would
+        // render the name quoted. Derived enum formatting puts the name in the interned format
+        // string instead, so it comes out bare.
+        #[cfg(feature = "defmt")]
+        const _: () = {
+            #[derive(defmt::Format)]
+            enum Fmt {
+                $($value,)*
+                Unknown($repr),
+            }
+
+            impl defmt::Format for $name {
+                fn format(&self, f: defmt::Formatter) {
+                    let fmt = match *self {
+                        $(<$name>::$value => Fmt::$value,)*
+                        $name(other) => Fmt::Unknown(other),
+                    };
+
+                    defmt::write!(f, "{}", fmt)
+                }
+            }
+        };
     }
 }

--- a/embassy-stm32-wpan/src/net/typedefs.rs
+++ b/embassy-stm32-wpan/src/net/typedefs.rs
@@ -29,23 +29,18 @@ impl From<u8> for MacError {
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Debug, Default)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum MacStatus {
-        #[default]
         Success = 0x00,
         Failure = 0xFF
     }
+    default = Success;
 }
 
 numeric_enum! {
     #[repr(u8)]
     /// this enum contains all the MAC PIB Ids
-    #[derive(Default, Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum PibId {
         // PHY
-        #[default]
         CurrentChannel = 0x00,
         ChannelsSupported = 0x01,
         TransmitPower = 0x02,
@@ -96,19 +91,18 @@ numeric_enum! {
         AssociatedPanCoordinator = 0x56,
         PromiscuousMode = 0x51,
     }
+    default = CurrentChannel;
 }
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Default, Clone, Copy, Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum AddressMode {
-        #[default]
         NoAddress = 0x00,
         Reserved = 0x01,
         Short = 0x02,
         Extended = 0x03,
-}
+    }
+    default = NoAddress;
 }
 
 impl TryFrom<AddressingMode> for AddressMode {
@@ -150,8 +144,7 @@ impl From<MacAddressAndMode> for Address {
         match mode {
             AddressMode::Short => Address::Short(unsafe { address.short }),
             AddressMode::Extended => Address::Extended(unsafe { address.extended }),
-            AddressMode::NoAddress => Address::Absent,
-            AddressMode::Reserved => Address::Absent,
+            _ => Address::Absent,
         }
     }
 }
@@ -228,7 +221,7 @@ pub struct PanDescriptor {
     /// The current channel page occupied by the network
     pub channel_page: u8,
     /// PAN coordinator is accepting GTS requests or not
-    pub gts_permit: bool,
+    pub gts_permit: u8,
     /// Superframe specification as specified in the received beacon frame
     pub superframe_spec: [u8; 2],
     /// The time at which the beacon frame was received, in symbols
@@ -248,25 +241,24 @@ impl TryFrom<&[u8]> for PanDescriptor {
             return Err(());
         }
 
-        let coord_addr_mode = AddressMode::try_from(buf[2])?;
+        let coord_addr_mode = AddressMode::from(buf[2]);
         let coord_addr = match coord_addr_mode {
-            AddressMode::NoAddress => MacAddress { short: [0, 0] },
-            AddressMode::Reserved => MacAddress { short: [0, 0] },
             AddressMode::Short => MacAddress {
                 short: [buf[4], buf[5]],
             },
             AddressMode::Extended => MacAddress {
                 extended: [buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11]],
             },
+            _ => MacAddress { short: [0, 0] },
         };
 
         Ok(Self {
             coord_pan_id: PanId([buf[0], buf[1]]),
             coord_addr_mode,
-            logical_channel: MacChannel::try_from(buf[3])?,
+            logical_channel: MacChannel::from(buf[3]),
             coord_addr,
             channel_page: buf[12],
-            gts_permit: buf[13] != 0,
+            gts_permit: buf[13],
             superframe_spec: [buf[14], buf[15]],
             time_stamp: [buf[16], buf[17], buf[18], buf[19]],
             link_quality: buf[20],
@@ -278,8 +270,6 @@ impl TryFrom<&[u8]> for PanDescriptor {
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Default, Clone, Copy, Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     /// Building wireless applications with STM32WB series MCUs - Application note 13.10.3
     pub enum MacChannel {
         Channel11 = 0x0B,
@@ -287,7 +277,6 @@ numeric_enum! {
         Channel13 = 0x0D,
         Channel14 = 0x0E,
         Channel15 = 0x0F,
-        #[default]
         Channel16 = 0x10,
         Channel17 = 0x11,
         Channel18 = 0x12,
@@ -300,10 +289,12 @@ numeric_enum! {
         Channel25 = 0x19,
         Channel26 = 0x1A,
     }
+    default = Channel16;
 }
 
 #[cfg(not(feature = "defmt"))]
 bitflags::bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     pub struct Capabilities: u8 {
         /// 1 if the device is capabaleof becoming a PAN coordinator
         const IS_COORDINATOR_CAPABLE = 0b00000001;
@@ -344,10 +335,7 @@ defmt::bitflags! {
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Default, Clone, Copy, Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum KeyIdMode {
-        #[default]
         /// the key is determined implicitly from the originator and recipient(s) of the frame
         Implicite = 0x00,
         /// the key is determined explicitly using a 1 bytes key source and a 1 byte key index
@@ -357,12 +345,11 @@ numeric_enum! {
         /// the key is determined explicitly using a 8 bytes key source and a 1 byte key index
         Explicite8Byte = 0x03,
     }
+    default = Implicite;
 }
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum AssociationStatus {
         /// Association successful
         Success = 0x00,
@@ -375,8 +362,6 @@ numeric_enum! {
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Clone, Copy, Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum DisassociationReason {
         /// The coordinator wishes the device to leave the PAN.
         CoordRequested = 0x01,
@@ -387,23 +372,19 @@ numeric_enum! {
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Default, Clone, Copy, Debug, PartialEq)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum SecurityLevel {
         /// MAC Unsecured Mode Security
-        #[default]
         Unsecure = 0x00,
         /// MAC ACL Mode Security
         AclMode = 0x01,
         /// MAC Secured Mode Security
         Secured = 0x02,
     }
+    default = Unsecure;
 }
 
 numeric_enum! {
     #[repr(u8)]
-    #[derive(Debug)]
-    #[cfg_attr(feature = "defmt", derive(defmt::Format))]
     pub enum ScanType {
         EdScan = 0x00,
         Active = 0x01,


### PR DESCRIPTION
AssociateConfirm.status in the tests is reporting 0xE1/0xE9 which is not
in the enum. Bytecasting forces creating the enum with a byte value it shouldn't
have, which is UB. The defmt format impl was jumping to nowhere due to overflowing a jump table.

Actually adding all the missing enum cases is TODO, but at least it's not UB now.
