### PR TITLE
Clear a stale suspend when enumeration is done

### DIFF
--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -1078,7 +1078,12 @@ impl<'d> embassy_usb_driver::Bus for Bus<'d> {
                 trace!("  speed={} trdt={}", speed.to_bits(), trdt);
                 regs.gusbcfg().modify(|w| w.set_trdt(trdt));
 
-                regs.gintsts().write(|w| w.set_enumdne(true)); // clear
+                // Clear the handled interrupt
+                regs.gintsts().write(|w| {
+                    // The reset ended suspend state, so USBSUSP needs to be also cleared.
+                    w.set_usbsusp(true);
+                    w.set_enumdne(true);
+                });
                 self.restore_irqs();
 
                 return Poll::Ready(Event::Reset);


### PR DESCRIPTION
Suspended bits needs to be clear when enumeration is done, otherwise if `Bus::poll()` runs late enough that `ENUMDNE` and `USBSUSP` are both latched, the suspend bit remains, resulting in enumeration failure.

The fix is from TinyUSB:

https://github.com/hathach/tinyusb/blob/master/src/portable/synopsys/dwc2/dcd_dwc2.c#L1197-L1198