### PR TITLE
ci: update docserver

### DIFF
--- a/.github/ci/doc.sh
+++ b/.github/ci/doc.sh
@@ -12,7 +12,7 @@ export CARGO_TARGET_DIR=/ci/cache/target
 export PATH=$CARGO_HOME/bin:$PATH
 
 cargo install --git https://github.com/embassy-rs/cargo-embassy-devtool --locked --rev f8a8cce4092ef2566fbae04f088daa70c9e1fe93
-cargo install --git https://github.com/embassy-rs/docserver --locked --rev 2fb83db984a178e5ff24d7b90b2028aeeceab103
+cargo install --git https://github.com/embassy-rs/docserver --locked --rev 5865eed8583205cee4d266277e4a639141362962
 
 mv rust-toolchain-nightly.toml rust-toolchain.toml
 


### PR DESCRIPTION
raise memory thresholds and kill the process if out of memory for too long.