### PR TITLE
feat: add initial ATmega328P HAL support

### DIFF
--- a/embassy-atmega328p/Cargo.toml
+++ b/embassy-atmega328p/Cargo.toml
@@ -6,7 +6,8 @@ license = "MIT OR Apache-2.0"
 description = "Embassy-compatible hardware abstraction layer for the ATmega328P"
 keywords = ["embedded", "async", "avr", "atmega328p", "embedded-hal"]
 categories = ["embedded", "hardware-support", "no-std"]
-repository = "https://github.com/nursude355/embassy"
+repository = "https://github.com/embassy-rs/embassy"
+documentation = "https://docs.embassy.dev/embassy-atmega328p"
 publish = false
 
 [package.metadata.embassy]

--- a/embassy-atmega328p/Cargo.toml
+++ b/embassy-atmega328p/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "embassy-atmega328p"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Embassy-compatible hardware abstraction layer for the ATmega328P"
+keywords = ["embedded", "async", "avr", "atmega328p", "embedded-hal"]
+categories = ["embedded", "hardware-support", "no-std"]
+repository = "https://github.com/nursude355/embassy"
+publish = false
+
+[package.metadata.embassy]
+build = [
+    { group = "nightly", target = "avr-none", features = ["time-driver-16mhz"], build-std = ["core"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" } },
+]
+
+[features]
+default = ["rt", "clock-16mhz"]
+rt = ["avr-device/rt"]
+unstable-pac = []
+clock-16mhz = []
+clock-8mhz = []
+time-driver-16mhz = [
+    "rt",
+    "clock-16mhz",
+    "dep:embassy-time-driver",
+    "dep:embassy-time-queue-utils",
+    "embassy-time-driver/tick-hz-2_000_000",
+]
+time-driver-8mhz = [
+    "rt",
+    "clock-8mhz",
+    "dep:embassy-time-driver",
+    "dep:embassy-time-queue-utils",
+    "embassy-time-driver/tick-hz-1_000_000",
+]
+
+[dependencies]
+avr-device = { version = "0.8.1", default-features = false, features = ["atmega328p", "critical-section"] }
+embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver", optional = true }
+embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-utils", optional = true }
+embedded-hal = "1.0"

--- a/embassy-atmega328p/README.md
+++ b/embassy-atmega328p/README.md
@@ -1,0 +1,178 @@
+# embassy-atmega328p
+
+An Embassy-compatible, `no_std` hardware abstraction layer for the
+Microchip ATmega328P.
+
+This crate is intentionally independent from `embassy-executor`. It can be
+used by a blocking application on its own, or together with Embassy's AVR
+executor in an asynchronous application.
+
+## Status
+
+The initial implementation provides:
+
+- ownership tokens for all GPIO pins on ports B, C and D;
+- input pins with floating or internal pull-up configuration;
+- push-pull output pins;
+- `embedded-hal` 1.0 digital trait implementations;
+- blocking USART0, SPI master and TWI/I2C master drivers;
+- blocking 10-bit ADC support for PC0 through PC5;
+- two-channel fast PWM using Timer0 or Timer2;
+- a bit-banged Dallas/Maxim 1-Wire master with CRC-8;
+- an optional Embassy time driver backed by Timer1;
+- 16 MHz and 8 MHz CPU-clock configurations;
+- a compiling Embassy executor + async timer Blinky example;
+- an optional re-export of the low-level PAC.
+
+GPIO external interrupts and asynchronous peripheral transfers are not
+implemented yet. USART, SPI, I2C and ADC currently use blocking APIs.
+
+## Using the HAL from another project
+
+While both projects are checked out on the same machine, a path dependency is
+the quickest option:
+
+```toml
+[dependencies]
+embassy-atmega328p = { path = "../embassy/embassy-atmega328p" }
+avr-device = { version = "0.8.1", features = ["atmega328p", "rt"] }
+```
+
+Enable the time driver that matches the board's CPU clock when using
+`embassy-time`. A normal Arduino Uno or classic Nano runs at 16 MHz:
+
+```toml
+[dependencies]
+embassy-atmega328p = {
+    path = "../embassy/embassy-atmega328p",
+    features = ["time-driver-16mhz"],
+}
+embassy-executor = {
+    path = "../embassy/embassy-executor",
+    features = ["nightly", "platform-avr", "executor-thread"],
+}
+embassy-time = { path = "../embassy/embassy-time" }
+avr-device = { version = "0.8.1", features = ["atmega328p", "rt"] }
+panic-halt = "1.0"
+```
+
+Use `time-driver-8mhz` instead for an ATmega328P actually clocked at 8 MHz.
+The selected feature must match the fuse and clock configuration or all
+durations will be scaled incorrectly. Since the default clock is 16 MHz, an
+8 MHz application must also set `default-features = false` and explicitly
+enable `rt` if it needs the runtime.
+
+The crate can also be used directly from this fork. Cargo searches the complete
+Git repository for the requested package, so the crate does not have to be at
+the repository root. Since the repository is private, GitHub authentication
+must already work on the development machine.
+
+Pin applications to a tested commit with `rev`; otherwise Cargo follows the
+latest commit on the repository's default branch:
+
+```toml
+[dependencies]
+embassy-atmega328p = {
+    git = "https://github.com/nursude355/embassy.git",
+    rev = "<tested-commit-sha>",
+}
+avr-device = { version = "0.8.1", features = ["atmega328p", "rt"] }
+```
+
+For an async 16 MHz application, enable the matching time-driver feature:
+
+```toml
+embassy-atmega328p = {
+    git = "https://github.com/nursude355/embassy.git",
+    rev = "<tested-commit-sha>",
+    features = ["time-driver-16mhz"],
+}
+embassy-executor = {
+    git = "https://github.com/nursude355/embassy.git",
+    rev = "<same-tested-commit-sha>",
+    features = ["nightly", "platform-avr", "executor-thread"],
+}
+embassy-time = {
+    git = "https://github.com/nursude355/embassy.git",
+    rev = "<same-tested-commit-sha>",
+}
+```
+
+Use the same revision for all Embassy crates so their internal APIs stay in
+sync. Keep `publish = false` while this HAL is private and hardware validation
+is still in progress.
+
+## GPIO example
+
+```rust,ignore
+#![no_std]
+#![no_main]
+
+use embassy_atmega328p::gpio::{Level, Output};
+use embedded_hal::digital::StatefulOutputPin;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut led = Output::new(p.PB5, Level::Low); // Arduino Uno D13
+
+    loop {
+        led.toggle().unwrap();
+    }
+}
+```
+
+`PC6` is the reset pin with the factory fuse configuration. Do not use it as
+GPIO unless the reset-disable fuse has deliberately been programmed.
+
+The complete async version is in
+[`examples/atmega328p/src/bin/async_blinky.rs`](../examples/atmega328p/src/bin/async_blinky.rs).
+
+## Timer1 ownership
+
+The Embassy time driver uses Timer/Counter1 in normal mode with a `/8`
+prescaler, including its overflow and compare-A interrupts. Applications must
+not reconfigure Timer1 while either `time-driver-*` feature is enabled. Timer0
+and Timer2 remain available to the PWM drivers or application-specific code.
+
+## Peripheral pin map
+
+| Peripheral | Pins | Notes |
+| --- | --- | --- |
+| USART0 | PD0/RX, PD1/TX | Blocking 8N1 |
+| TWI/I2C | PC4/SDA, PC5/SCL | External pull-ups required |
+| SPI master | PB2/SS, PB3/MOSI, PB4/MISO, PB5/SCK | Use another GPIO for device CS if desired |
+| ADC | PC0 through PC5 | 10-bit blocking conversions |
+| PWM0 | PD6/OC0A, PD5/OC0B | Timer0, 8-bit fast PWM |
+| PWM2 | PB3/OC2A, PD3/OC2B | Timer2, 8-bit fast PWM |
+| 1-Wire | Any GPIO | External pull-up, normally 4.7 kOhm |
+
+Pin ownership makes incompatible combinations fail to compile. For example,
+PB3 cannot simultaneously be SPI/MOSI and Timer2/OC2A.
+
+## AVR build settings
+
+AVR currently requires a nightly compiler and `build-std`:
+
+```toml
+# .cargo/config.toml in the application
+[build]
+target = "avr-none"
+
+[unstable]
+build-std = ["core"]
+
+[target.avr-none]
+rustflags = ["-C", "target-cpu=atmega328p"]
+```
+
+The final link step also requires an AVR GNU toolchain providing `avr-gcc`.
+Application profiles must abort on panic:
+
+```toml
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"
+```

--- a/embassy-atmega328p/README.md
+++ b/embassy-atmega328p/README.md
@@ -62,10 +62,9 @@ durations will be scaled incorrectly. Since the default clock is 16 MHz, an
 8 MHz application must also set `default-features = false` and explicitly
 enable `rt` if it needs the runtime.
 
-The crate can also be used directly from this fork. Cargo searches the complete
-Git repository for the requested package, so the crate does not have to be at
-the repository root. Since the repository is private, GitHub authentication
-must already work on the development machine.
+The crate can also be used directly from the Embassy Git repository. Cargo
+searches the complete repository for the requested package, so the crate does
+not have to be at the repository root.
 
 Pin applications to a tested commit with `rev`; otherwise Cargo follows the
 latest commit on the repository's default branch:
@@ -73,7 +72,7 @@ latest commit on the repository's default branch:
 ```toml
 [dependencies]
 embassy-atmega328p = {
-    git = "https://github.com/nursude355/embassy.git",
+    git = "https://github.com/embassy-rs/embassy.git",
     rev = "<tested-commit-sha>",
 }
 avr-device = { version = "0.8.1", features = ["atmega328p", "rt"] }
@@ -83,17 +82,17 @@ For an async 16 MHz application, enable the matching time-driver feature:
 
 ```toml
 embassy-atmega328p = {
-    git = "https://github.com/nursude355/embassy.git",
+    git = "https://github.com/embassy-rs/embassy.git",
     rev = "<tested-commit-sha>",
     features = ["time-driver-16mhz"],
 }
 embassy-executor = {
-    git = "https://github.com/nursude355/embassy.git",
+    git = "https://github.com/embassy-rs/embassy.git",
     rev = "<same-tested-commit-sha>",
     features = ["nightly", "platform-avr", "executor-thread"],
 }
 embassy-time = {
-    git = "https://github.com/nursude355/embassy.git",
+    git = "https://github.com/embassy-rs/embassy.git",
     rev = "<same-tested-commit-sha>",
 }
 ```

--- a/embassy-atmega328p/src/adc.rs
+++ b/embassy-atmega328p/src/adc.rs
@@ -1,0 +1,113 @@
+//! Blocking 10-bit analog-to-digital converter.
+
+use core::ptr::{read_volatile, write_volatile};
+
+use crate::gpio::{PC0, PC1, PC2, PC3, PC4, PC5};
+
+const ADCL: *mut u8 = 0x78 as *mut u8;
+const ADCH: *mut u8 = 0x79 as *mut u8;
+const ADCSRA: *mut u8 = 0x7a as *mut u8;
+const ADMUX: *mut u8 = 0x7c as *mut u8;
+const DIDR0: *mut u8 = 0x7e as *mut u8;
+
+const ADEN: u8 = 1 << 7;
+const ADSC: u8 = 1 << 6;
+
+/// Ownership token for the ADC peripheral.
+pub struct AdcPeripheral {
+    _private: (),
+}
+
+impl AdcPeripheral {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// ADC voltage reference.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Reference {
+    /// External voltage applied to AREF.
+    Aref,
+    /// AVCC, normally 5 V or 3.3 V depending on the board.
+    Avcc,
+    /// Internal nominal 1.1 V reference.
+    Internal1V1,
+}
+
+/// A pin that can be connected to the ADC multiplexer.
+pub trait AdcPin: sealed::AdcPin {}
+
+mod sealed {
+    pub trait AdcPin {
+        const CHANNEL: u8;
+    }
+}
+
+macro_rules! adc_pin {
+    ($pin:ty, $channel:expr) => {
+        impl sealed::AdcPin for $pin {
+            const CHANNEL: u8 = $channel;
+        }
+        impl AdcPin for $pin {}
+    };
+}
+
+adc_pin!(PC0, 0);
+adc_pin!(PC1, 1);
+adc_pin!(PC2, 2);
+adc_pin!(PC3, 3);
+adc_pin!(PC4, 4);
+adc_pin!(PC5, 5);
+
+/// Blocking ADC driver.
+pub struct Adc {
+    peripheral: AdcPeripheral,
+    reference: Reference,
+}
+
+impl Adc {
+    /// Enables the ADC with a conversion clock near 125 kHz.
+    pub fn new(peripheral: AdcPeripheral, reference: Reference) -> Self {
+        let prescaler = if crate::CPU_HZ == 16_000_000 {
+            0b111 // /128
+        } else {
+            0b110 // /64
+        };
+        unsafe { write_volatile(ADCSRA, ADEN | prescaler) };
+        Self { peripheral, reference }
+    }
+
+    /// Performs one blocking 10-bit conversion.
+    pub fn read<P: AdcPin>(&mut self, _pin: &mut P) -> u16 {
+        let reference = match self.reference {
+            Reference::Aref => 0b00,
+            Reference::Avcc => 0b01,
+            Reference::Internal1V1 => 0b11,
+        };
+
+        unsafe {
+            modify(DIDR0, 1 << P::CHANNEL, true);
+            write_volatile(ADMUX, (reference << 6) | P::CHANNEL);
+            modify(ADCSRA, ADSC, true);
+            while read_volatile(ADCSRA) & ADSC != 0 {}
+
+            // ADCL must be read before ADCH.
+            let low = read_volatile(ADCL);
+            let high = read_volatile(ADCH);
+            u16::from_le_bytes([low, high])
+        }
+    }
+
+    /// Disables the ADC and returns its ownership token.
+    pub fn free(self) -> AdcPeripheral {
+        unsafe { modify(ADCSRA, ADEN, false) };
+        self.peripheral
+    }
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/delay.rs
+++ b/embassy-atmega328p/src/delay.rs
@@ -1,0 +1,43 @@
+//! Cycle-counted blocking delays.
+
+use embedded_hal::delay::DelayNs;
+
+/// Blocking delay provider using the selected CPU clock.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Delay;
+
+impl Delay {
+    /// Creates a delay provider.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    /// Blocks for at least `microseconds` microseconds, excluding interrupts.
+    pub fn delay_us(&mut self, microseconds: u32) {
+        let cycles_per_us = crate::CPU_HZ / 1_000_000;
+        delay_cycles_saturating(microseconds.saturating_mul(cycles_per_us));
+    }
+
+    /// Blocks for at least `milliseconds` milliseconds, excluding interrupts.
+    pub fn delay_ms(&mut self, milliseconds: u32) {
+        for _ in 0..milliseconds {
+            self.delay_us(1_000);
+        }
+    }
+}
+
+impl DelayNs for Delay {
+    fn delay_ns(&mut self, ns: u32) {
+        if ns == 0 {
+            return;
+        }
+        let cycles = (u64::from(ns) * u64::from(crate::CPU_HZ)).div_ceil(1_000_000_000);
+        delay_cycles_saturating(cycles.min(u64::from(u32::MAX)) as u32);
+    }
+}
+
+fn delay_cycles_saturating(cycles: u32) {
+    if cycles != 0 {
+        avr_device::asm::delay_cycles(cycles);
+    }
+}

--- a/embassy-atmega328p/src/gpio.rs
+++ b/embassy-atmega328p/src/gpio.rs
@@ -1,0 +1,240 @@
+//! General-purpose input/output.
+
+use core::convert::Infallible;
+use core::marker::PhantomData;
+use core::ptr::{read_volatile, write_volatile};
+
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, PinState, StatefulOutputPin};
+
+const PINB: *mut u8 = 0x23 as *mut u8;
+const DDRB: *mut u8 = 0x24 as *mut u8;
+const PORTB: *mut u8 = 0x25 as *mut u8;
+const PINC: *mut u8 = 0x26 as *mut u8;
+const DDRC: *mut u8 = 0x27 as *mut u8;
+const PORTC: *mut u8 = 0x28 as *mut u8;
+const PIND: *mut u8 = 0x29 as *mut u8;
+const DDRD: *mut u8 = 0x2a as *mut u8;
+const PORTD: *mut u8 = 0x2b as *mut u8;
+
+/// Logical GPIO level.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Level {
+    Low,
+    High,
+}
+
+impl From<Level> for PinState {
+    fn from(level: Level) -> Self {
+        match level {
+            Level::Low => PinState::Low,
+            Level::High => PinState::High,
+        }
+    }
+}
+
+/// Input pull resistor configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Pull {
+    /// High-impedance input without a pull resistor.
+    Floating,
+    /// Enable the ATmega328P's internal pull-up resistor.
+    Up,
+}
+
+pub(crate) mod sealed {
+    pub trait Pin {
+        const PIN: *mut u8;
+        const DDR: *mut u8;
+        const PORT: *mut u8;
+        const MASK: u8;
+    }
+}
+
+/// A GPIO pin owned by the caller.
+pub trait Pin: sealed::Pin {}
+
+macro_rules! pin {
+    ($name:ident, $pin:expr, $ddr:expr, $port:expr, $bit:expr) => {
+        #[doc = concat!("GPIO pin `", stringify!($name), "`.")]
+        pub struct $name {
+            _private: (),
+        }
+
+        impl $name {
+            pub(crate) const fn new() -> Self {
+                Self { _private: () }
+            }
+        }
+
+        impl sealed::Pin for $name {
+            const PIN: *mut u8 = $pin;
+            const DDR: *mut u8 = $ddr;
+            const PORT: *mut u8 = $port;
+            const MASK: u8 = 1 << $bit;
+        }
+
+        impl Pin for $name {}
+    };
+}
+
+pin!(PB0, PINB, DDRB, PORTB, 0);
+pin!(PB1, PINB, DDRB, PORTB, 1);
+pin!(PB2, PINB, DDRB, PORTB, 2);
+pin!(PB3, PINB, DDRB, PORTB, 3);
+pin!(PB4, PINB, DDRB, PORTB, 4);
+pin!(PB5, PINB, DDRB, PORTB, 5);
+pin!(PB6, PINB, DDRB, PORTB, 6);
+pin!(PB7, PINB, DDRB, PORTB, 7);
+pin!(PC0, PINC, DDRC, PORTC, 0);
+pin!(PC1, PINC, DDRC, PORTC, 1);
+pin!(PC2, PINC, DDRC, PORTC, 2);
+pin!(PC3, PINC, DDRC, PORTC, 3);
+pin!(PC4, PINC, DDRC, PORTC, 4);
+pin!(PC5, PINC, DDRC, PORTC, 5);
+pin!(PC6, PINC, DDRC, PORTC, 6);
+pin!(PD0, PIND, DDRD, PORTD, 0);
+pin!(PD1, PIND, DDRD, PORTD, 1);
+pin!(PD2, PIND, DDRD, PORTD, 2);
+pin!(PD3, PIND, DDRD, PORTD, 3);
+pin!(PD4, PIND, DDRD, PORTD, 4);
+pin!(PD5, PIND, DDRD, PORTD, 5);
+pin!(PD6, PIND, DDRD, PORTD, 6);
+pin!(PD7, PIND, DDRD, PORTD, 7);
+
+/// A GPIO configured as a digital input.
+pub struct Input<P: Pin> {
+    pin: P,
+}
+
+impl<P: Pin> Input<P> {
+    /// Configures an owned pin as an input.
+    pub fn new(pin: P, pull: Pull) -> Self {
+        avr_device::interrupt::free(|_| unsafe {
+            modify(P::DDR, P::MASK, false);
+            modify(P::PORT, P::MASK, pull == Pull::Up);
+        });
+        Self { pin }
+    }
+
+    /// Returns the owned pin without changing its hardware configuration.
+    pub fn free(self) -> P {
+        self.pin
+    }
+
+    /// Returns `true` when the electrical input level is high.
+    pub fn is_high(&self) -> bool {
+        unsafe { read_volatile(P::PIN) & P::MASK != 0 }
+    }
+
+    /// Returns `true` when the electrical input level is low.
+    pub fn is_low(&self) -> bool {
+        !self.is_high()
+    }
+}
+
+impl<P: Pin> ErrorType for Input<P> {
+    type Error = Infallible;
+}
+
+impl<P: Pin> InputPin for Input<P> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Input::is_high(self))
+    }
+
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Input::is_low(self))
+    }
+}
+
+/// A GPIO configured as a push-pull digital output.
+pub struct Output<P: Pin> {
+    pin: P,
+    _not_send: PhantomData<*mut ()>,
+}
+
+impl<P: Pin> Output<P> {
+    /// Configures an owned pin as an output with the requested initial level.
+    pub fn new(pin: P, initial: Level) -> Self {
+        avr_device::interrupt::free(|_| unsafe {
+            // Set the output latch before enabling the driver to avoid a glitch.
+            modify(P::PORT, P::MASK, initial == Level::High);
+            modify(P::DDR, P::MASK, true);
+        });
+        Self {
+            pin,
+            _not_send: PhantomData,
+        }
+    }
+
+    /// Returns the owned pin without changing its hardware configuration.
+    pub fn free(self) -> P {
+        self.pin
+    }
+
+    /// Drives the output low.
+    pub fn set_low(&mut self) {
+        set_output_latch::<P>(false);
+    }
+
+    /// Drives the output high.
+    pub fn set_high(&mut self) {
+        set_output_latch::<P>(true);
+    }
+
+    /// Returns whether the output latch is set high.
+    pub fn is_set_high(&self) -> bool {
+        unsafe { read_volatile(P::PORT) & P::MASK != 0 }
+    }
+
+    /// Returns whether the output latch is set low.
+    pub fn is_set_low(&self) -> bool {
+        !self.is_set_high()
+    }
+
+    /// Toggles the output latch.
+    pub fn toggle(&mut self) {
+        // On classic AVR, writing a one to PINx atomically toggles PORTx.
+        unsafe { write_volatile(P::PIN, P::MASK) }
+    }
+}
+
+impl<P: Pin> ErrorType for Output<P> {
+    type Error = Infallible;
+}
+
+impl<P: Pin> OutputPin for Output<P> {
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Output::set_low(self);
+        Ok(())
+    }
+
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Output::set_high(self);
+        Ok(())
+    }
+}
+
+impl<P: Pin> StatefulOutputPin for Output<P> {
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Output::is_set_high(self))
+    }
+
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Output::is_set_low(self))
+    }
+
+    fn toggle(&mut self) -> Result<(), Self::Error> {
+        Output::toggle(self);
+        Ok(())
+    }
+}
+
+fn set_output_latch<P: Pin>(high: bool) {
+    avr_device::interrupt::free(|_| unsafe { modify(P::PORT, P::MASK, high) });
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/i2c.rs
+++ b/embassy-atmega328p/src/i2c.rs
@@ -1,0 +1,238 @@
+//! Blocking TWI/I2C master driver.
+
+use core::ptr::{read_volatile, write_volatile};
+
+use embedded_hal::i2c::{ErrorKind, ErrorType, I2c as I2cTrait, NoAcknowledgeSource, Operation};
+
+use crate::gpio::{PC4, PC5};
+
+const TWBR: *mut u8 = 0xb8 as *mut u8;
+const TWSR: *mut u8 = 0xb9 as *mut u8;
+const TWDR: *mut u8 = 0xbb as *mut u8;
+const TWCR: *mut u8 = 0xbc as *mut u8;
+const DDRC: *mut u8 = 0x27 as *mut u8;
+const PORTC: *mut u8 = 0x28 as *mut u8;
+
+const TWINT: u8 = 1 << 7;
+const TWEA: u8 = 1 << 6;
+const TWSTA: u8 = 1 << 5;
+const TWSTO: u8 = 1 << 4;
+const TWEN: u8 = 1 << 2;
+
+/// Ownership token for the TWI peripheral.
+pub struct TwiPeripheral {
+    _private: (),
+}
+
+impl TwiPeripheral {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// I2C configuration error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfigError {
+    InvalidFrequency,
+}
+
+/// I2C transfer error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    Bus,
+    ArbitrationLoss,
+    AddressNack,
+    DataNack,
+    UnexpectedStatus(u8),
+}
+
+impl embedded_hal::i2c::Error for Error {
+    fn kind(&self) -> ErrorKind {
+        match self {
+            Error::Bus => ErrorKind::Bus,
+            Error::ArbitrationLoss => ErrorKind::ArbitrationLoss,
+            Error::AddressNack => ErrorKind::NoAcknowledge(NoAcknowledgeSource::Address),
+            Error::DataNack => ErrorKind::NoAcknowledge(NoAcknowledgeSource::Data),
+            Error::UnexpectedStatus(_) => ErrorKind::Other,
+        }
+    }
+}
+
+/// Blocking seven-bit-address TWI/I2C master on PC4/SDA and PC5/SCL.
+pub struct I2c {
+    peripheral: TwiPeripheral,
+    sda: PC4,
+    scl: PC5,
+}
+
+impl I2c {
+    /// Configures TWI at the requested bus frequency.
+    pub fn new(peripheral: TwiPeripheral, sda: PC4, scl: PC5, frequency_hz: u32) -> Result<Self, ConfigError> {
+        if frequency_hz == 0 || frequency_hz > crate::CPU_HZ / 16 {
+            return Err(ConfigError::InvalidFrequency);
+        }
+        let divider = crate::CPU_HZ.div_ceil(frequency_hz).saturating_sub(16).div_ceil(2);
+        if divider > u32::from(u8::MAX) {
+            return Err(ConfigError::InvalidFrequency);
+        }
+
+        unsafe {
+            // Release SDA/SCL. External pull-up resistors are required.
+            modify(DDRC, (1 << 4) | (1 << 5), false);
+            modify(PORTC, (1 << 4) | (1 << 5), false);
+            write_volatile(TWSR, 0); // prescaler = 1
+            write_volatile(TWBR, divider as u8);
+            write_volatile(TWCR, TWEN);
+        }
+        Ok(Self { peripheral, sda, scl })
+    }
+
+    /// Disables TWI and returns its ownership tokens.
+    pub fn free(self) -> (TwiPeripheral, PC4, PC5) {
+        unsafe { write_volatile(TWCR, 0) };
+        (self.peripheral, self.sda, self.scl)
+    }
+
+    fn start(&mut self, address: u8, read: bool) -> Result<(), Error> {
+        unsafe {
+            write_volatile(TWCR, TWINT | TWSTA | TWEN);
+            wait_for_interrupt();
+        }
+        match status() {
+            0x08 | 0x10 => {}
+            value => return Err(status_error(value, true)),
+        }
+
+        unsafe {
+            write_volatile(TWDR, (address << 1) | u8::from(read));
+            write_volatile(TWCR, TWINT | TWEN);
+            wait_for_interrupt();
+        }
+        match status() {
+            0x18 | 0x40 => Ok(()),
+            0x20 | 0x48 => Err(Error::AddressNack),
+            value => Err(status_error(value, true)),
+        }
+    }
+
+    fn write_data(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        for &byte in bytes {
+            unsafe {
+                write_volatile(TWDR, byte);
+                write_volatile(TWCR, TWINT | TWEN);
+                wait_for_interrupt();
+            }
+            match status() {
+                0x28 => {}
+                0x30 => return Err(Error::DataNack),
+                value => return Err(status_error(value, false)),
+            }
+        }
+        Ok(())
+    }
+
+    fn read_data(&mut self, bytes: &mut [u8], remaining: &mut usize) -> Result<(), Error> {
+        for byte in bytes {
+            *remaining -= 1;
+            let acknowledge = *remaining != 0;
+            unsafe {
+                write_volatile(TWCR, TWINT | TWEN | if acknowledge { TWEA } else { 0 });
+                wait_for_interrupt();
+            }
+            match (status(), acknowledge) {
+                (0x50, true) | (0x58, false) => unsafe { *byte = read_volatile(TWDR) },
+                (value, _) => return Err(status_error(value, false)),
+            }
+        }
+        Ok(())
+    }
+
+    fn stop(&mut self) {
+        unsafe {
+            write_volatile(TWCR, TWINT | TWEN | TWSTO);
+            while read_volatile(TWCR) & TWSTO != 0 {}
+        }
+    }
+}
+
+impl ErrorType for I2c {
+    type Error = Error;
+}
+
+impl I2cTrait<u8> for I2c {
+    fn transaction(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Self::Error> {
+        if address > 0x7f {
+            return Err(Error::AddressNack);
+        }
+        if operations.is_empty() {
+            return Ok(());
+        }
+
+        let result = self.transaction_inner(address, operations);
+        if !matches!(result, Err(Error::ArbitrationLoss)) {
+            self.stop();
+        }
+        result
+    }
+}
+
+impl I2c {
+    fn transaction_inner(&mut self, address: u8, operations: &mut [Operation<'_>]) -> Result<(), Error> {
+        let mut index = 0;
+        while index < operations.len() {
+            let read_group = matches!(operations[index], Operation::Read(_));
+            let mut end = index + 1;
+            while end < operations.len() && matches!(operations[end], Operation::Read(_)) == read_group {
+                end += 1;
+            }
+
+            self.start(address, read_group)?;
+            if read_group {
+                let mut remaining = operations[index..end]
+                    .iter()
+                    .map(|operation| match operation {
+                        Operation::Read(bytes) => bytes.len(),
+                        Operation::Write(_) => 0,
+                    })
+                    .sum();
+                for operation in operations.iter_mut().take(end).skip(index) {
+                    if let Operation::Read(bytes) = operation {
+                        self.read_data(bytes, &mut remaining)?;
+                    }
+                }
+            } else {
+                for operation in &operations[index..end] {
+                    if let Operation::Write(bytes) = operation {
+                        self.write_data(bytes)?;
+                    }
+                }
+            }
+            index = end;
+        }
+        Ok(())
+    }
+}
+
+fn status() -> u8 {
+    unsafe { read_volatile(TWSR) & 0xf8 }
+}
+
+fn status_error(status: u8, address_phase: bool) -> Error {
+    match status {
+        0x00 => Error::Bus,
+        0x38 => Error::ArbitrationLoss,
+        0x20 | 0x48 if address_phase => Error::AddressNack,
+        0x30 => Error::DataNack,
+        value => Error::UnexpectedStatus(value),
+    }
+}
+
+unsafe fn wait_for_interrupt() {
+    while unsafe { read_volatile(TWCR) } & TWINT == 0 {}
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/lib.rs
+++ b/embassy-atmega328p/src/lib.rs
@@ -1,0 +1,128 @@
+#![no_std]
+#![doc = include_str!("../README.md")]
+#![allow(non_snake_case)]
+#![cfg_attr(target_arch = "avr", feature(abi_avr_interrupt))]
+
+#[cfg(all(feature = "clock-16mhz", feature = "clock-8mhz"))]
+compile_error!("enable only one CPU clock feature: `clock-16mhz` or `clock-8mhz`");
+#[cfg(not(any(feature = "clock-16mhz", feature = "clock-8mhz")))]
+compile_error!("enable one CPU clock feature: `clock-16mhz` or `clock-8mhz`");
+
+pub mod adc;
+pub mod delay;
+pub mod gpio;
+pub mod i2c;
+pub mod onewire;
+pub mod pwm;
+pub mod spi;
+pub mod usart;
+
+#[cfg(any(feature = "time-driver-16mhz", feature = "time-driver-8mhz"))]
+mod time_driver;
+
+/// Low-level peripheral access crate for advanced use.
+///
+/// This API is not covered by this crate's semantic-versioning guarantees.
+#[cfg(feature = "unstable-pac")]
+pub use avr_device::atmega328p as pac;
+
+/// All peripheral ownership tokens exposed by this HAL.
+///
+/// There can be only one safe instance. Obtain it with [`init`] or
+/// [`try_init`].
+pub struct Peripherals {
+    pub ADC: adc::AdcPeripheral,
+    pub TWI: i2c::TwiPeripheral,
+    pub SPI: spi::SpiPeripheral,
+    pub USART0: usart::Usart0Peripheral,
+    pub TIMER0: pwm::Timer0,
+    pub TIMER2: pwm::Timer2,
+    pub PB0: gpio::PB0,
+    pub PB1: gpio::PB1,
+    pub PB2: gpio::PB2,
+    pub PB3: gpio::PB3,
+    pub PB4: gpio::PB4,
+    pub PB5: gpio::PB5,
+    pub PB6: gpio::PB6,
+    pub PB7: gpio::PB7,
+    pub PC0: gpio::PC0,
+    pub PC1: gpio::PC1,
+    pub PC2: gpio::PC2,
+    pub PC3: gpio::PC3,
+    pub PC4: gpio::PC4,
+    pub PC5: gpio::PC5,
+    pub PC6: gpio::PC6,
+    pub PD0: gpio::PD0,
+    pub PD1: gpio::PD1,
+    pub PD2: gpio::PD2,
+    pub PD3: gpio::PD3,
+    pub PD4: gpio::PD4,
+    pub PD5: gpio::PD5,
+    pub PD6: gpio::PD6,
+    pub PD7: gpio::PD7,
+}
+
+impl Peripherals {
+    fn new() -> Self {
+        Self {
+            ADC: adc::AdcPeripheral::new(),
+            TWI: i2c::TwiPeripheral::new(),
+            SPI: spi::SpiPeripheral::new(),
+            USART0: usart::Usart0Peripheral::new(),
+            TIMER0: pwm::Timer0::new(),
+            TIMER2: pwm::Timer2::new(),
+            PB0: gpio::PB0::new(),
+            PB1: gpio::PB1::new(),
+            PB2: gpio::PB2::new(),
+            PB3: gpio::PB3::new(),
+            PB4: gpio::PB4::new(),
+            PB5: gpio::PB5::new(),
+            PB6: gpio::PB6::new(),
+            PB7: gpio::PB7::new(),
+            PC0: gpio::PC0::new(),
+            PC1: gpio::PC1::new(),
+            PC2: gpio::PC2::new(),
+            PC3: gpio::PC3::new(),
+            PC4: gpio::PC4::new(),
+            PC5: gpio::PC5::new(),
+            PC6: gpio::PC6::new(),
+            PD0: gpio::PD0::new(),
+            PD1: gpio::PD1::new(),
+            PD2: gpio::PD2::new(),
+            PD3: gpio::PD3::new(),
+            PD4: gpio::PD4::new(),
+            PD5: gpio::PD5::new(),
+            PD6: gpio::PD6::new(),
+            PD7: gpio::PD7::new(),
+        }
+    }
+}
+
+/// CPU clock frequency selected at compile time.
+#[cfg(feature = "clock-16mhz")]
+pub const CPU_HZ: u32 = 16_000_000;
+
+/// CPU clock frequency selected at compile time.
+#[cfg(feature = "clock-8mhz")]
+pub const CPU_HZ: u32 = 8_000_000;
+
+/// Initializes the HAL and returns its peripheral ownership tokens.
+///
+/// # Panics
+///
+/// Panics if the HAL or the underlying PAC has already been taken.
+pub fn init() -> Peripherals {
+    try_init().expect("embassy-atmega328p is already initialized")
+}
+
+/// Attempts to initialize the HAL.
+///
+/// Returns `None` if the HAL or the underlying PAC has already been taken.
+pub fn try_init() -> Option<Peripherals> {
+    avr_device::atmega328p::Peripherals::take().map(|_| {
+        #[cfg(any(feature = "time-driver-16mhz", feature = "time-driver-8mhz"))]
+        time_driver::init();
+
+        Peripherals::new()
+    })
+}

--- a/embassy-atmega328p/src/onewire.rs
+++ b/embassy-atmega328p/src/onewire.rs
@@ -1,0 +1,145 @@
+//! Blocking Dallas/Maxim 1-Wire bus using any GPIO pin.
+
+use core::ptr::{read_volatile, write_volatile};
+
+use crate::gpio::Pin;
+
+/// Bit-banged 1-Wire master.
+///
+/// The bus requires an external pull-up resistor, normally about 4.7 kOhm.
+/// Timing-critical slots temporarily disable interrupts.
+pub struct OneWire<P: Pin> {
+    pin: P,
+}
+
+impl<P: Pin> OneWire<P> {
+    /// Creates a 1-Wire bus and releases the line to the external pull-up.
+    pub fn new(pin: P) -> Self {
+        avr_device::interrupt::free(|_| release::<P>());
+        Self { pin }
+    }
+
+    /// Sends a reset pulse and returns whether a presence pulse was detected.
+    pub fn reset(&mut self) -> bool {
+        avr_device::interrupt::free(|_| {
+            drive_low::<P>();
+            delay_us(480);
+            release::<P>();
+            delay_us(70);
+            let present = !read_level::<P>();
+            delay_us(410);
+            present
+        })
+    }
+
+    /// Writes one least-significant-bit-first bus bit.
+    pub fn write_bit(&mut self, bit: bool) {
+        avr_device::interrupt::free(|_| {
+            drive_low::<P>();
+            if bit {
+                delay_us(6);
+                release::<P>();
+                delay_us(64);
+            } else {
+                delay_us(60);
+                release::<P>();
+                delay_us(10);
+            }
+        });
+    }
+
+    /// Reads one bus bit.
+    pub fn read_bit(&mut self) -> bool {
+        avr_device::interrupt::free(|_| {
+            drive_low::<P>();
+            delay_us(6);
+            release::<P>();
+            delay_us(9);
+            let bit = read_level::<P>();
+            delay_us(55);
+            bit
+        })
+    }
+
+    /// Writes one byte, least-significant bit first.
+    pub fn write_byte(&mut self, byte: u8) {
+        for bit in 0..8 {
+            self.write_bit(byte & (1 << bit) != 0);
+        }
+    }
+
+    /// Reads one byte, least-significant bit first.
+    pub fn read_byte(&mut self) -> u8 {
+        let mut byte = 0;
+        for bit in 0..8 {
+            if self.read_bit() {
+                byte |= 1 << bit;
+            }
+        }
+        byte
+    }
+
+    /// Sends the Skip ROM command (`0xCC`).
+    pub fn skip_rom(&mut self) {
+        self.write_byte(0xcc);
+    }
+
+    /// Selects one device by its eight-byte ROM code.
+    pub fn match_rom(&mut self, rom: &[u8; 8]) {
+        self.write_byte(0x55);
+        for &byte in rom {
+            self.write_byte(byte);
+        }
+    }
+
+    /// Releases and returns the owned GPIO pin.
+    pub fn free(self) -> P {
+        avr_device::interrupt::free(|_| release::<P>());
+        self.pin
+    }
+}
+
+/// Computes the Dallas/Maxim CRC-8 used by 1-Wire devices.
+pub fn crc8(bytes: &[u8]) -> u8 {
+    let mut crc = 0u8;
+    for &byte in bytes {
+        let mut value = byte;
+        for _ in 0..8 {
+            let mix = (crc ^ value) & 1;
+            crc >>= 1;
+            if mix != 0 {
+                crc ^= 0x8c;
+            }
+            value >>= 1;
+        }
+    }
+    crc
+}
+
+fn drive_low<P: Pin>() {
+    unsafe {
+        modify(P::PORT, P::MASK, false);
+        modify(P::DDR, P::MASK, true);
+    }
+}
+
+fn release<P: Pin>() {
+    unsafe {
+        modify(P::DDR, P::MASK, false);
+        modify(P::PORT, P::MASK, false);
+    }
+}
+
+fn read_level<P: Pin>() -> bool {
+    unsafe { read_volatile(P::PIN) & P::MASK != 0 }
+}
+
+fn delay_us(us: u32) {
+    avr_device::asm::delay_cycles(us.saturating_mul(crate::CPU_HZ / 1_000_000));
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/pwm.rs
+++ b/embassy-atmega328p/src/pwm.rs
@@ -1,0 +1,201 @@
+//! Fast-PWM outputs backed by Timer0 and Timer2.
+
+use core::ptr::{read_volatile, write_volatile};
+
+use crate::gpio::{PB3, PD3, PD5, PD6};
+
+const DDRB: *mut u8 = 0x24 as *mut u8;
+const DDRD: *mut u8 = 0x2a as *mut u8;
+const TCCR0A: *mut u8 = 0x44 as *mut u8;
+const TCCR0B: *mut u8 = 0x45 as *mut u8;
+const OCR0A: *mut u8 = 0x47 as *mut u8;
+const OCR0B: *mut u8 = 0x48 as *mut u8;
+const TCCR2A: *mut u8 = 0xb0 as *mut u8;
+const TCCR2B: *mut u8 = 0xb1 as *mut u8;
+const OCR2A: *mut u8 = 0xb3 as *mut u8;
+const OCR2B: *mut u8 = 0xb4 as *mut u8;
+
+const COM_A1: u8 = 1 << 7;
+const COM_B1: u8 = 1 << 5;
+const WGM_8BIT_FAST: u8 = (1 << 1) | (1 << 0);
+
+/// Ownership token for Timer0.
+pub struct Timer0 {
+    _private: (),
+}
+
+impl Timer0 {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// Ownership token for Timer2.
+pub struct Timer2 {
+    _private: (),
+}
+
+impl Timer2 {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// Timer0 clock prescaler.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Timer0Prescaler {
+    Div1 = 1,
+    Div8 = 2,
+    Div64 = 3,
+    Div256 = 4,
+    Div1024 = 5,
+}
+
+impl Timer0Prescaler {
+    const fn divisor(self) -> u32 {
+        match self {
+            Self::Div1 => 1,
+            Self::Div8 => 8,
+            Self::Div64 => 64,
+            Self::Div256 => 256,
+            Self::Div1024 => 1024,
+        }
+    }
+}
+
+/// Timer2 clock prescaler.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum Timer2Prescaler {
+    Div1 = 1,
+    Div8 = 2,
+    Div32 = 3,
+    Div64 = 4,
+    Div128 = 5,
+    Div256 = 6,
+    Div1024 = 7,
+}
+
+impl Timer2Prescaler {
+    const fn divisor(self) -> u32 {
+        match self {
+            Self::Div1 => 1,
+            Self::Div8 => 8,
+            Self::Div32 => 32,
+            Self::Div64 => 64,
+            Self::Div128 => 128,
+            Self::Div256 => 256,
+            Self::Div1024 => 1024,
+        }
+    }
+}
+
+/// Two-channel 8-bit PWM using Timer0: channel A on PD6, channel B on PD5.
+pub struct Pwm0 {
+    timer: Timer0,
+    channel_a: PD6,
+    channel_b: PD5,
+    prescaler: Timer0Prescaler,
+}
+
+impl Pwm0 {
+    /// Starts Timer0 in non-inverting fast-PWM mode.
+    pub fn new(timer: Timer0, channel_a: PD6, channel_b: PD5, prescaler: Timer0Prescaler) -> Self {
+        avr_device::interrupt::free(|_| unsafe {
+            modify(DDRD, (1 << 6) | (1 << 5), true);
+            write_volatile(OCR0A, 0);
+            write_volatile(OCR0B, 0);
+            write_volatile(TCCR0A, COM_A1 | COM_B1 | WGM_8BIT_FAST);
+            write_volatile(TCCR0B, prescaler as u8);
+        });
+        Self {
+            timer,
+            channel_a,
+            channel_b,
+            prescaler,
+        }
+    }
+
+    /// Sets channel A (PD6) duty, from 0 to 255.
+    pub fn set_duty_a(&mut self, duty: u8) {
+        unsafe { write_volatile(OCR0A, duty) };
+    }
+
+    /// Sets channel B (PD5) duty, from 0 to 255.
+    pub fn set_duty_b(&mut self, duty: u8) {
+        unsafe { write_volatile(OCR0B, duty) };
+    }
+
+    /// Returns the fast-PWM repetition frequency.
+    pub const fn frequency_hz(&self) -> u32 {
+        crate::CPU_HZ / self.prescaler.divisor() / 256
+    }
+
+    /// Stops Timer0 and returns its ownership tokens.
+    pub fn free(self) -> (Timer0, PD6, PD5) {
+        unsafe {
+            write_volatile(TCCR0A, 0);
+            write_volatile(TCCR0B, 0);
+        }
+        (self.timer, self.channel_a, self.channel_b)
+    }
+}
+
+/// Two-channel 8-bit PWM using Timer2: channel A on PB3, channel B on PD3.
+pub struct Pwm2 {
+    timer: Timer2,
+    channel_a: PB3,
+    channel_b: PD3,
+    prescaler: Timer2Prescaler,
+}
+
+impl Pwm2 {
+    /// Starts Timer2 in non-inverting fast-PWM mode.
+    pub fn new(timer: Timer2, channel_a: PB3, channel_b: PD3, prescaler: Timer2Prescaler) -> Self {
+        avr_device::interrupt::free(|_| unsafe {
+            modify(DDRB, 1 << 3, true);
+            modify(DDRD, 1 << 3, true);
+            write_volatile(OCR2A, 0);
+            write_volatile(OCR2B, 0);
+            write_volatile(TCCR2A, COM_A1 | COM_B1 | WGM_8BIT_FAST);
+            write_volatile(TCCR2B, prescaler as u8);
+        });
+        Self {
+            timer,
+            channel_a,
+            channel_b,
+            prescaler,
+        }
+    }
+
+    /// Sets channel A (PB3) duty, from 0 to 255.
+    pub fn set_duty_a(&mut self, duty: u8) {
+        unsafe { write_volatile(OCR2A, duty) };
+    }
+
+    /// Sets channel B (PD3) duty, from 0 to 255.
+    pub fn set_duty_b(&mut self, duty: u8) {
+        unsafe { write_volatile(OCR2B, duty) };
+    }
+
+    /// Returns the fast-PWM repetition frequency.
+    pub const fn frequency_hz(&self) -> u32 {
+        crate::CPU_HZ / self.prescaler.divisor() / 256
+    }
+
+    /// Stops Timer2 and returns its ownership tokens.
+    pub fn free(self) -> (Timer2, PB3, PD3) {
+        unsafe {
+            write_volatile(TCCR2A, 0);
+            write_volatile(TCCR2B, 0);
+        }
+        (self.timer, self.channel_a, self.channel_b)
+    }
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/spi.rs
+++ b/embassy-atmega328p/src/spi.rs
@@ -1,0 +1,203 @@
+//! Blocking SPI master driver.
+
+use core::convert::Infallible;
+use core::ptr::{read_volatile, write_volatile};
+
+use embedded_hal::spi::{ErrorType, MODE_0, Mode, Phase, Polarity, SpiBus};
+
+use crate::gpio::{PB2, PB3, PB4, PB5};
+
+const DDRB: *mut u8 = 0x24 as *mut u8;
+const PORTB: *mut u8 = 0x25 as *mut u8;
+const SPCR: *mut u8 = 0x4c as *mut u8;
+const SPSR: *mut u8 = 0x4d as *mut u8;
+const SPDR: *mut u8 = 0x4e as *mut u8;
+
+const SPE: u8 = 1 << 6;
+const DORD: u8 = 1 << 5;
+const MSTR: u8 = 1 << 4;
+const CPOL: u8 = 1 << 3;
+const CPHA: u8 = 1 << 2;
+const SPIF: u8 = 1 << 7;
+const SPI2X: u8 = 1 << 0;
+
+/// Ownership token for the SPI peripheral.
+pub struct SpiPeripheral {
+    _private: (),
+}
+
+impl SpiPeripheral {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// SPI bit transmission order.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BitOrder {
+    MostSignificantFirst,
+    LeastSignificantFirst,
+}
+
+/// SPI configuration error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfigError {
+    InvalidFrequency,
+}
+
+/// SPI master configuration.
+#[derive(Clone, Copy, Debug)]
+pub struct Config {
+    pub frequency_hz: u32,
+    pub mode: Mode,
+    pub bit_order: BitOrder,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            frequency_hz: 1_000_000,
+            mode: MODE_0,
+            bit_order: BitOrder::MostSignificantFirst,
+        }
+    }
+}
+
+/// Blocking SPI master using PB2/SS, PB3/MOSI, PB4/MISO and PB5/SCK.
+pub struct Spi {
+    peripheral: SpiPeripheral,
+    ss: PB2,
+    mosi: PB3,
+    miso: PB4,
+    sck: PB5,
+}
+
+impl Spi {
+    /// Configures the hardware SPI master at or below `frequency_hz`.
+    pub fn new(
+        peripheral: SpiPeripheral,
+        ss: PB2,
+        mosi: PB3,
+        miso: PB4,
+        sck: PB5,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        let (spr, double_speed) = divider_bits(config.frequency_hz)?;
+        let mut control = SPE | MSTR | spr;
+        if config.bit_order == BitOrder::LeastSignificantFirst {
+            control |= DORD;
+        }
+        if config.mode.polarity == Polarity::IdleHigh {
+            control |= CPOL;
+        }
+        if config.mode.phase == Phase::CaptureOnSecondTransition {
+            control |= CPHA;
+        }
+
+        avr_device::interrupt::free(|_| unsafe {
+            // Keep SS as a driven-high output so the peripheral remains master.
+            modify(PORTB, 1 << 2, true);
+            modify(DDRB, (1 << 2) | (1 << 3) | (1 << 5), true);
+            modify(DDRB, 1 << 4, false);
+            modify(PORTB, 1 << 5, config.mode.polarity == Polarity::IdleHigh);
+            write_volatile(SPCR, control);
+            write_volatile(SPSR, if double_speed { SPI2X } else { 0 });
+        });
+
+        Ok(Self {
+            peripheral,
+            ss,
+            mosi,
+            miso,
+            sck,
+        })
+    }
+
+    /// Exchanges one byte with the selected slave.
+    pub fn transfer_byte(&mut self, byte: u8) -> u8 {
+        unsafe {
+            write_volatile(SPDR, byte);
+            while read_volatile(SPSR) & SPIF == 0 {}
+            read_volatile(SPDR)
+        }
+    }
+
+    /// Disables SPI and returns its ownership tokens.
+    pub fn free(self) -> (SpiPeripheral, PB2, PB3, PB4, PB5) {
+        unsafe { write_volatile(SPCR, 0) };
+        (self.peripheral, self.ss, self.mosi, self.miso, self.sck)
+    }
+}
+
+impl ErrorType for Spi {
+    type Error = Infallible;
+}
+
+impl SpiBus<u8> for Spi {
+    fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        for word in words {
+            *word = self.transfer_byte(0);
+        }
+        Ok(())
+    }
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        for &word in words {
+            self.transfer_byte(word);
+        }
+        Ok(())
+    }
+
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        let count = read.len().max(write.len());
+        for index in 0..count {
+            let received = self.transfer_byte(write.get(index).copied().unwrap_or(0));
+            if let Some(slot) = read.get_mut(index) {
+                *slot = received;
+            }
+        }
+        Ok(())
+    }
+
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        for word in words {
+            *word = self.transfer_byte(*word);
+        }
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+fn divider_bits(frequency_hz: u32) -> Result<(u8, bool), ConfigError> {
+    if frequency_hz == 0 {
+        return Err(ConfigError::InvalidFrequency);
+    }
+    let required = crate::CPU_HZ.div_ceil(frequency_hz);
+    let result = if required <= 2 {
+        (0b00, true)
+    } else if required <= 4 {
+        (0b00, false)
+    } else if required <= 8 {
+        (0b01, true)
+    } else if required <= 16 {
+        (0b01, false)
+    } else if required <= 32 {
+        (0b10, true)
+    } else if required <= 64 {
+        (0b10, false)
+    } else if required <= 128 {
+        (0b11, false)
+    } else {
+        return Err(ConfigError::InvalidFrequency);
+    };
+    Ok(result)
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/time_driver.rs
+++ b/embassy-atmega328p/src/time_driver.rs
@@ -1,0 +1,204 @@
+//! Embassy time driver backed by the 16-bit Timer/Counter1.
+
+use core::cell::{Cell, RefCell};
+use core::ptr::{read_volatile, write_volatile};
+use core::task::Waker;
+
+use avr_device::interrupt::{CriticalSection, Mutex};
+use embassy_time_driver::Driver;
+use embassy_time_queue_utils::queue_generic::ConstGenericQueue;
+
+#[cfg(all(feature = "time-driver-16mhz", feature = "time-driver-8mhz"))]
+compile_error!("enable only one ATmega328P time-driver clock feature");
+
+// Timer1 registers in the ATmega328P data address space.
+const TIFR1: *mut u8 = 0x36 as *mut u8;
+const TCCR1A: *mut u8 = 0x80 as *mut u8;
+const TCCR1B: *mut u8 = 0x81 as *mut u8;
+const TCNT1L: *mut u8 = 0x84 as *mut u8;
+const TCNT1H: *mut u8 = 0x85 as *mut u8;
+const OCR1AL: *mut u8 = 0x88 as *mut u8;
+const OCR1AH: *mut u8 = 0x89 as *mut u8;
+const TIMSK1: *mut u8 = 0x6f as *mut u8;
+
+const TOV1: u8 = 1 << 0;
+const OCF1A: u8 = 1 << 1;
+const TOIE1: u8 = 1 << 0;
+const OCIE1A: u8 = 1 << 1;
+const CS11: u8 = 1 << 1;
+
+const COUNTER_RANGE: u64 = 1 << 16;
+const QUEUE_SIZE: usize = 8;
+
+struct Timer1Driver {
+    initialized: Mutex<Cell<bool>>,
+    overflows: Mutex<Cell<u64>>,
+    queue: Mutex<RefCell<ConstGenericQueue<QUEUE_SIZE>>>,
+}
+
+embassy_time_driver::time_driver_impl!(static DRIVER: Timer1Driver = Timer1Driver {
+    initialized: Mutex::new(Cell::new(false)),
+    overflows: Mutex::new(Cell::new(0)),
+    queue: Mutex::new(RefCell::new(ConstGenericQueue::new())),
+});
+
+impl Driver for Timer1Driver {
+    fn now(&self) -> u64 {
+        avr_device::interrupt::free(|cs| self.now_locked(cs))
+    }
+
+    fn schedule_wake(&self, at: u64, waker: &Waker) {
+        avr_device::interrupt::free(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now_locked(cs));
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now_locked(cs));
+                }
+            }
+        });
+    }
+}
+
+impl Timer1Driver {
+    fn now_locked(&self, cs: CriticalSection<'_>) -> u64 {
+        if !self.initialized.borrow(cs).get() {
+            return 0;
+        }
+
+        let high = self.overflows.borrow(cs).get();
+        let low = read_counter();
+
+        // If the counter wrapped while interrupts were disabled, the overflow
+        // ISR has not updated `overflows` yet. Account for the pending flag.
+        if unsafe { read_volatile(TIFR1) } & TOV1 != 0 {
+            let low = read_counter();
+            (high + COUNTER_RANGE) | u64::from(low)
+        } else {
+            high | u64::from(low)
+        }
+    }
+
+    fn set_alarm(&self, cs: CriticalSection<'_>, timestamp: u64) -> bool {
+        let now = self.now_locked(cs);
+        if timestamp <= now {
+            disable_compare_interrupt();
+            return false;
+        }
+
+        // A 16-bit compare value is only unambiguous within the current
+        // counter cycle. For farther deadlines, the overflow ISR retries.
+        if timestamp - now >= COUNTER_RANGE {
+            disable_compare_interrupt();
+            return true;
+        }
+
+        write_compare(timestamp as u16);
+        unsafe {
+            // Clear a stale compare flag before enabling its interrupt.
+            write_volatile(TIFR1, OCF1A);
+            modify(TIMSK1, OCIE1A, true);
+        }
+
+        // The counter may have passed the compare value during programming.
+        if timestamp <= self.now_locked(cs) {
+            disable_compare_interrupt();
+            false
+        } else {
+            true
+        }
+    }
+
+    #[cfg(target_arch = "avr")]
+    fn trigger_alarm(&self, cs: CriticalSection<'_>) {
+        let mut queue = self.queue.borrow(cs).borrow_mut();
+        let mut next = queue.next_expiration(self.now_locked(cs));
+        while !self.set_alarm(cs, next) {
+            next = queue.next_expiration(self.now_locked(cs));
+        }
+    }
+
+    #[cfg(target_arch = "avr")]
+    fn on_overflow(&self) {
+        avr_device::interrupt::free(|cs| {
+            let high = self.overflows.borrow(cs);
+            high.set(high.get() + COUNTER_RANGE);
+            self.trigger_alarm(cs);
+        });
+    }
+
+    #[cfg(target_arch = "avr")]
+    fn on_compare(&self) {
+        avr_device::interrupt::free(|cs| {
+            disable_compare_interrupt();
+            self.trigger_alarm(cs);
+        });
+    }
+}
+
+pub(crate) fn init() {
+    avr_device::interrupt::free(|cs| unsafe {
+        // Normal mode, stopped while configuring.
+        write_volatile(TCCR1A, 0);
+        write_volatile(TCCR1B, 0);
+        write_counter(0);
+        write_compare(0);
+        write_volatile(TIFR1, TOV1 | OCF1A);
+        write_volatile(TIMSK1, TOIE1);
+
+        DRIVER.overflows.borrow(cs).set(0);
+        DRIVER.initialized.borrow(cs).set(true);
+
+        // Start Timer1 with a /8 prescaler. This produces a 2 MHz timebase at
+        // 16 MHz CPU clock, or a 1 MHz timebase at 8 MHz CPU clock.
+        write_volatile(TCCR1B, CS11);
+    });
+}
+
+#[cfg(target_arch = "avr")]
+#[avr_device::interrupt(atmega328p)]
+fn TIMER1_OVF() {
+    DRIVER.on_overflow();
+}
+
+#[cfg(target_arch = "avr")]
+#[avr_device::interrupt(atmega328p)]
+fn TIMER1_COMPA() {
+    DRIVER.on_compare();
+}
+
+fn read_counter() -> u16 {
+    unsafe {
+        // Reading the low byte latches the high byte on classic AVR timers.
+        let low = read_volatile(TCNT1L);
+        let high = read_volatile(TCNT1H);
+        u16::from_le_bytes([low, high])
+    }
+}
+
+unsafe fn write_counter(value: u16) {
+    let [low, high] = value.to_le_bytes();
+    unsafe {
+        // For 16-bit timer writes, the high byte must be written first.
+        write_volatile(TCNT1H, high);
+        write_volatile(TCNT1L, low);
+    }
+}
+
+fn write_compare(value: u16) {
+    let [low, high] = value.to_le_bytes();
+    unsafe {
+        write_volatile(OCR1AH, high);
+        write_volatile(OCR1AL, low);
+    }
+}
+
+fn disable_compare_interrupt() {
+    unsafe { modify(TIMSK1, OCIE1A, false) }
+}
+
+unsafe fn modify(register: *mut u8, mask: u8, set: bool) {
+    let current = unsafe { read_volatile(register) };
+    let value = if set { current | mask } else { current & !mask };
+    unsafe { write_volatile(register, value) };
+}

--- a/embassy-atmega328p/src/usart.rs
+++ b/embassy-atmega328p/src/usart.rs
@@ -1,0 +1,137 @@
+//! Blocking USART0 driver.
+
+use core::fmt;
+use core::ptr::{read_volatile, write_volatile};
+
+use crate::gpio::{PD0, PD1};
+
+const UCSR0A: *mut u8 = 0xc0 as *mut u8;
+const UCSR0B: *mut u8 = 0xc1 as *mut u8;
+const UCSR0C: *mut u8 = 0xc2 as *mut u8;
+const UBRR0L: *mut u8 = 0xc4 as *mut u8;
+const UBRR0H: *mut u8 = 0xc5 as *mut u8;
+const UDR0: *mut u8 = 0xc6 as *mut u8;
+
+const RXC0: u8 = 1 << 7;
+const UDRE0: u8 = 1 << 5;
+const FE0: u8 = 1 << 4;
+const DOR0: u8 = 1 << 3;
+const UPE0: u8 = 1 << 2;
+const U2X0: u8 = 1 << 1;
+const RXEN0: u8 = 1 << 4;
+const TXEN0: u8 = 1 << 3;
+const UCSZ01: u8 = 1 << 2;
+const UCSZ00: u8 = 1 << 1;
+
+/// Ownership token for USART0.
+pub struct Usart0Peripheral {
+    _private: (),
+}
+
+impl Usart0Peripheral {
+    pub(crate) const fn new() -> Self {
+        Self { _private: () }
+    }
+}
+
+/// USART configuration error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ConfigError {
+    /// The requested baud rate cannot be represented by the hardware divider.
+    InvalidBaudRate,
+}
+
+/// USART receive error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Error {
+    Framing,
+    DataOverrun,
+    Parity,
+}
+
+/// Blocking 8-data-bit, no-parity, one-stop-bit USART0.
+pub struct Usart {
+    peripheral: Usart0Peripheral,
+    rx: PD0,
+    tx: PD1,
+}
+
+impl Usart {
+    /// Configures USART0 in double-speed asynchronous mode.
+    pub fn new(peripheral: Usart0Peripheral, rx: PD0, tx: PD1, baud: u32) -> Result<Self, ConfigError> {
+        if baud == 0 {
+            return Err(ConfigError::InvalidBaudRate);
+        }
+
+        let divisor = (u64::from(crate::CPU_HZ) + u64::from(baud) * 4) / (u64::from(baud) * 8);
+        if divisor == 0 || divisor > 4096 {
+            return Err(ConfigError::InvalidBaudRate);
+        }
+        let ubrr = (divisor - 1) as u16;
+        let [low, high] = ubrr.to_le_bytes();
+
+        unsafe {
+            write_volatile(UCSR0A, U2X0);
+            write_volatile(UBRR0H, high & 0x0f);
+            write_volatile(UBRR0L, low);
+            write_volatile(UCSR0C, UCSZ01 | UCSZ00);
+            write_volatile(UCSR0B, RXEN0 | TXEN0);
+        }
+
+        Ok(Self { peripheral, rx, tx })
+    }
+
+    /// Writes one byte, blocking until the transmit register is available.
+    pub fn write_byte(&mut self, byte: u8) {
+        unsafe {
+            while read_volatile(UCSR0A) & UDRE0 == 0 {}
+            write_volatile(UDR0, byte);
+        }
+    }
+
+    /// Reads one byte, blocking until data arrives.
+    pub fn read_byte(&mut self) -> Result<u8, Error> {
+        unsafe {
+            while read_volatile(UCSR0A) & RXC0 == 0 {}
+            self.read_ready()
+        }
+    }
+
+    /// Reads a byte without blocking, returning `None` if no byte is ready.
+    pub fn try_read(&mut self) -> Option<Result<u8, Error>> {
+        if unsafe { read_volatile(UCSR0A) } & RXC0 == 0 {
+            None
+        } else {
+            Some(unsafe { self.read_ready() })
+        }
+    }
+
+    /// Disables USART0 and returns the peripheral and pin tokens.
+    pub fn free(self) -> (Usart0Peripheral, PD0, PD1) {
+        unsafe { write_volatile(UCSR0B, 0) };
+        (self.peripheral, self.rx, self.tx)
+    }
+
+    unsafe fn read_ready(&mut self) -> Result<u8, Error> {
+        let status = unsafe { read_volatile(UCSR0A) };
+        let data = unsafe { read_volatile(UDR0) };
+        if status & FE0 != 0 {
+            Err(Error::Framing)
+        } else if status & DOR0 != 0 {
+            Err(Error::DataOverrun)
+        } else if status & UPE0 != 0 {
+            Err(Error::Parity)
+        } else {
+            Ok(data)
+        }
+    }
+}
+
+impl fmt::Write for Usart {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        for byte in value.bytes() {
+            self.write_byte(byte);
+        }
+        Ok(())
+    }
+}

--- a/examples/atmega328p/.cargo/config.toml
+++ b/examples/atmega328p/.cargo/config.toml
@@ -1,0 +1,8 @@
+[build]
+target = "avr-none"
+
+[unstable]
+build-std = ["core"]
+
+[target.avr-none]
+rustflags = ["-C", "target-cpu=atmega328p"]

--- a/examples/atmega328p/Cargo.toml
+++ b/examples/atmega328p/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [package.metadata.embassy]
 build = [
-    { target = "avr-none", artifact-dir = "out/examples/atmega328p", build-std = ["core"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" } },
+    { group = "nightly", target = "avr-none", artifact-dir = "out/examples/atmega328p", build-std = ["core"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" } },
 ]
 
 [dependencies]

--- a/examples/atmega328p/Cargo.toml
+++ b/examples/atmega328p/Cargo.toml
@@ -7,7 +7,9 @@ publish = false
 
 [package.metadata.embassy]
 build = [
-    { group = "nightly", target = "avr-none", artifact-dir = "out/examples/atmega328p", build-std = ["core"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" } },
+    # The default Embassy CI image does not currently provide avr-gcc. Keep
+    # AVR binaries in a separate group until that linker is available there.
+    { group = "avr", target = "avr-none", artifact-dir = "out/examples/atmega328p", build-std = ["core"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" } },
 ]
 
 [dependencies]

--- a/examples/atmega328p/Cargo.toml
+++ b/examples/atmega328p/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "embassy-atmega328p-examples"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[package.metadata.embassy]
+build = [
+    { target = "avr-none", artifact-dir = "out/examples/atmega328p", build-std = ["core"], env = { RUSTFLAGS = "-Ctarget-cpu=atmega328p" } },
+]
+
+[dependencies]
+avr-device = { version = "0.8.1", features = ["atmega328p", "rt"] }
+embassy-atmega328p = { path = "../../embassy-atmega328p", features = ["time-driver-16mhz"] }
+embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["nightly", "platform-avr", "executor-thread"] }
+embassy-time = { version = "0.5.1", path = "../../embassy-time" }
+embedded-hal = "1.0"
+panic-halt = "1.0"
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/examples/atmega328p/README.md
+++ b/examples/atmega328p/README.md
@@ -1,0 +1,58 @@
+# ATmega328P examples
+
+These examples exercise the `embassy-atmega328p` HAL on an ATmega328P. The
+default configuration assumes a 16 MHz CPU clock, as used by a classic Arduino
+Uno or Nano.
+
+## Prerequisites
+
+- a Rust nightly toolchain with the `rust-src` component;
+- an AVR GNU toolchain providing `avr-gcc` and `avr-objcopy`;
+- `avrdude`, or another programmer supported by the board.
+
+The local `.cargo/config.toml` selects `avr-none`, builds `core`, and sets the
+CPU to `atmega328p`. Run Cargo commands from this directory so that Cargo loads
+that configuration.
+
+## Check all examples
+
+```console
+cargo +nightly check --bins
+```
+
+## Build one example
+
+```console
+cargo +nightly build --release --bin async_blinky
+avr-objcopy -O ihex -R .eeprom target/avr-none/release/async_blinky.elf async_blinky.hex
+```
+
+Available binaries are `async_blinky`, `adc`, `i2c`, `onewire`, `pwm`, `spi`,
+and `usart`.
+
+## Upload through an Arduino-compatible bootloader
+
+Replace `COM5` with the board's serial port. A classic Uno bootloader commonly
+uses 115200 baud:
+
+```console
+avrdude -p atmega328p -c arduino -P COM5 -b 115200 -D -U flash:w:async_blinky.hex:i
+```
+
+Some classic Nano bootloaders use 57600 baud instead. Boards programmed over
+ISP require the matching `avrdude` programmer option rather than `-c arduino`.
+
+## Clock selection
+
+The examples depend on the HAL's `time-driver-16mhz` feature. For a board that
+actually runs at 8 MHz, change that dependency to disable default features and
+enable `time-driver-8mhz`. The selected frequency must match the clock source
+and fuse configuration.
+
+## Hardware notes
+
+- `async_blinky` drives PB5, the built-in LED pin on a classic Uno.
+- I2C requires external pull-up resistors on PC4/SDA and PC5/SCL.
+- 1-Wire normally requires an external 4.7 kOhm pull-up resistor.
+- PC6 is RESET with the factory fuse configuration and is not a normal GPIO
+  unless the reset-disable fuse is deliberately programmed.

--- a/examples/atmega328p/src/bin/adc.rs
+++ b/examples/atmega328p/src/bin/adc.rs
@@ -1,0 +1,16 @@
+#![no_std]
+#![no_main]
+
+use embassy_atmega328p::adc::{Adc, Reference};
+use panic_halt as _;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut input = p.PC0;
+    let mut adc = Adc::new(p.ADC, Reference::Avcc);
+
+    loop {
+        let _sample = adc.read(&mut input);
+    }
+}

--- a/examples/atmega328p/src/bin/async_blinky.rs
+++ b/examples/atmega328p/src/bin/async_blinky.rs
@@ -1,0 +1,19 @@
+#![no_std]
+#![no_main]
+#![feature(impl_trait_in_assoc_type)]
+
+use embassy_atmega328p::gpio::{Level, Output};
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_halt as _;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_atmega328p::init();
+    let mut led = Output::new(p.PB5, Level::Low);
+
+    loop {
+        led.toggle();
+        Timer::after_millis(500).await;
+    }
+}

--- a/examples/atmega328p/src/bin/i2c.rs
+++ b/examples/atmega328p/src/bin/i2c.rs
@@ -1,0 +1,18 @@
+#![no_std]
+#![no_main]
+
+use embassy_atmega328p::i2c::I2c;
+use embedded_hal::i2c::I2c as _;
+use panic_halt as _;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut i2c = I2c::new(p.TWI, p.PC4, p.PC5, 100_000).unwrap();
+    let mut byte = [0u8; 1];
+
+    loop {
+        // Replace the address/register with those of the connected device.
+        let _ = i2c.write_read(0x50, &[0x00], &mut byte);
+    }
+}

--- a/examples/atmega328p/src/bin/onewire.rs
+++ b/examples/atmega328p/src/bin/onewire.rs
@@ -1,0 +1,31 @@
+#![no_std]
+#![no_main]
+
+use embassy_atmega328p::delay::Delay;
+use embassy_atmega328p::onewire::{OneWire, crc8};
+use panic_halt as _;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut bus = OneWire::new(p.PD2);
+    let mut delay = Delay::new();
+
+    loop {
+        if bus.reset() {
+            bus.skip_rom();
+            bus.write_byte(0x44); // DS18B20: Convert T
+            delay.delay_ms(750);
+
+            if bus.reset() {
+                bus.skip_rom();
+                bus.write_byte(0xbe); // Read Scratchpad
+                let mut scratchpad = [0u8; 9];
+                for byte in &mut scratchpad {
+                    *byte = bus.read_byte();
+                }
+                let _valid = crc8(&scratchpad[..8]) == scratchpad[8];
+            }
+        }
+    }
+}

--- a/examples/atmega328p/src/bin/pwm.rs
+++ b/examples/atmega328p/src/bin/pwm.rs
@@ -1,0 +1,21 @@
+#![no_std]
+#![no_main]
+
+use embassy_atmega328p::delay::Delay;
+use embassy_atmega328p::pwm::{Pwm0, Timer0Prescaler};
+use panic_halt as _;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut pwm = Pwm0::new(p.TIMER0, p.PD6, p.PD5, Timer0Prescaler::Div64);
+    let mut delay = Delay::new();
+
+    loop {
+        for duty in 0..=u8::MAX {
+            pwm.set_duty_a(duty);
+            pwm.set_duty_b(u8::MAX - duty);
+            delay.delay_ms(4);
+        }
+    }
+}

--- a/examples/atmega328p/src/bin/spi.rs
+++ b/examples/atmega328p/src/bin/spi.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use embassy_atmega328p::gpio::{Level, Output};
+use embassy_atmega328p::spi::{Config, Spi};
+use embedded_hal::spi::SpiBus;
+use panic_halt as _;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut spi = Spi::new(p.SPI, p.PB2, p.PB3, p.PB4, p.PB5, Config::default()).unwrap();
+    let mut chip_select = Output::new(p.PD7, Level::High);
+
+    loop {
+        chip_select.set_low();
+        let _ = spi.write(&[0x9f]);
+        chip_select.set_high();
+    }
+}

--- a/examples/atmega328p/src/bin/usart.rs
+++ b/examples/atmega328p/src/bin/usart.rs
@@ -1,0 +1,20 @@
+#![no_std]
+#![no_main]
+
+use core::fmt::Write;
+
+use embassy_atmega328p::usart::Usart;
+use panic_halt as _;
+
+#[avr_device::entry]
+fn main() -> ! {
+    let p = embassy_atmega328p::init();
+    let mut usart = Usart::new(p.USART0, p.PD0, p.PD1, 115_200).unwrap();
+    writeln!(usart, "Hello from Embassy on ATmega328P!").unwrap();
+
+    loop {
+        if let Ok(byte) = usart.read_byte() {
+            usart.write_byte(byte);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds initial Embassy-compatible HAL support for the ATmega328P.

The implementation currently includes:

- GPIO for ports B, C and D
- Timer1-based Embassy time driver
- blocking ADC, I2C, SPI and USART drivers
- Timer0 and Timer2 PWM
- bit-banged 1-Wire support
- ATmega328P examples, including async blinky
- 8 MHz and 16 MHz clock configurations

## Current validation

- Host cargo check passes
- Clippy with warnings denied passes
- All AVR examples pass cargo check for `avr-none`
- 8 MHz and 16 MHz configurations compile

## Remaining validation

- Final linking with avr-gcc
- Flashing and testing on real ATmega328P hardware
- Peripheral hardware validation

This draft PR is also intended to request feedback on whether the HAL
should remain ATmega328P-specific or evolve into a broader `embassy-avr`
crate.