### PR TITLE
embassy-usb-driver: make endpoint address methods const

### DIFF
--- a/embassy-usb-driver/src/lib.rs
+++ b/embassy-usb-driver/src/lib.rs
@@ -85,7 +85,7 @@ impl EndpointAddress {
 
     /// Constructs a new EndpointAddress with the given index and direction.
     #[inline]
-    pub fn from_parts(index: usize, dir: Direction) -> Self {
+    pub const fn from_parts(index: usize, dir: Direction) -> Self {
         let dir_u8 = match dir {
             Direction::Out => 0x00,
             Direction::In => Self::INBITS,
@@ -95,7 +95,7 @@ impl EndpointAddress {
 
     /// Gets the direction part of the address.
     #[inline]
-    pub fn direction(&self) -> Direction {
+    pub const fn direction(&self) -> Direction {
         if (self.0 & Self::INBITS) != 0 {
             Direction::In
         } else {
@@ -105,19 +105,19 @@ impl EndpointAddress {
 
     /// Returns true if the direction is IN, otherwise false.
     #[inline]
-    pub fn is_in(&self) -> bool {
+    pub const fn is_in(&self) -> bool {
         (self.0 & Self::INBITS) != 0
     }
 
     /// Returns true if the direction is OUT, otherwise false.
     #[inline]
-    pub fn is_out(&self) -> bool {
+    pub const fn is_out(&self) -> bool {
         (self.0 & Self::INBITS) == 0
     }
 
     /// Gets the index part of the endpoint address.
     #[inline]
-    pub fn index(&self) -> usize {
+    pub const fn index(&self) -> usize {
         (self.0 & !Self::INBITS) as usize
     }
 }


### PR DESCRIPTION
followup to #6447