### PR TITLE
perf(executor): skip run-queue take_all when the queue is empty

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `platform-riscv64` for RISC-V 64-bit targets (thread executor only, uses `WFI`; shares implementation with `platform-riscv32`).
 - Relaxed memory ordering of work flag in RISC-V thread executor.
+- Skip the run queue's `take_all` write when the queue is empty.
 
 ## 0.10.0 - 2026-03-10
 

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -128,7 +128,7 @@ zynq7000 = { version = "0.4", optional = true }
 arbitrary-int = { version = "2", optional = true }
 
 [dependencies.cordyceps]
-version = "0.3.4"
+version = "0.3.5"
 features = ["no-cache-pad"]
 
 [dev-dependencies]

--- a/embassy-executor/src/raw/run_queue.rs
+++ b/embassy-executor/src/raw/run_queue.rs
@@ -78,10 +78,6 @@ impl RunQueue {
         )
     }
 
-    /// Whether there is definitely nothing to dequeue: a plain load where
-    /// pointer-width atomics exist. Without them the queue is behind a critical
-    /// section and peeking would take a second one, so report "might have work".
-    /// A racing push is safe; see the comment in [`dequeue_all`](Self::dequeue_all).
     #[inline]
     fn definitely_empty(&self) -> bool {
         #[cfg(target_has_atomic = "ptr")]
@@ -101,10 +97,6 @@ impl RunQueue {
     /// and will be processed by the *next* call to `dequeue_all`, *not* the current one.
     #[cfg(not(any(feature = "scheduler-priority", feature = "scheduler-deadline")))]
     pub(crate) fn dequeue_all(&self, on_task: impl Fn(TaskRef)) {
-        // Skip the `take_all` swap when there is nothing to take. A racing push
-        // is safe: `enqueue` reports the empty -> non-empty transition and
-        // `SyncExecutor::enqueue` pends on exactly it, so a push landing here
-        // re-pends the executor and the next poll picks it up; no wake is lost.
         // Besides the saved write, this matters on RP2350, where any exclusive
         // access posts an event that keeps the idle `WFE` from ever sleeping.
         if self.definitely_empty() {
@@ -134,9 +126,6 @@ impl RunQueue {
     /// runqueue are both empty, at which point this function will return.
     #[cfg(any(feature = "scheduler-priority", feature = "scheduler-deadline"))]
     pub(crate) fn dequeue_all(&self, on_task: impl Fn(TaskRef)) {
-        // Skip the `take_all` when there is nothing to take: `sorted` is freshly
-        // empty here, so an empty runqueue means no work at all. See the
-        // standard `dequeue_all` above for the racing-push argument.
         if self.definitely_empty() {
             return;
         }

--- a/embassy-executor/src/raw/run_queue.rs
+++ b/embassy-executor/src/raw/run_queue.rs
@@ -78,6 +78,22 @@ impl RunQueue {
         )
     }
 
+    /// Whether there is definitely nothing to dequeue: a plain load where
+    /// pointer-width atomics exist. Without them the queue is behind a critical
+    /// section and peeking would take a second one, so report "might have work".
+    /// A racing push is safe; see the comment in [`dequeue_all`](Self::dequeue_all).
+    #[inline]
+    fn definitely_empty(&self) -> bool {
+        #[cfg(target_has_atomic = "ptr")]
+        {
+            self.stack.is_empty()
+        }
+        #[cfg(not(target_has_atomic = "ptr"))]
+        {
+            false
+        }
+    }
+
     /// # Standard atomic runqueue
     ///
     /// Empty the queue, then call `on_task` for each task that was in the queue.
@@ -85,6 +101,16 @@ impl RunQueue {
     /// and will be processed by the *next* call to `dequeue_all`, *not* the current one.
     #[cfg(not(any(feature = "scheduler-priority", feature = "scheduler-deadline")))]
     pub(crate) fn dequeue_all(&self, on_task: impl Fn(TaskRef)) {
+        // Skip the `take_all` swap when there is nothing to take. A racing push
+        // is safe: `enqueue` reports the empty -> non-empty transition and
+        // `SyncExecutor::enqueue` pends on exactly it, so a push landing here
+        // re-pends the executor and the next poll picks it up; no wake is lost.
+        // Besides the saved write, this matters on RP2350, where any exclusive
+        // access posts an event that keeps the idle `WFE` from ever sleeping.
+        if self.definitely_empty() {
+            return;
+        }
+
         let taken = self.stack.take_all();
         for taskref in taken {
             run_dequeue(&taskref);
@@ -108,6 +134,13 @@ impl RunQueue {
     /// runqueue are both empty, at which point this function will return.
     #[cfg(any(feature = "scheduler-priority", feature = "scheduler-deadline"))]
     pub(crate) fn dequeue_all(&self, on_task: impl Fn(TaskRef)) {
+        // Skip the `take_all` when there is nothing to take: `sorted` is freshly
+        // empty here, so an empty runqueue means no work at all. See the
+        // standard `dequeue_all` above for the racing-push argument.
+        if self.definitely_empty() {
+            return;
+        }
+
         let mut sorted = SortedList::<TaskHeader>::new_with_cmp(|lhs, rhs| {
             // compare by priority first
             #[cfg(feature = "scheduler-priority")]


### PR DESCRIPTION
`RunQueue::dequeue_all` calls `TransferStack::take_all`, a `swap` on the queue
head, on every `poll()`, even when the queue is empty. This PR checks emptiness
with a plain load first and returns early, so an executor with nothing to do no
longer performs a read-modify-write per pass.

## Why it matters on RP2350

Any exclusive access on RP2350 posts a monitor event that acts as an effective
`SEV` on its own core, and the event flag is sticky (#4818,
raspberrypi/pico-feedback#482, raspberrypi/pico-sdk#1812). The thread executor's
idle loop is `poll(); wfe`, so the unconditional `swap` re-armed the event on
every pass and the `WFE` never blocked: the executor free-runs at ~1 MHz and
never sleeps, in every WFE-idle embassy program on the chip. With this change an
empty pass is a plain load, a compare and a return; disassembly of the test
firmware confirms no exclusive and no `sev` remain between the check and the
`WFE`.

## Measured

RP2350 at 150 MHz, dual-core measurement firmware, identical source, only the
executor swapped. On a thread executor `passes` equals WFE wakeups exactly;
`net` is the busiest task (USB-NCM + TCP under a 10 s `wrk` run):

|              | passes/s | polls/s | busy% | net mean poll |
|--------------|---------:|--------:|------:|--------------:|
| main         |   962167 |    1853 |  14.8 |       59.3 us |
| this branch  |     3385 |    1886 |  14.6 |       57.9 us |

Near idle the thread executor drops from ~1.1 M passes/s to 2.5 passes/s, and
idle board draw (no USB, no network) drops from 27.65 mA to 20.35 mA. Under load
busy% and poll times are unchanged: the storm burned only otherwise-idle time,
so on RP2350 the gain is sleep and power, not throughput.

Reproducible A/B: two branches build the same measurement firmware against
upstream main and against this branch, with the instrumentation and recipes in
their README:
https://github.com/cedrivard/embassy-supervisor/blob/pr-executor-skip-empty-dequeue-main/firmware/README.md
https://github.com/cedrivard/embassy-supervisor/blob/pr-executor-skip-empty-dequeue-fixed/firmware/README.md

## Scope

- Both `dequeue_all` variants get the check. The priority/deadline variant's
  early return sits where `sorted` is freshly empty, so an empty run queue means
  no work at all. Both variants were validated on hardware (the standard queue
  in the numbers above; `scheduler-priority` idles at 2.2 passes/s with a clean
  load run).
- Gated on `target_has_atomic = "ptr"`: CAS-less targets (thumbv6m) keep the
  queue behind a critical section, where peeking would add a second critical
  section on the busy path; they compile to the old behaviour.
- Not gated to RP2350: the executor has no chip-specific code, and the check is
  a net saving everywhere. An empty pass skips an RMW and the cache-line write
  on any target (spurious WFE returns and interrupts that enqueue nothing may
  exist on them too); a productive pass adds one relaxed load in front of a swap
  of the same location.
- This is a mitigation for the RP2350 behaviour, not a fix: any other exclusive
  in the idle path (user task code, drivers, embassy-time) still defeats `WFE`
  there.

## Dependencies

Bumps cordyceps to 0.3.5 for `TransferStack::is_empty` (hawkw/mycelium#565).