### PR TITLE
synopsys-otg: Make e-time optional for device mode

### DIFF
--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - ReleaseDate
 
+- Changed: `embassy-time` is now an optional feature for device mode. Remote wakeup is now supported via `embassy-time`.
 - Fixed: Periodic IN transfer future can no longer park forever.
 - Fixed: Later events no longer override earlier ones.
 - Fixed: Correctly work with low-speed devices over high-speed hubs.

--- a/embassy-usb-synopsys-otg/Cargo.toml
+++ b/embassy-usb-synopsys-otg/Cargo.toml
@@ -20,7 +20,7 @@ critical-section = "1.1"
 portable-atomic = { version = "1" }
 
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
-embassy-time = { version = "0.5.1", path = "../embassy-time" }
+embassy-time = { version = "0.5.1", path = "../embassy-time", optional = true }
 embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 
 defmt = { version = "1.0.1", optional = true }
@@ -30,4 +30,7 @@ log = { version = "0.4.14", optional = true }
 default = []
 defmt = ["dep:defmt", "embassy-usb-driver/defmt"]
 log = ["dep:log"]
-host = []
+host = ["embassy-time"]
+
+## Enables remote wakeup
+embassy-time = ["dep:embassy-time"]

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -1254,25 +1254,33 @@ impl<'d> embassy_usb_driver::Bus for Bus<'d> {
     }
 
     async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
-        let r = self.instance.regs;
+        #[cfg(feature = "embassy-time")]
+        {
+            let r = self.instance.regs;
 
-        // Re-enable PHY clock gated during suspend.
-        // See RM0368 §22.8 "OTG low-power modes" (STPPCLK / GATEHCLK).
-        r.pcgcctl().modify(|w| {
-            w.set_stppclk(false);
-            // GATEHCLK is only present on HS cores.
-            if self.instance.phy_type.high_speed() {
-                w.set_gatehclk(false);
-            }
-        });
+            // Re-enable PHY clock gated during suspend.
+            // See RM0368 §22.8 "OTG low-power modes" (STPPCLK / GATEHCLK).
+            r.pcgcctl().modify(|w| {
+                w.set_stppclk(false);
+                // GATEHCLK is only present on HS cores.
+                if self.instance.phy_type.high_speed() {
+                    w.set_gatehclk(false);
+                }
+            });
 
-        // Assert resume K-state on D+/D-.
-        // USB 2.0 spec §7.1.7.7: TDRSMUP requires 1–15 ms of resume signaling.
-        r.dctl().modify(|w| w.set_rwusig(true));
-        embassy_time::Timer::after_millis(10).await;
-        r.dctl().modify(|w| w.set_rwusig(false));
+            // Assert resume K-state on D+/D-.
+            // USB 2.0 spec §7.1.7.7: TDRSMUP requires 1–15 ms of resume signaling.
+            r.dctl().modify(|w| w.set_rwusig(true));
+            embassy_time::Timer::after_millis(10).await;
+            r.dctl().modify(|w| w.set_rwusig(false));
 
-        Ok(())
+            Ok(())
+        }
+
+        #[cfg(not(feature = "embassy-time"))]
+        {
+            Err(Unsupported)
+        }
     }
 }
 


### PR DESCRIPTION
Remote wakeup silently needs it, so it goes back to unsupported when not enabled.