### PR TITLE
stm32/eth: ungate ptp feature on f4

### DIFF
--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -185,6 +185,10 @@ impl<'a, 'd> embassy_net_driver::RxToken for RxToken<'a, 'd> {
         self.rx.meta()
     }
 
+    fn buf(&mut self) -> &mut [u8] {
+        unsafe { &mut *self.pkt }
+    }
+
     #[inline]
     fn consume<R, F>(self, f: F) -> R
     where

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -1,8 +1,8 @@
 //! Ethernet (ETH)
 #![macro_use]
 
-#[cfg(all(feature = "ptp", not(eth_v2), not(eth_v2a)))]
-compile_error!("The 'ptp' feature is only supported on STM32 Ethernet MAC v2/v2a peripherals.");
+#[cfg(all(feature = "ptp", eth_v1a))]
+compile_error!("The 'ptp' feature is not supported on STM32 Ethernet MAC v1a.");
 
 #[cfg_attr(any(eth_v1a, eth_v1b, eth_v1c), path = "v1/mod.rs")]
 #[cfg_attr(any(eth_v2, eth_v2a, eth_v2b), path = "v2/mod.rs")]

--- a/embassy-stm32/src/eth/v1/tx_desc.rs
+++ b/embassy-stm32/src/eth/v1/tx_desc.rs
@@ -223,8 +223,13 @@ impl<'a> TDesRing<'a> {
         }
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.descriptors.len()
+    }
+
+    #[cfg(feature = "ptp")]
+    pub(crate) const fn completion_index(&self) -> usize {
+        (self.index + self.len() - self.in_flight) % self.len()
     }
 
     /// Return the next available packet buffer for transmitting, or None
@@ -247,7 +252,7 @@ impl<'a> TDesRing<'a> {
     #[cfg(feature = "ptp")]
     pub(crate) fn poll_timestamp(&mut self) -> Option<embassy_net_driver::TxTimestamp> {
         loop {
-            let completion_index = (self.index + self.descriptors.len() - self.in_flight) % self.descriptors.len();
+            let completion_index = self.completion_index();
             let descriptor = &self.descriptors[completion_index];
 
             if self.in_flight == 0 || !descriptor.available() {
@@ -256,28 +261,28 @@ impl<'a> TDesRing<'a> {
 
             let timestamp = descriptor.timestamp();
             let packet_id = self.ids[completion_index];
-            if packet_id != 0 {
-                if timestamp.is_some() {
-                    trace!(
-                        "eth ptp tx complete idx={} packet_id={} tdes0={:#010x} tdes7={} tdes6={}",
-                        completion_index,
-                        packet_id,
-                        descriptor.tdes0.get(),
-                        descriptor.tdes7.get(),
-                        descriptor.tdes6.get()
-                    );
-                } else {
-                    trace!(
-                        "eth ptp tx complete no-ts idx={} packet_id={} tdes0={:#010x} tdes1={:#010x}",
-                        completion_index,
-                        packet_id,
-                        descriptor.tdes0.get(),
-                        descriptor.tdes1.get()
-                    );
-                }
+
+            if packet_id != 0 && timestamp.is_some() {
+                trace!(
+                    "eth ptp tx complete idx={} packet_id={} tdes0={:#010x} tdes7={} tdes6={}",
+                    completion_index,
+                    packet_id,
+                    descriptor.tdes0.get(),
+                    descriptor.tdes7.get(),
+                    descriptor.tdes6.get()
+                );
+            } else if packet_id != 0 {
+                trace!(
+                    "eth ptp tx complete no-ts idx={} packet_id={} tdes0={:#010x} tdes1={:#010x}",
+                    completion_index,
+                    packet_id,
+                    descriptor.tdes0.get(),
+                    descriptor.tdes1.get()
+                );
             }
 
             self.in_flight -= 1;
+            self.ids[completion_index] = 0;
 
             if let Some(timestamp) = timestamp {
                 break Some(embassy_net_driver::TxTimestamp {

--- a/embassy-stm32/src/eth/v2/descriptors.rs
+++ b/embassy-stm32/src/eth/v2/descriptors.rs
@@ -148,8 +148,13 @@ impl<'a> TDesRing<'a> {
         }
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.descriptors.len()
+    }
+
+    #[cfg(feature = "ptp")]
+    pub(crate) const fn completion_index(&self) -> usize {
+        (self.index + self.len() - self.in_flight) % self.len()
     }
 
     /// Return the next available packet buffer for transmitting, or None
@@ -172,7 +177,7 @@ impl<'a> TDesRing<'a> {
     #[cfg(feature = "ptp")]
     pub(crate) fn poll_timestamp(&mut self) -> Option<embassy_net_driver::TxTimestamp> {
         loop {
-            let completion_index = (self.index + self.descriptors.len() - self.in_flight) % self.descriptors.len();
+            let completion_index = self.completion_index();
             let descriptor = &self.descriptors[completion_index];
 
             if self.in_flight == 0 || !descriptor.available() {
@@ -181,28 +186,28 @@ impl<'a> TDesRing<'a> {
 
             let timestamp = descriptor.timestamp();
             let packet_id = self.ids[completion_index];
-            if packet_id != 0 {
-                if timestamp.is_some() {
-                    trace!(
-                        "eth ptp tx complete idx={} packet_id={} tdes3={:#010x} tdes1={} tdes0={}",
-                        completion_index,
-                        packet_id,
-                        descriptor.tdes3.get(),
-                        descriptor.tdes1.get(),
-                        descriptor.tdes0.get()
-                    );
-                } else {
-                    trace!(
-                        "eth ptp tx complete no-ts idx={} packet_id={} tdes3={:#010x} tdes2={:#010x}",
-                        completion_index,
-                        packet_id,
-                        descriptor.tdes3.get(),
-                        descriptor.tdes2.get()
-                    );
-                }
+
+            if packet_id != 0 && timestamp.is_some() {
+                trace!(
+                    "eth ptp tx complete idx={} packet_id={} tdes3={:#010x} tdes1={} tdes0={}",
+                    completion_index,
+                    packet_id,
+                    descriptor.tdes3.get(),
+                    descriptor.tdes1.get(),
+                    descriptor.tdes0.get()
+                );
+            } else if packet_id != 0 {
+                trace!(
+                    "eth ptp tx complete no-ts idx={} packet_id={} tdes3={:#010x} tdes2={:#010x}",
+                    completion_index,
+                    packet_id,
+                    descriptor.tdes3.get(),
+                    descriptor.tdes2.get()
+                );
             }
 
             self.in_flight -= 1;
+            self.ids[completion_index] = 0;
 
             if let Some(timestamp) = timestamp {
                 break Some(embassy_net_driver::TxTimestamp {

--- a/examples/stm32f4/Cargo.toml
+++ b/examples/stm32f4/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 # Change stm32f429zi to your chip name, if necessary.
-embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono", "usb-host"] }
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f429zi", "unstable-pac", "memory-x", "time-driver-tim4", "exti", "chrono", "usb-host", "ptp"] }
 embassy-sync = { version = "0.8.0", path = "../../embassy-sync", features = ["defmt"] }
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-cortex-m", "executor-thread", "executor-interrupt", "defmt"] }
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime", "tick-hz-32_768"] }


### PR DESCRIPTION
in addition to a bit of cleanup, this enables the ptp feature on f4/f7 bringing us to feature parity with stm32-eth.