### PR TITLE
Fixing Embassy USB DFU runtime GET_STATUS stale control-buffer disclosure

### DIFF
--- a/embassy-usb/src/class/dfu/app_mode.rs
+++ b/embassy-usb/src/class/dfu/app_mode.rs
@@ -104,7 +104,7 @@ impl<H: Handler> crate::Handler for DfuState<H> {
                     self.state as u8,
                     0x00,
                 ]);
-                Some(InResponse::Accepted(buf))
+                Some(InResponse::Accepted(&buf[0..6]))
             }
             _ => None,
         }


### PR DESCRIPTION
The DFU app-mode `GetStatus` handler returns the entire shared EP0 control buffer instead of just the 6 status bytes it writes, leaking stale buffer contents to a USB host that requests more than 6 bytes.

fixes #6651  