### PR TITLE
Fix flash offset bounds check for chips with non-contiguous banks (Closes #6258)

### DIFF
--- a/embassy-stm32/src/flash/asynch.rs
+++ b/embassy-stm32/src/flash/asynch.rs
@@ -7,7 +7,7 @@ use embassy_sync::mutex::Mutex;
 
 use super::{
     Async, Error, FLASH_BASE, FLASH_SIZE, Flash, FlashLayout, WRITE_SIZE, blocking_read, ensure_sector_aligned, family,
-    get_flash_regions, get_sector,
+    flash_addressable_size, get_flash_regions, get_sector,
 };
 use crate::interrupt::InterruptExt;
 use crate::peripherals::FLASH;
@@ -46,7 +46,7 @@ impl<'d> Flash<'d, Async> {
     /// NOTE: `offset` is an offset from the flash start, NOT an absolute address.
     /// For example, to write address `0x0800_1234` you have to use offset `0x1234`.
     pub async fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Error> {
-        unsafe { write_chunked(FLASH_BASE as u32, FLASH_SIZE as u32, offset, bytes).await }
+        unsafe { write_chunked(FLASH_BASE as u32, flash_addressable_size(), offset, bytes).await }
     }
 
     /// Async erase.

--- a/embassy-stm32/src/flash/common.rs
+++ b/embassy-stm32/src/flash/common.rs
@@ -44,7 +44,7 @@ impl<'d, MODE> Flash<'d, MODE> {
     /// NOTE: `offset` is an offset from the flash start, NOT an absolute address.
     /// For example, to read address `0x0800_1234` you have to use offset `0x1234`.
     pub fn blocking_read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Error> {
-        blocking_read(FLASH_BASE as u32, FLASH_SIZE as u32, offset, bytes)
+        blocking_read(FLASH_BASE as u32, flash_addressable_size(), offset, bytes)
     }
 
     /// Blocking write.
@@ -55,7 +55,7 @@ impl<'d, MODE> Flash<'d, MODE> {
         unsafe {
             blocking_write(
                 FLASH_BASE as u32,
-                FLASH_SIZE as u32,
+                flash_addressable_size(),
                 offset,
                 bytes,
                 write_chunk_unlocked,
@@ -175,6 +175,19 @@ pub(super) unsafe fn erase_sector_unlocked(sector: &FlashSector) -> Result<(), E
 
 pub(super) unsafe fn erase_sector_with_critical_section(sector: &FlashSector) -> Result<(), Error> {
     critical_section::with(|_| erase_sector_unlocked(sector))
+}
+
+/// Size of the address range spanned by all flash regions, from the start of the first
+/// region to the end of the last region.
+///
+/// This can be larger than `FLASH_SIZE` (the sum of region sizes) on chips where the banks
+/// are not contiguous, e.g. STM32G473CB has a 192KB gap between bank 1 and bank 2. Bounding
+/// offsets by `FLASH_SIZE` in that case would make the later bank unreachable even though
+/// `get_sector` can resolve its addresses just fine.
+pub(super) fn flash_addressable_size() -> u32 {
+    let regions = get_flash_regions();
+    let end = regions.iter().map(|r| r.end()).max().unwrap();
+    end - FLASH_BASE as u32
 }
 
 pub(super) fn get_sector(address: u32, regions: &[&FlashRegion]) -> Result<FlashSector, Error> {


### PR DESCRIPTION
Flash::blocking_read/blocking_write (and the async write) bounded offsets by FLASH_SIZE, which is the sum of bank sizes. On chips like STM32G473CB, banks are separated by a gap (Bank2 starts at address offset 0x40000 while FLASH_SIZE is only 0x20000), so any valid Bank2 address was rejected with Error::Size even though erase() could reach it fine via get_sector(). Bound by the true addressable span instead.


https://github.com/embassy-rs/embassy/issues/6258#issuecomment-4870259250 - This is the issue I am solving

Closes #6258