### PR TITLE
stm32: fix injected adc type system

### DIFF
--- a/embassy-stm32/src/adc/injected.rs
+++ b/embassy-stm32/src/adc/injected.rs
@@ -5,45 +5,20 @@ use core::task::Poll;
 
 use crate::adc::{BasicAdcRegs, BorrowedAdcChannel, DefaultInstance, InjectedAdcRegs, Instance, State};
 use crate::atomic::AtomicClear;
-use crate::interrupt::typelevel::{Handler, Interrupt};
-use crate::mode::{Async, Blocking, Mode};
-
-// Implement NoHandler bindings so that when the user requests no interrupt, the binding is satisfied.
-
-#[derive(Clone, Copy)]
-pub struct NoHandler<I: Interrupt> {
-    _marker: PhantomData<I>,
-}
-
-impl<I: Interrupt> crate::interrupt::typelevel::Handler<I> for NoHandler<I> {
-    unsafe fn on_interrupt() {}
-}
-
-unsafe impl<I: Interrupt + Copy> crate::interrupt::typelevel::Binding<I, NoHandler<I>> for I {}
-
-pub(crate) trait SealedIrqMode: Mode {
-    const IRQ: bool;
-}
+use crate::interrupt::typelevel::Handler;
+use crate::mode::{Async, Blocking, Mode, NoHandler};
 
 #[allow(private_bounds)]
-pub trait IrqMode: SealedIrqMode {
+pub trait InjectedMode: Mode {
     type Handler<T: DefaultInstance>: Handler<<T as Instance>::Interrupt>;
 }
 
-impl IrqMode for Async {
+impl InjectedMode for Async {
     type Handler<T: DefaultInstance> = crate::adc::InterruptHandler<T>;
 }
 
-impl IrqMode for Blocking {
+impl InjectedMode for Blocking {
     type Handler<T: DefaultInstance> = NoHandler<T::Interrupt>;
-}
-
-impl SealedIrqMode for Async {
-    const IRQ: bool = true;
-}
-
-impl SealedIrqMode for Blocking {
-    const IRQ: bool = false;
 }
 
 /// Injected ADC sequence with owned channels.

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -31,7 +31,7 @@ pub use configured_sequence::ConfiguredSequence;
 #[cfg(any(adc_f1, adc_f3v1, adc_v1, adc_l0, adc_f3v2, adc_u5, adc_wba, adc_h5, adc_v2, adc_g4))]
 use embassy_sync::waitqueue::AtomicWaker;
 #[cfg(any(adc_v2, adc_h5, adc_g4))]
-pub use injected::{InjectedAdc, IrqMode, NoHandler};
+pub use injected::{InjectedAdc, InjectedMode};
 pub use ringbuffered::{OverrunError, RingBufferedAdc};
 
 #[cfg(adc_u5)]
@@ -664,7 +664,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
     /// - The order of channels in `sequence` determines the rank order in the injected sequence.
     /// - Accessing samples beyond `N` will result in a panic; use the returned type
     ///   `InjectedAdc<T, N>` to enforce bounds at compile time.
-    pub fn setup_injected_conversions<'a, const N: usize, M: IrqMode>(
+    pub fn setup_injected_conversions<'a, const N: usize, M: InjectedMode>(
         self,
         _irq: impl crate::interrupt::typelevel::Binding<T::Interrupt, M::Handler<T>> + 'a,
         sequence: [(BorrowedAdcChannel<'a, T>, <T::Regs as BasicAdcRegs>::SampleTime); N],
@@ -681,13 +681,6 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
             NR_INJECTED_RANKS
         );
 
-        if M::IRQ {
-            <T::Interrupt as crate::interrupt::typelevel::Interrupt>::unpend();
-            unsafe {
-                <T::Interrupt as crate::interrupt::typelevel::Interrupt>::enable();
-            }
-        }
-
         T::regs().stop_injected();
         T::regs().configure_sequence(
             sequence
@@ -697,7 +690,15 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
         );
 
         T::regs().enable();
-        T::regs().configure_injected_trigger((trigger._trigger, trigger._edge), M::IRQ);
+        T::regs().configure_injected_trigger((trigger._trigger, trigger._edge), M::ASYNC);
+
+        if M::ASYNC {
+            <T::Interrupt as crate::interrupt::typelevel::Interrupt>::unpend();
+            unsafe {
+                <T::Interrupt as crate::interrupt::typelevel::Interrupt>::enable();
+            }
+        }
+
         T::regs().start_injected();
 
         core::mem::forget(self);
@@ -727,7 +728,7 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
     /// This function is `unsafe` because it clones the ADC peripheral handle unchecked. Both the
     /// `RingBufferedAdc` and `InjectedAdc` take ownership of the handle and drop it independently.
     /// Ensure no other code concurrently accesses the same ADC instance in a conflicting way.
-    pub fn into_ring_buffered_and_injected<'a, 'b, const N: usize, D: RxDma<T>, M: IrqMode>(
+    pub fn into_ring_buffered_and_injected<'a, 'b, const N: usize, D: RxDma<T>, M: InjectedMode>(
         self,
         dma: embassy_hal_internal::Peri<'a, D>,
         dma_buf: &'a mut [u16],
@@ -772,16 +773,16 @@ impl<'d, T: Instance<Regs: InjectedAdcRegs>> Adc<'d, T> {
 
         T::regs().enable();
         T::regs().configure_dma(ConversionMode::Repeated(regular_trigger.map(|t| (t.trigger, t.edge))));
-        T::regs().configure_injected_trigger((injected_trigger._trigger, injected_trigger._edge), M::IRQ);
+        T::regs().configure_injected_trigger((injected_trigger._trigger, injected_trigger._edge), M::ASYNC);
 
-        T::regs().start_injected();
-
-        if M::IRQ {
+        if M::ASYNC {
             <T::Interrupt as crate::interrupt::typelevel::Interrupt>::unpend();
             unsafe {
                 <T::Interrupt as crate::interrupt::typelevel::Interrupt>::enable();
             }
         }
+
+        T::regs().start_injected();
 
         core::mem::forget(self);
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -22,15 +22,36 @@ pub mod time;
 mod wait;
 /// Operating modes for peripherals.
 pub mod mode {
-    trait SealedMode {}
+    use core::marker::PhantomData;
+
+    use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+
+    /// Interrupt Handler with bindings autoimplemented for all Irq structs.
+    #[derive(Clone, Copy)]
+    pub struct NoHandler<I: Interrupt> {
+        _marker: PhantomData<I>,
+    }
+
+    impl<I: Interrupt> Handler<I> for NoHandler<I> {
+        unsafe fn on_interrupt() {}
+    }
+
+    unsafe impl<T: Copy, I: Interrupt> Binding<I, NoHandler<I>> for T {}
+
+    pub(crate) trait SealedMode {
+        #[allow(dead_code)]
+        const ASYNC: bool;
+    }
 
     /// Operating mode for a peripheral.
     #[allow(private_bounds)]
     pub trait Mode: SealedMode {}
 
     macro_rules! impl_mode {
-        ($name:ident) => {
-            impl SealedMode for $name {}
+        ($name:ident, $async: expr) => {
+            impl SealedMode for $name {
+                const ASYNC: bool = $async;
+            }
             impl Mode for $name {}
         };
     }
@@ -40,8 +61,8 @@ pub mod mode {
     /// Async mode.
     pub struct Async;
 
-    impl_mode!(Blocking);
-    impl_mode!(Async);
+    impl_mode!(Blocking, false);
+    impl_mode!(Async, true);
 }
 
 // Always-present hardware

--- a/examples/stm32g4/src/bin/adc_injected_and_regular.rs
+++ b/examples/stm32g4/src/bin/adc_injected_and_regular.rs
@@ -11,9 +11,9 @@ use core::cell::RefCell;
 use defmt::info;
 use defmt_rtt as _;
 use embassy_stm32::adc::{
-    self, Adc, AdcChannel as _, Exten, InjectedAdc, InjectedAdcTrigger, RegularAdcTrigger, SampleTime, VrefInt,
+    Adc, AdcChannel as _, Exten, InjectedAdc, InjectedAdcTrigger, RegularAdcTrigger, SampleTime, VrefInt,
 };
-use embassy_stm32::mode::Async;
+use embassy_stm32::mode::Blocking;
 use embassy_stm32::pac::adc::Adc as AdcRegs;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::timer::complementary_pwm::{ComplementaryPwm, Mms2};
@@ -24,21 +24,16 @@ use embassy_sync::blocking_mutex::CriticalSectionMutex;
 use panic_probe as _;
 use static_cell::StaticCell;
 
-static ADC1_HANDLE: CriticalSectionMutex<RefCell<Option<InjectedAdc<AdcRegs, Async>>>> =
+static ADC1_HANDLE: CriticalSectionMutex<RefCell<Option<InjectedAdc<AdcRegs, Blocking>>>> =
     CriticalSectionMutex::new(RefCell::new(None));
+
+// static ADC1_HANDLE: CriticalSectionMutex<RefCell<Option<InjectedAdc<AdcRegs, Async>>>> =
+//     CriticalSectionMutex::new(RefCell::new(None));
 
 bind_interrupts!(struct Irqs {
     DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    // ADC1_2 => embassy_stm32::adc::InterruptHandler<ADC1>;
 });
-
-// The interrupt is implemented manually.
-unsafe impl
-    embassy_stm32::interrupt::typelevel::Binding<
-        embassy_stm32::interrupt::typelevel::ADC1_2,
-        adc::InterruptHandler<peripherals::ADC1>,
-    > for Irqs
-{
-}
 
 /// This example showcases how to use both regular ADC conversions with DMA and injected ADC
 /// conversions with ADC interrupt simultaneously. Both conversion types can be configured with
@@ -118,7 +113,7 @@ async fn main(_spawner: embassy_executor::Spawner) {
         RegularAdcTrigger::from(TIM1_TRGO2, Exten::RisingEdge),
         injected_sequence,
         InjectedAdcTrigger::from(TIM1_TRGO2, Exten::RisingEdge),
-        Async,
+        Blocking,
     );
 
     // Store ADC globally to allow access from ADC interrupt


### PR DESCRIPTION
Implement bindings to the NoHandler for all irq structs.