### PR TITLE
Implement `Copy` on CSRM, require `Copy` on mutexes in synopsys-otg

### DIFF
--- a/embassy-nrf/src/usb/usbhs.rs
+++ b/embassy-nrf/src/usb/usbhs.rs
@@ -8,6 +8,7 @@ use core::task::Poll;
 
 use embassy_futures::select::{Either, select};
 use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::waitqueue::AtomicWaker;
 use embassy_usb_driver::{EndpointAddress, EndpointAllocError, EndpointType, Event, Unsupported};
 pub use embassy_usb_synopsys_otg::Config;
@@ -323,7 +324,7 @@ impl SealedInstance for crate::peripherals::USBHS {
     }
 
     fn state() -> State<'static> {
-        static STATE: StateStorage<MAX_EP_COUNT> = StateStorage::new();
+        static STATE: StateStorage<MAX_EP_COUNT> = StateStorage::new(CriticalSectionRawMutex::new());
         STATE.as_state()
     }
 }

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -546,9 +546,10 @@ foreach_interrupt!(
 
             fn state() -> State<'static> {
                 use embassy_usb_synopsys_otg::StateStorage;
+                use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
                 const EP_COUNT: usize = crate::peripherals::USB_OTG_FS::ENDPOINT_COUNT;
-                static STATE: StateStorage<EP_COUNT> = StateStorage::new();
+                static STATE: StateStorage<EP_COUNT> = StateStorage::new(CriticalSectionRawMutex::new());
                 STATE.as_state()
             }
         }
@@ -627,9 +628,10 @@ foreach_interrupt!(
 
             fn state() -> State<'static> {
                 use embassy_usb_synopsys_otg::StateStorage;
+                use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
                 const EP_COUNT: usize = crate::peripherals::USB_OTG_HS::ENDPOINT_COUNT;
-                static STATE: StateStorage<EP_COUNT> = StateStorage::new();
+                static STATE: StateStorage<EP_COUNT> = StateStorage::new(CriticalSectionRawMutex::new());
                 STATE.as_state()
             }
         }
@@ -664,9 +666,10 @@ mod host_impl {
             impl SealedHostInstance for crate::peripherals::USB_OTG_FS {
                 fn host_state() -> HostState<'static> {
                     use embassy_usb_synopsys_otg::host::HostStateStorage;
+                    use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
                     const CH_COUNT:usize = crate::peripherals::USB_OTG_FS::ENDPOINT_COUNT;
-                    static STATE: HostStateStorage<CH_COUNT> = HostStateStorage::new();
+                    static STATE: HostStateStorage<CH_COUNT> = HostStateStorage::new(CriticalSectionRawMutex::new());
                     STATE.as_host_state()
                 }
             }
@@ -675,9 +678,10 @@ mod host_impl {
             impl SealedHostInstance for crate::peripherals::USB_OTG_HS {
                 fn host_state() -> HostState<'static> {
                     use embassy_usb_synopsys_otg::host::HostStateStorage;
+                    use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 
                     const CH_COUNT:usize = crate::peripherals::USB_OTG_HS::ENDPOINT_COUNT;
-                    static STATE: HostStateStorage<CH_COUNT> = HostStateStorage::new();
+                    static STATE: HostStateStorage<CH_COUNT> = HostStateStorage::new(CriticalSectionRawMutex::new());
                     STATE.as_host_state()
                 }
             }

--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- `CriticalSectionRawMutex` now implements `Clone + Copy`.
 - Add `write_all` as a method to `pipe::Writer`, trait import not strictly necessary anymore.
 - `AtomicWaker` is now lockless: `register()` and `wake()` no longer enter a critical section,
   using a small atomic state machine (ported from `futures::task::AtomicWaker`).

--- a/embassy-sync/src/blocking_mutex/raw.rs
+++ b/embassy-sync/src/blocking_mutex/raw.rs
@@ -37,7 +37,7 @@ pub unsafe trait RawMutex {
 /// # Safety
 ///
 /// This mutex is safe to share between different executors and interrupts.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct CriticalSectionRawMutex {
     _phantom: PhantomData<()>,
 }

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -71,13 +71,19 @@ struct HostStateFields {
 }
 
 /// Storage object for USB host driver state. Create one per OTG instance.
-pub struct HostStateStorage<const CH_COUNT: usize, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct HostStateStorage<const CH_COUNT: usize, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     channels: [ChannelState; CH_COUNT],
     fields: HostStateFields,
     mutex: M,
 }
 
-impl<const CH_COUNT: usize, M: RawMutex + Copy> HostStateStorage<CH_COUNT, M> {
+impl<const CH_COUNT: usize, M> HostStateStorage<CH_COUNT, M>
+where
+    M: RawMutex + Copy,
+{
     /// Create a new host state.
     pub const fn new(mutex: M) -> Self {
         Self {
@@ -113,13 +119,19 @@ impl<const CH_COUNT: usize, M: RawMutex + Copy> HostStateStorage<CH_COUNT, M> {
 /// Type-erased view of [`HostState`] for [`OtgHostInstance`], [`OtgHost`], [`on_host_interrupt`], and pipes.
 ///
 /// Build from [`HostState::as_host_state`].
-pub struct HostState<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct HostState<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     channels: &'d [ChannelState],
     fields: &'d HostStateFields,
     mutex: &'d M,
 }
 
-impl<'d, M: RawMutex + Copy> Clone for HostState<'d, M> {
+impl<'d, M> Clone for HostState<'d, M>
+where
+    M: RawMutex + Copy,
+{
     fn clone(&self) -> Self {
         Self {
             channels: self.channels,
@@ -129,9 +141,12 @@ impl<'d, M: RawMutex + Copy> Clone for HostState<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex + Copy> Copy for HostState<'d, M> {}
+impl<'d, M> Copy for HostState<'d, M> where M: RawMutex + Copy {}
 
-impl<'d, M: RawMutex + Copy> HostState<'d, M> {
+impl<'d, M> HostState<'d, M>
+where
+    M: RawMutex + Copy,
+{
     /// Returns the number of host channels supported by this state.
     pub fn channel_count(&self) -> usize {
         self.channels.len()
@@ -140,7 +155,10 @@ impl<'d, M: RawMutex + Copy> HostState<'d, M> {
 
 /// Hardware-dependent host configuration.
 #[derive(Copy, Clone)]
-pub struct OtgHostInstance<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct OtgHostInstance<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     /// The USB peripheral registers.
     pub regs: Otg,
     /// Shared host driver state from [`HostState::as_host_state`].
@@ -155,7 +173,10 @@ pub struct OtgHostInstance<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
 ///
 /// # Safety
 /// Must be called from the USB OTG interrupt handler when the controller is in host mode.
-pub unsafe fn on_host_interrupt<M: RawMutex + Copy>(r: Otg, state: &HostState<'_, M>) {
+pub unsafe fn on_host_interrupt<M>(r: Otg, state: &HostState<'_, M>)
+where
+    M: RawMutex + Copy,
+{
     let gintsts = r.gintsts().read();
     let ch_count = state.channels.len();
 
@@ -411,12 +432,18 @@ fn hprt_read_safe(r: Otg) -> u32 {
 }
 
 /// USB OTG Host Driver.
-pub struct OtgHost<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct OtgHost<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     instance: OtgHostInstance<'d, M>,
     inited: bool,
 }
 
-impl<'d, M: RawMutex + Copy> OtgHost<'d, M> {
+impl<'d, M> OtgHost<'d, M>
+where
+    M: RawMutex + Copy,
+{
     /// Create a new OTG host driver.
     pub fn new(instance: OtgHostInstance<'d, M>) -> Self {
         Self {
@@ -563,20 +590,29 @@ impl<'d, M: RawMutex + Copy> OtgHost<'d, M> {
 /// Obtained from [`UsbHostController::allocator`]. Holds only `Copy` handles
 /// to the controller's `'d`-borrowed state, so it can be freely copied and
 /// retained by class drivers independently of the controller's `&mut` borrow.
-pub struct OtgHostAllocator<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct OtgHostAllocator<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     regs: Otg,
     state: HostState<'d, M>,
 }
 
-impl<'d, M: RawMutex + Copy> Clone for OtgHostAllocator<'d, M> {
+impl<'d, M> Clone for OtgHostAllocator<'d, M>
+where
+    M: RawMutex + Copy,
+{
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'d, M: RawMutex + Copy> Copy for OtgHostAllocator<'d, M> {}
+impl<'d, M> Copy for OtgHostAllocator<'d, M> where M: RawMutex + Copy {}
 
-impl<'d, M: RawMutex + Copy> UsbHostAllocator<'d> for OtgHostAllocator<'d, M> {
+impl<'d, M> UsbHostAllocator<'d> for OtgHostAllocator<'d, M>
+where
+    M: RawMutex + Copy,
+{
     type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, T, D, M>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
@@ -633,7 +669,10 @@ impl<'d, M: RawMutex + Copy> UsbHostAllocator<'d> for OtgHostAllocator<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex + Copy> UsbHostController<'d> for OtgHost<'d, M> {
+impl<'d, M> UsbHostController<'d> for OtgHost<'d, M>
+where
+    M: RawMutex + Copy,
+{
     type Allocator = OtgHostAllocator<'d, M>;
 
     fn allocator(&self) -> Self::Allocator {
@@ -838,7 +877,12 @@ impl<'d, M: RawMutex + Copy> UsbHostController<'d> for OtgHost<'d, M> {
 /// A USB host channel for performing transfers.
 ///
 /// The channel is automatically released when dropped.
-pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct Channel<'d, T, D, M = CriticalSectionRawMutex>
+where
+    T: pipe::Type,
+    D: pipe::Direction,
+    M: RawMutex + Copy,
+{
     regs: Otg,
     state: HostState<'d, M>,
     index: usize,
@@ -851,9 +895,20 @@ pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy = C
 }
 
 // SAFETY: Channel only accesses its own state in the shared HostState.
-unsafe impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Send for Channel<'_, T, D, M> {}
+unsafe impl<T, D, M> Send for Channel<'_, T, D, M>
+where
+    T: pipe::Type,
+    D: pipe::Direction,
+    M: RawMutex + Copy,
+{
+}
 
-impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Drop for Channel<'_, T, D, M> {
+impl<T, D, M> Drop for Channel<'_, T, D, M>
+where
+    T: pipe::Type,
+    D: pipe::Direction,
+    M: RawMutex + Copy,
+{
     fn drop(&mut self) {
         let r = self.regs;
         let ch = self.index;
@@ -886,7 +941,12 @@ impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Drop for Channel<'_,
     }
 }
 
-impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Channel<'_, T, D, M> {
+impl<T, D, M> Channel<'_, T, D, M>
+where
+    T: pipe::Type,
+    D: pipe::Direction,
+    M: RawMutex + Copy,
+{
     fn configure_channel(&self, dir_in: bool, ep_type: EndpointType, pktcnt: u16, xfrsiz: u32, dpid: u8) {
         let r = self.regs;
         let ch = self.index;
@@ -1257,7 +1317,12 @@ impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Channel<'_, T, D, M>
     }
 }
 
-impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> UsbPipe<T, D> for Channel<'_, T, D, M> {
+impl<T, D, M> UsbPipe<T, D> for Channel<'_, T, D, M>
+where
+    T: pipe::Type,
+    D: pipe::Direction,
+    M: RawMutex + Copy,
+{
     async fn control_in(&mut self, setup: &[u8; 8], buf: &mut [u8]) -> Result<usize, PipeError>
     where
         T: pipe::IsControl,

--- a/embassy-usb-synopsys-otg/src/host.rs
+++ b/embassy-usb-synopsys-otg/src/host.rs
@@ -71,15 +71,15 @@ struct HostStateFields {
 }
 
 /// Storage object for USB host driver state. Create one per OTG instance.
-pub struct HostStateStorage<const CH_COUNT: usize, M: RawMutex = CriticalSectionRawMutex> {
+pub struct HostStateStorage<const CH_COUNT: usize, M: RawMutex + Copy = CriticalSectionRawMutex> {
     channels: [ChannelState; CH_COUNT],
     fields: HostStateFields,
     mutex: M,
 }
 
-impl<const CH_COUNT: usize, M: RawMutex> HostStateStorage<CH_COUNT, M> {
+impl<const CH_COUNT: usize, M: RawMutex + Copy> HostStateStorage<CH_COUNT, M> {
     /// Create a new host state.
-    pub const fn new() -> Self {
+    pub const fn new(mutex: M) -> Self {
         Self {
             channels: [const {
                 ChannelState {
@@ -96,7 +96,7 @@ impl<const CH_COUNT: usize, M: RawMutex> HostStateStorage<CH_COUNT, M> {
                 port_event: AtomicU8::new(0),
                 port_speed: AtomicU8::new(0),
             },
-            mutex: M::INIT,
+            mutex,
         }
     }
 
@@ -113,13 +113,13 @@ impl<const CH_COUNT: usize, M: RawMutex> HostStateStorage<CH_COUNT, M> {
 /// Type-erased view of [`HostState`] for [`OtgHostInstance`], [`OtgHost`], [`on_host_interrupt`], and pipes.
 ///
 /// Build from [`HostState::as_host_state`].
-pub struct HostState<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct HostState<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     channels: &'d [ChannelState],
     fields: &'d HostStateFields,
     mutex: &'d M,
 }
 
-impl<'d, M: RawMutex> Clone for HostState<'d, M> {
+impl<'d, M: RawMutex + Copy> Clone for HostState<'d, M> {
     fn clone(&self) -> Self {
         Self {
             channels: self.channels,
@@ -129,9 +129,9 @@ impl<'d, M: RawMutex> Clone for HostState<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex> Copy for HostState<'d, M> {}
+impl<'d, M: RawMutex + Copy> Copy for HostState<'d, M> {}
 
-impl<'d, M: RawMutex> HostState<'d, M> {
+impl<'d, M: RawMutex + Copy> HostState<'d, M> {
     /// Returns the number of host channels supported by this state.
     pub fn channel_count(&self) -> usize {
         self.channels.len()
@@ -140,7 +140,7 @@ impl<'d, M: RawMutex> HostState<'d, M> {
 
 /// Hardware-dependent host configuration.
 #[derive(Copy, Clone)]
-pub struct OtgHostInstance<'d, M: RawMutex> {
+pub struct OtgHostInstance<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     /// The USB peripheral registers.
     pub regs: Otg,
     /// Shared host driver state from [`HostState::as_host_state`].
@@ -155,7 +155,7 @@ pub struct OtgHostInstance<'d, M: RawMutex> {
 ///
 /// # Safety
 /// Must be called from the USB OTG interrupt handler when the controller is in host mode.
-pub unsafe fn on_host_interrupt<M: RawMutex>(r: Otg, state: &HostState<'_, M>) {
+pub unsafe fn on_host_interrupt<M: RawMutex + Copy>(r: Otg, state: &HostState<'_, M>) {
     let gintsts = r.gintsts().read();
     let ch_count = state.channels.len();
 
@@ -411,12 +411,12 @@ fn hprt_read_safe(r: Otg) -> u32 {
 }
 
 /// USB OTG Host Driver.
-pub struct OtgHost<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct OtgHost<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     instance: OtgHostInstance<'d, M>,
     inited: bool,
 }
 
-impl<'d, M: RawMutex> OtgHost<'d, M> {
+impl<'d, M: RawMutex + Copy> OtgHost<'d, M> {
     /// Create a new OTG host driver.
     pub fn new(instance: OtgHostInstance<'d, M>) -> Self {
         Self {
@@ -563,20 +563,20 @@ impl<'d, M: RawMutex> OtgHost<'d, M> {
 /// Obtained from [`UsbHostController::allocator`]. Holds only `Copy` handles
 /// to the controller's `'d`-borrowed state, so it can be freely copied and
 /// retained by class drivers independently of the controller's `&mut` borrow.
-pub struct OtgHostAllocator<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct OtgHostAllocator<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     regs: Otg,
     state: HostState<'d, M>,
 }
 
-impl<'d, M: RawMutex> Clone for OtgHostAllocator<'d, M> {
+impl<'d, M: RawMutex + Copy> Clone for OtgHostAllocator<'d, M> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'d, M: RawMutex> Copy for OtgHostAllocator<'d, M> {}
+impl<'d, M: RawMutex + Copy> Copy for OtgHostAllocator<'d, M> {}
 
-impl<'d, M: RawMutex> UsbHostAllocator<'d> for OtgHostAllocator<'d, M> {
+impl<'d, M: RawMutex + Copy> UsbHostAllocator<'d> for OtgHostAllocator<'d, M> {
     type Pipe<T: pipe::Type, D: pipe::Direction> = Channel<'d, T, D, M>;
 
     fn alloc_pipe<T: pipe::Type, D: pipe::Direction>(
@@ -633,7 +633,7 @@ impl<'d, M: RawMutex> UsbHostAllocator<'d> for OtgHostAllocator<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex> UsbHostController<'d> for OtgHost<'d, M> {
+impl<'d, M: RawMutex + Copy> UsbHostController<'d> for OtgHost<'d, M> {
     type Allocator = OtgHostAllocator<'d, M>;
 
     fn allocator(&self) -> Self::Allocator {
@@ -838,7 +838,7 @@ impl<'d, M: RawMutex> UsbHostController<'d> for OtgHost<'d, M> {
 /// A USB host channel for performing transfers.
 ///
 /// The channel is automatically released when dropped.
-pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, M: RawMutex = CriticalSectionRawMutex> {
+pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy = CriticalSectionRawMutex> {
     regs: Otg,
     state: HostState<'d, M>,
     index: usize,
@@ -851,9 +851,9 @@ pub struct Channel<'d, T: pipe::Type, D: pipe::Direction, M: RawMutex = Critical
 }
 
 // SAFETY: Channel only accesses its own state in the shared HostState.
-unsafe impl<T: pipe::Type, D: pipe::Direction, M: RawMutex> Send for Channel<'_, T, D, M> {}
+unsafe impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Send for Channel<'_, T, D, M> {}
 
-impl<T: pipe::Type, D: pipe::Direction, M: RawMutex> Drop for Channel<'_, T, D, M> {
+impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Drop for Channel<'_, T, D, M> {
     fn drop(&mut self) {
         let r = self.regs;
         let ch = self.index;
@@ -886,7 +886,7 @@ impl<T: pipe::Type, D: pipe::Direction, M: RawMutex> Drop for Channel<'_, T, D, 
     }
 }
 
-impl<T: pipe::Type, D: pipe::Direction, M: RawMutex> Channel<'_, T, D, M> {
+impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> Channel<'_, T, D, M> {
     fn configure_channel(&self, dir_in: bool, ep_type: EndpointType, pktcnt: u16, xfrsiz: u32, dpid: u8) {
         let r = self.regs;
         let ch = self.index;
@@ -1257,7 +1257,7 @@ impl<T: pipe::Type, D: pipe::Direction, M: RawMutex> Channel<'_, T, D, M> {
     }
 }
 
-impl<T: pipe::Type, D: pipe::Direction, M: RawMutex> UsbPipe<T, D> for Channel<'_, T, D, M> {
+impl<T: pipe::Type, D: pipe::Direction, M: RawMutex + Copy> UsbPipe<T, D> for Channel<'_, T, D, M> {
     async fn control_in(&mut self, setup: &[u8; 8], buf: &mut [u8]) -> Result<usize, PipeError>
     where
         T: pipe::IsControl,

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -35,7 +35,10 @@ pub mod host;
 use otg_v1::{Otg, regs, vals};
 
 /// Handle interrupts.
-pub unsafe fn on_interrupt<M: RawMutex + Copy>(r: Otg, state: &State<'_, M>) {
+pub unsafe fn on_interrupt<M>(r: Otg, state: &State<'_, M>)
+where
+    M: RawMutex + Copy,
+{
     trace!("irq");
     let ep_count = state.endpoint_count();
 
@@ -300,14 +303,20 @@ struct EndpointData {
 /// and [`on_interrupt`].
 ///
 /// Build from [`State::as_state`].
-pub struct State<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct State<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     cp_state: &'d ControlPipeSetupState,
     ep_states: &'d [EpState],
     bus_waker: &'d AtomicWaker,
     mutex: M,
 }
 
-impl<'d, M: RawMutex + Copy> Clone for State<'d, M> {
+impl<'d, M> Clone for State<'d, M>
+where
+    M: RawMutex + Copy,
+{
     fn clone(&self) -> Self {
         Self {
             cp_state: self.cp_state,
@@ -318,16 +327,22 @@ impl<'d, M: RawMutex + Copy> Clone for State<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex + Copy> Copy for State<'d, M> {}
+impl<'d, M> Copy for State<'d, M> where M: RawMutex + Copy {}
 
-impl<M: RawMutex + Copy> State<'_, M> {
+impl<M> State<'_, M>
+where
+    M: RawMutex + Copy,
+{
     /// Returns the number of device endpoints supported by this state.
     pub fn endpoint_count(&self) -> usize {
         self.ep_states.len()
     }
 }
 
-impl<'d, M: RawMutex + Copy> State<'d, M> {
+impl<'d, M> State<'d, M>
+where
+    M: RawMutex + Copy,
+{
     pub(crate) fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<&EndpointData> {
         unsafe {
             match dir {
@@ -383,14 +398,20 @@ impl<'d, M: RawMutex + Copy> State<'d, M> {
 }
 
 /// Storage object for USB OTG driver state.
-pub struct StateStorage<const EP_COUNT: usize, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct StateStorage<const EP_COUNT: usize, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     cp_state: ControlPipeSetupState,
     ep_states: [EpState; EP_COUNT],
     bus_waker: AtomicWaker,
     mutex: M,
 }
 
-impl<const EP_COUNT: usize, M: RawMutex + Copy> StateStorage<EP_COUNT, M> {
+impl<const EP_COUNT: usize, M> StateStorage<EP_COUNT, M>
+where
+    M: RawMutex + Copy,
+{
     /// Create a new StateStorage.
     pub const fn new(mutex: M) -> Self {
         Self {
@@ -465,14 +486,20 @@ impl Default for Config {
 }
 
 /// USB OTG driver.
-pub struct Driver<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct Driver<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     config: Config,
     ep_out_buffer: &'d mut [u8],
     ep_out_buffer_offset: usize,
     instance: OtgInstance<'d, M>,
 }
 
-impl<'d, M: RawMutex + Copy> Driver<'d, M> {
+impl<'d, M> Driver<'d, M>
+where
+    M: RawMutex + Copy,
+{
     /// Initializes the USB OTG peripheral.
     ///
     /// # Arguments
@@ -606,7 +633,10 @@ impl<'d, M: RawMutex + Copy> Driver<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex + Copy + 'd> embassy_usb_driver::Driver<'d> for Driver<'d, M> {
+impl<'d, M> embassy_usb_driver::Driver<'d> for Driver<'d, M>
+where
+    M: RawMutex + Copy + 'd,
+{
     type EndpointOut = Endpoint<'d, Out, M>;
     type EndpointIn = Endpoint<'d, In, M>;
     type ControlPipe = ControlPipe<'d, M>;
@@ -793,13 +823,19 @@ fn has_data_toggle(ep_type: EndpointType) -> bool {
 }
 
 /// USB bus.
-pub struct Bus<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct Bus<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     config: Config,
     instance: OtgInstance<'d, M>,
     inited: bool,
 }
 
-impl<'d, M: RawMutex + Copy> Bus<'d, M> {
+impl<'d, M> Bus<'d, M>
+where
+    M: RawMutex + Copy,
+{
     fn restore_irqs(&mut self) {
         self.instance.regs.gintmsk().write(|w| {
             w.set_usbrst(true);
@@ -1194,7 +1230,10 @@ impl<'d, M: RawMutex + Copy> Bus<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex + Copy> embassy_usb_driver::Bus for Bus<'d, M> {
+impl<'d, M> embassy_usb_driver::Bus for Bus<'d, M>
+where
+    M: RawMutex + Copy,
+{
     async fn poll(&mut self) -> Event {
         poll_fn(move |cx| {
             if !self.inited {
@@ -1530,7 +1569,10 @@ impl Dir for Out {
 }
 
 /// USB endpoint.
-pub struct Endpoint<'d, D, M: RawMutex = CriticalSectionRawMutex> {
+pub struct Endpoint<'d, D, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     _phantom: PhantomData<D>,
     regs: Otg,
     info: EndpointInfo,
@@ -1538,7 +1580,10 @@ pub struct Endpoint<'d, D, M: RawMutex = CriticalSectionRawMutex> {
     mutex: M,
 }
 
-impl<'d, M: RawMutex + Copy> embassy_usb_driver::Endpoint for Endpoint<'d, In, M> {
+impl<'d, M> embassy_usb_driver::Endpoint for Endpoint<'d, In, M>
+where
+    M: RawMutex + Copy,
+{
     fn info(&self) -> &EndpointInfo {
         &self.info
     }
@@ -1557,7 +1602,10 @@ impl<'d, M: RawMutex + Copy> embassy_usb_driver::Endpoint for Endpoint<'d, In, M
     }
 }
 
-impl<'d, M: RawMutex + Copy> embassy_usb_driver::Endpoint for Endpoint<'d, Out, M> {
+impl<'d, M> embassy_usb_driver::Endpoint for Endpoint<'d, Out, M>
+where
+    M: RawMutex + Copy,
+{
     fn info(&self) -> &EndpointInfo {
         &self.info
     }
@@ -1576,7 +1624,10 @@ impl<'d, M: RawMutex + Copy> embassy_usb_driver::Endpoint for Endpoint<'d, Out, 
     }
 }
 
-impl<'d, M: RawMutex + Copy> embassy_usb_driver::EndpointOut for Endpoint<'d, Out, M> {
+impl<'d, M> embassy_usb_driver::EndpointOut for Endpoint<'d, Out, M>
+where
+    M: RawMutex + Copy,
+{
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
         trace!("read start len={}", buf.len());
 
@@ -1644,7 +1695,10 @@ impl<'d, M: RawMutex + Copy> embassy_usb_driver::EndpointOut for Endpoint<'d, Ou
     }
 }
 
-impl<'d, M: RawMutex + Copy> embassy_usb_driver::EndpointIn for Endpoint<'d, In, M> {
+impl<'d, M> embassy_usb_driver::EndpointIn for Endpoint<'d, In, M>
+where
+    M: RawMutex + Copy,
+{
     async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         trace!("write ep={:?} data={:?}", self.info.addr, Bytes(buf));
 
@@ -1761,7 +1815,10 @@ impl<'d, M: RawMutex + Copy> embassy_usb_driver::EndpointIn for Endpoint<'d, In,
 }
 
 /// USB control pipe.
-pub struct ControlPipe<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct ControlPipe<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     max_packet_size: u16,
     regs: Otg,
     setup_state: &'d ControlPipeSetupState,
@@ -1770,7 +1827,10 @@ pub struct ControlPipe<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     mutex: M,
 }
 
-impl<'d, M: RawMutex + Copy> embassy_usb_driver::ControlPipe for ControlPipe<'d, M> {
+impl<'d, M> embassy_usb_driver::ControlPipe for ControlPipe<'d, M>
+where
+    M: RawMutex + Copy,
+{
     fn max_packet_size(&self) -> usize {
         usize::from(self.max_packet_size)
     }
@@ -1882,7 +1942,10 @@ fn ep0_mpsiz(max_packet_size: u16) -> u16 {
 
 /// Hardware-dependent USB IP configuration.
 #[derive(Copy, Clone)]
-pub struct OtgInstance<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
+pub struct OtgInstance<'d, M = CriticalSectionRawMutex>
+where
+    M: RawMutex + Copy,
+{
     /// The USB peripheral.
     pub regs: Otg,
     /// Shared driver/interrupt state from [`State::as_state`].

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -35,7 +35,7 @@ pub mod host;
 use otg_v1::{Otg, regs, vals};
 
 /// Handle interrupts.
-pub unsafe fn on_interrupt<M: RawMutex>(r: Otg, state: &State<'_, M>) {
+pub unsafe fn on_interrupt<M: RawMutex + Copy>(r: Otg, state: &State<'_, M>) {
     trace!("irq");
     let ep_count = state.endpoint_count();
 
@@ -300,14 +300,14 @@ struct EndpointData {
 /// and [`on_interrupt`].
 ///
 /// Build from [`State::as_state`].
-pub struct State<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct State<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     cp_state: &'d ControlPipeSetupState,
     ep_states: &'d [EpState],
     bus_waker: &'d AtomicWaker,
-    mutex: &'d M,
+    mutex: M,
 }
 
-impl<'d, M: RawMutex> Clone for State<'d, M> {
+impl<'d, M: RawMutex + Copy> Clone for State<'d, M> {
     fn clone(&self) -> Self {
         Self {
             cp_state: self.cp_state,
@@ -318,16 +318,16 @@ impl<'d, M: RawMutex> Clone for State<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex> Copy for State<'d, M> {}
+impl<'d, M: RawMutex + Copy> Copy for State<'d, M> {}
 
-impl<M: RawMutex> State<'_, M> {
+impl<M: RawMutex + Copy> State<'_, M> {
     /// Returns the number of device endpoints supported by this state.
     pub fn endpoint_count(&self) -> usize {
         self.ep_states.len()
     }
 }
 
-impl<'d, M: RawMutex> State<'d, M> {
+impl<'d, M: RawMutex + Copy> State<'d, M> {
     pub(crate) fn ep_alloc_get(&self, dir: Direction, index: usize) -> Option<&EndpointData> {
         unsafe {
             match dir {
@@ -383,16 +383,16 @@ impl<'d, M: RawMutex> State<'d, M> {
 }
 
 /// Storage object for USB OTG driver state.
-pub struct StateStorage<const EP_COUNT: usize, M: RawMutex = CriticalSectionRawMutex> {
+pub struct StateStorage<const EP_COUNT: usize, M: RawMutex + Copy = CriticalSectionRawMutex> {
     cp_state: ControlPipeSetupState,
     ep_states: [EpState; EP_COUNT],
     bus_waker: AtomicWaker,
     mutex: M,
 }
 
-impl<const EP_COUNT: usize, M: RawMutex> StateStorage<EP_COUNT, M> {
+impl<const EP_COUNT: usize, M: RawMutex + Copy> StateStorage<EP_COUNT, M> {
     /// Create a new StateStorage.
-    pub const fn new() -> Self {
+    pub const fn new(mutex: M) -> Self {
         Self {
             cp_state: ControlPipeSetupState {
                 setup_data: [const { AtomicU32::new(0) }; 2],
@@ -411,7 +411,7 @@ impl<const EP_COUNT: usize, M: RawMutex> StateStorage<EP_COUNT, M> {
                 }
             }; EP_COUNT],
             bus_waker: AtomicWaker::new(),
-            mutex: M::INIT,
+            mutex,
         }
     }
 
@@ -421,7 +421,7 @@ impl<const EP_COUNT: usize, M: RawMutex> StateStorage<EP_COUNT, M> {
             cp_state: &self.cp_state,
             ep_states: self.ep_states.as_slice(),
             bus_waker: &self.bus_waker,
-            mutex: &self.mutex,
+            mutex: self.mutex,
         }
     }
 }
@@ -465,14 +465,14 @@ impl Default for Config {
 }
 
 /// USB OTG driver.
-pub struct Driver<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct Driver<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     config: Config,
     ep_out_buffer: &'d mut [u8],
     ep_out_buffer_offset: usize,
     instance: OtgInstance<'d, M>,
 }
 
-impl<'d, M: RawMutex> Driver<'d, M> {
+impl<'d, M: RawMutex + Copy> Driver<'d, M> {
     /// Initializes the USB OTG peripheral.
     ///
     /// # Arguments
@@ -606,7 +606,7 @@ impl<'d, M: RawMutex> Driver<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::Driver<'d> for Driver<'d, M> {
+impl<'d, M: RawMutex + Copy + 'd> embassy_usb_driver::Driver<'d> for Driver<'d, M> {
     type EndpointOut = Endpoint<'d, Out, M>;
     type EndpointIn = Endpoint<'d, In, M>;
     type ControlPipe = ControlPipe<'d, M>;
@@ -793,13 +793,13 @@ fn has_data_toggle(ep_type: EndpointType) -> bool {
 }
 
 /// USB bus.
-pub struct Bus<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct Bus<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     config: Config,
     instance: OtgInstance<'d, M>,
     inited: bool,
 }
 
-impl<'d, M: RawMutex> Bus<'d, M> {
+impl<'d, M: RawMutex + Copy> Bus<'d, M> {
     fn restore_irqs(&mut self) {
         self.instance.regs.gintmsk().write(|w| {
             w.set_usbrst(true);
@@ -1194,7 +1194,7 @@ impl<'d, M: RawMutex> Bus<'d, M> {
     }
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::Bus for Bus<'d, M> {
+impl<'d, M: RawMutex + Copy> embassy_usb_driver::Bus for Bus<'d, M> {
     async fn poll(&mut self) -> Event {
         poll_fn(move |cx| {
             if !self.inited {
@@ -1535,10 +1535,10 @@ pub struct Endpoint<'d, D, M: RawMutex = CriticalSectionRawMutex> {
     regs: Otg,
     info: EndpointInfo,
     state: &'d EpState,
-    mutex: &'d M,
+    mutex: M,
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::Endpoint for Endpoint<'d, In, M> {
+impl<'d, M: RawMutex + Copy> embassy_usb_driver::Endpoint for Endpoint<'d, In, M> {
     fn info(&self) -> &EndpointInfo {
         &self.info
     }
@@ -1557,7 +1557,7 @@ impl<'d, M: RawMutex> embassy_usb_driver::Endpoint for Endpoint<'d, In, M> {
     }
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::Endpoint for Endpoint<'d, Out, M> {
+impl<'d, M: RawMutex + Copy> embassy_usb_driver::Endpoint for Endpoint<'d, Out, M> {
     fn info(&self) -> &EndpointInfo {
         &self.info
     }
@@ -1576,7 +1576,7 @@ impl<'d, M: RawMutex> embassy_usb_driver::Endpoint for Endpoint<'d, Out, M> {
     }
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::EndpointOut for Endpoint<'d, Out, M> {
+impl<'d, M: RawMutex + Copy> embassy_usb_driver::EndpointOut for Endpoint<'d, Out, M> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, EndpointError> {
         trace!("read start len={}", buf.len());
 
@@ -1644,7 +1644,7 @@ impl<'d, M: RawMutex> embassy_usb_driver::EndpointOut for Endpoint<'d, Out, M> {
     }
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::EndpointIn for Endpoint<'d, In, M> {
+impl<'d, M: RawMutex + Copy> embassy_usb_driver::EndpointIn for Endpoint<'d, In, M> {
     async fn write(&mut self, buf: &[u8]) -> Result<(), EndpointError> {
         trace!("write ep={:?} data={:?}", self.info.addr, Bytes(buf));
 
@@ -1761,16 +1761,16 @@ impl<'d, M: RawMutex> embassy_usb_driver::EndpointIn for Endpoint<'d, In, M> {
 }
 
 /// USB control pipe.
-pub struct ControlPipe<'d, M: RawMutex = CriticalSectionRawMutex> {
+pub struct ControlPipe<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     max_packet_size: u16,
     regs: Otg,
     setup_state: &'d ControlPipeSetupState,
     ep_in: Endpoint<'d, In, M>,
     ep_out: Endpoint<'d, Out, M>,
-    mutex: &'d M,
+    mutex: M,
 }
 
-impl<'d, M: RawMutex> embassy_usb_driver::ControlPipe for ControlPipe<'d, M> {
+impl<'d, M: RawMutex + Copy> embassy_usb_driver::ControlPipe for ControlPipe<'d, M> {
     fn max_packet_size(&self) -> usize {
         usize::from(self.max_packet_size)
     }
@@ -1882,7 +1882,7 @@ fn ep0_mpsiz(max_packet_size: u16) -> u16 {
 
 /// Hardware-dependent USB IP configuration.
 #[derive(Copy, Clone)]
-pub struct OtgInstance<'d, M: RawMutex> {
+pub struct OtgInstance<'d, M: RawMutex + Copy = CriticalSectionRawMutex> {
     /// The USB peripheral.
     pub regs: Otg,
     /// Shared driver/interrupt state from [`State::as_state`].


### PR DESCRIPTION
CSRM is zero-sized, and global. A multi-core spinlock like esp_sync's RawMutex is local and not zero sized. This change allows for APIs that take `RawMutex + Copy` to use either `CSRM` or a custom mutex, while not forcing the cost of references for the zero-sized types.

Using CSRM should collapse into a zero-sized option, so this PR should fix the slight memory regression of #6691