### PR TITLE
stm32/flash: poll BSY2 and CFGBSY in G0 completion waits

### DIFF
--- a/embassy-stm32/src/flash/g.rs
+++ b/embassy-stm32/src/flash/g.rs
@@ -184,6 +184,19 @@ pub(crate) unsafe fn blocking_erase_sector(sector: &FlashSector) -> Result<(), E
     ret
 }
 
+/// Whether an operation is still in flight (bank-2 ops on dual-bank G0 assert
+/// BSY2/CFGBSY, not BSY1).
+fn sr_busy(sr: Sr) -> bool {
+    #[cfg(any(flash_g0x0, flash_g0x1))]
+    {
+        sr.bsy() | sr.bsy2() | sr.cfgbsy()
+    }
+    #[cfg(not(any(flash_g0x0, flash_g0x1)))]
+    {
+        sr.bsy()
+    }
+}
+
 pub(crate) async fn wait_ready() -> Result<(), Error> {
     use core::future::poll_fn;
     use core::task::Poll;
@@ -192,7 +205,7 @@ pub(crate) async fn wait_ready() -> Result<(), Error> {
         WAKER.register(cx.waker());
 
         let sr = pac::FLASH.sr().read();
-        if !sr.bsy() {
+        if !sr_busy(sr) {
             Poll::Ready(get_result(sr))
         } else {
             Poll::Pending
@@ -204,7 +217,7 @@ pub(crate) async fn wait_ready() -> Result<(), Error> {
 pub(crate) unsafe fn wait_ready_blocking() -> Result<(), Error> {
     loop {
         let sr = pac::FLASH.sr().read();
-        if !sr.bsy() {
+        if !sr_busy(sr) {
             return get_result(sr);
         }
     }
@@ -232,14 +245,8 @@ pub(crate) unsafe fn clear_all_err() {
     pac::FLASH.sr().modify(|_| {});
 }
 
-#[cfg(any(flash_g0x0, flash_g0x1))]
 fn wait_busy() {
-    while pac::FLASH.sr().read().bsy() | pac::FLASH.sr().read().bsy2() {}
-}
-
-#[cfg(not(any(flash_g0x0, flash_g0x1)))]
-fn wait_busy() {
-    while pac::FLASH.sr().read().bsy() {}
+    while sr_busy(pac::FLASH.sr().read()) {}
 }
 
 // G4 data cache handling - must disable during flash operations


### PR DESCRIPTION
Fixes #6678.

## Problem

On dual-bank STM32G0 (G0B0/G0B1/G0C1), an operation targeting bank 2 asserts only
**BSY2** — never BSY1 — and **CFGBSY** stays set until the operation retires.
`wait_ready()` / `wait_ready_blocking()` in `flash/g.rs` poll only `sr.bsy()` (BSY1),
so bank-2 operations appear complete immediately:

1. `get_result()` samples the error flags **mid-operation** — a failed bank-2
   erase/program reports `Ok`, and the trailing `clear_all_err()` wipes the
   late-asserting flags, so the failure is unobservable.
2. The driver's next CR write (`w.set_per(false)`) **bus-stalls the core with
   interrupts blocked** until CFGBSY clears — measured 22 ms for a page erase. This
   accidental stall is the only reason the blocking API appears to wait correctly,
   and it defeats the dual-bank read-while-write capability for code running from
   the other bank (which otherwise works — see measurements).

All measurements on STM32G0B1CE silicon (code in bank 1, page erase in bank 2,
~22 ms erase; full data and methodology in #6678):

| Observation | Value |
|---|---|
| BSY1 during a bank-2 erase (3,205 SR polls) | never set; BSY2=1, CFGBSY=1 |
| Bank-1 flash read mid-erase (RWW) | 3 µs (= baseline) |
| `CR.modify(PER=false)` issued 4 µs after STRT | stalls 22,020 µs |
| SysTick armed to fire 2–8 ms into that stall | delivered 22,027 µs after STRT |

## Change

One shared `sr_busy()` predicate used by `wait_busy()` and both completion waits:
`BSY1 | BSY2 | CFGBSY` on `flash_g0x0`/`flash_g0x1`, `BSY1` elsewhere. This matches
ST HAL's `FLASH_WaitForLastOperation` (BSY1|BSY2, then CFGBSY, under
`FLASH_DBANK_SUPPORT`) and Zephyr's G0 driver. Behavior for non-G0 G-family parts is
unchanged. The `wait_busy()` cfg duplication collapses into the same predicate (also
removing a double SR read per poll iteration).

## Validation

On-target before/after with the same test (SysTick armed for 2–8 ms, then a bank-2
`Flash::blocking_erase`; STM32G0B1CE):

- **stock 0.6.0 / current main code:** erase returns in 22,127 µs but SysTick is
  delivered 22,118 µs late — IRQs blocked for the whole erase by the CR-write stall.
- **with this patch:** erase returns in 22,120 µs (a genuine completion wait — SR
  idle, error flags sampled post-completion) and SysTick is delivered on schedule at
  8,001 µs — interrupts stay live; the CR write no longer stalls.

Build checks on the patched crate:

- `--features stm32g0b1ce,defmt,exti,time-driver-any --target thumbv6m-none-eabi` ✓
- `--features stm32g070cb,defmt,exti,time-driver-any --target thumbv6m-none-eabi` ✓ (`flash_g0x0` arm)
- `--features stm32g474re,defmt,exti,time-driver-any,single-bank --target thumbv7em-none-eabihf` ✓ (non-G0 arm)
- `cargo fmt` clean
