### PR TITLE
embassy-stm32/low-power: add stm32f4 support

### DIFF
--- a/embassy-stm32/src/low_power.rs
+++ b/embassy-stm32/src/low_power.rs
@@ -164,6 +164,12 @@ mod platform {
             });
         }
 
+        #[cfg(stm32f4)]
+        crate::pac::PWR.cr1().modify(|w| {
+            w.set_pdds(crate::pac::pwr::vals::Pdds::StopMode);
+            w.set_lpds(true);
+        });
+
         #[cfg(stm32wb)]
         drop(mutex);
 
@@ -217,7 +223,7 @@ mod platform {
             crate::pac::PWR.sr().modify(|w| w.set_cssf(true));
         }
 
-        #[cfg(any(stm32wl, stm32wb, stm32wba))]
+        #[cfg(any(stm32wl, stm32wb, stm32wba, stm32f4))]
         {
             // stm32wl5x is dual core and we don't want BOTH cores to re-initialize RCC so we hold a lock
             #[cfg(stm32wl5x)]
@@ -230,7 +236,7 @@ mod platform {
             let es = crate::pac::PWR.sr().read();
 
             // we need to re-initialize RCC if *BOTH* cores have been in some STOP mode!
-            #[cfg(any(stm32wl, stm32wba))]
+            #[cfg(any(stm32wl, stm32wba, stm32f4))]
             let re_initialize_rcc = {
                 #[cfg(stm32wl5x)]
                 {
@@ -244,6 +250,10 @@ mod platform {
                 #[cfg(stm32wba)]
                 {
                     es.stopf()
+                }
+                #[cfg(stm32f4)]
+                {
+                    true
                 }
             };
 
@@ -263,7 +273,7 @@ mod platform {
                 }
             };
 
-            #[cfg(any(stm32wl, stm32wba))]
+            #[cfg(any(stm32wl, stm32wba, stm32f4))]
             if re_initialize_rcc {
                 // when we wake from any stop mode we need to re-initialize the rcc
                 crate::rcc::reinit_saved(_cs);
@@ -345,9 +355,9 @@ fn configure_pwr(cs: CriticalSection) -> bool {
 
         false
     } else {
-        #[cfg(stm32l0)]
+        #[cfg(any(stm32l0, stm32f4))]
         trace!("low power: enter stop");
-        #[cfg(not(stm32l0))]
+        #[cfg(not(any(stm32l0, stm32f4)))]
         trace!("low power: enter stop: {}", stop_mode);
 
         #[cfg(not(feature = "low-power-debug-with-sleep"))]

--- a/examples/stm32f4-lp/.cargo/config.toml
+++ b/examples/stm32f4-lp/.cargo/config.toml
@@ -1,0 +1,10 @@
+[target.'cfg(all(target_arch = "arm", target_os = "none"))']
+# replace STM32F401RC with your chip as listed in `probe-rs chip list`
+runner = "probe-rs run --chip STM32F401RC"
+
+
+[build]
+target = "thumbv7em-none-eabi"
+
+[env]
+DEFMT_LOG = "trace"

--- a/examples/stm32f4-lp/Cargo.toml
+++ b/examples/stm32f4-lp/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+edition = "2024"
+name = "embassy-stm32f4-lp-examples"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+embassy-stm32 = { version = "0.6.0", path = "../../embassy-stm32", features = ["defmt", "stm32f401rc", "unstable-pac", "memory-x", "time-driver-any", "exti", "low-power", "executor-thread", "executor-interrupt"] }
+embassy-sync = { version = "0.8.0", path = "../../embassy-sync", features = ["defmt"] }
+embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["defmt"] }
+embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
+
+defmt = "1.0.1"
+defmt-rtt = "1.0.0"
+cortex-m = { version = "0.7.6", features = ["inline-asm", "critical-section-single-core"] }
+cortex-m-rt = "0.7.0"
+panic-probe = { version = "1.0.0", features = ["print-defmt"] }
+
+[profile.release]
+debug = 2
+
+[package.metadata.embassy]
+build = [
+  { target = "thumbv7em-none-eabi", artifact-dir = "out/examples/stm32f4-lp" }
+]

--- a/examples/stm32f4-lp/build.rs
+++ b/examples/stm32f4-lp/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/examples/stm32f4-lp/src/bin/stop_exti.rs
+++ b/examples/stm32f4-lp/src/bin/stop_exti.rs
@@ -1,0 +1,130 @@
+#![no_std]
+#![no_main]
+
+//! Low-power example for STM32F401.
+//!
+//! This example automatically enters STOP mode during idle periods longer than 300ms
+//! to save power. On the STM32F401, the expected current consumption in STOP mode is
+//! ~42uA. This is the expected behavior. Enabling the `FPDS` bit in `PWR.CR1` can
+//! further reduce the current to ~12uA at the cost of increased wakeup latency.
+//!
+//! # Debugging
+//! Enabling `enable_debug_during_sleep` consumes a significant amount of current
+//! (measured at ~1mA on STM32F401RC). Furthermore, even with this option enabled,
+//! RTT output is unreliable because RAM clocks are likely stopped during sleep. Because
+//! of this, this project relies on an LED connected to `PC5` to indicate system status.
+//! It is highly recommended to use USART for logging instead.
+//!
+//! # GPIO Configuration
+//! After power-on, most STM32F401 IOs default to floating input mode. Any unconnected
+//! pins will float, causing their internal Schmitt triggers to oscillate and draw
+//! significant leakage current. Setting these unused pins to Analog In mode disables
+//! the digital input/output circuitry entirely to prevent this leakage. (This issue is
+//! specific to older series, newer families like the STM32U5 default to Analog In mode
+//! upon reset.)
+//!
+//! If the board is connected to other external peripherals, configuring communication IOs
+//! as Analog IN may cause similar floating input leakage on the peripheral side. Depending
+//! on the communication interface and the peripheral's requirements, you may need to
+//! configure these pins as pulled-up/pulled-down inputs or explicit high/low outputs.
+//!
+//! For more information, please refer to:
+//! [AN4365: Using STM32F4 MCU power modes with best dynamic efficiency](https://www.st.com/resource/en/application_note/an4365-using-stm32f4-mcu-power-modes-with-best-dynamic-efficiency-stmicroelectronics.pdf)
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either, select};
+use embassy_stm32::exti::ExtiInput;
+use embassy_stm32::gpio::{Level, Output, Pull, Speed};
+use embassy_stm32::{bind_interrupts, interrupt, pac};
+use embassy_time::{Duration, Timer, block_for};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    EXTI0 => embassy_stm32::exti::InterruptHandler<interrupt::typelevel::EXTI0>;
+});
+
+#[embassy_executor::main(entry = "cortex_m_rt::entry", executor = "embassy_stm32::executor::Executor")]
+async fn main(_spawner: Spawner) {
+    let mut config = embassy_stm32::Config::default();
+    config.enable_debug_during_sleep = false;
+    config.min_stop_pause = Duration::from_millis(300);
+    // Initialize RTC so the time driver can hand off timekeeping during STOP mode
+    config.rtc = Default::default();
+
+    let p = embassy_stm32::init(config);
+
+    info!("System initialized.");
+
+    // Block for 3 seconds to keep the MCU awake after power-on.
+    // This provides a window for the debugger to attach and reprogram the flash.
+    // Without this, entering STOP mode immediately disconnects SWD,
+    // requiring you to manually press the BOOT button to re-flash.
+    info!("Waiting 3 seconds to allow debugger connection...");
+    block_for(Duration::from_secs(3));
+
+    // Set all unused IOs to Analog In mode to minimize power consumption.
+    pac::GPIOA.moder().modify(|w| {
+        for i in 0..16 {
+            if i != 13 && i != 14 {
+                // Exclude SWDIO/SWCLK here to handle them separately
+                w.set_moder(i, pac::gpio::vals::Moder::Analog);
+            }
+        }
+    });
+
+    // Uncomment or comment the following block to toggle SWD pins (PA13, PA14) Analog mode.
+    // Note: Setting these to Analog will minimize power consumption but will detach the SWD debugger.
+    pac::GPIOA.moder().modify(|w| {
+        w.set_moder(13, pac::gpio::vals::Moder::Analog);
+        w.set_moder(14, pac::gpio::vals::Moder::Analog);
+    });
+
+    pac::GPIOB.moder().modify(|w| {
+        for i in 0..16 {
+            if i != 0 {
+                // Exclude PB0 used for EXTI
+                w.set_moder(i, pac::gpio::vals::Moder::Analog);
+            }
+        }
+    });
+
+    pac::GPIOC.moder().modify(|w| {
+        for i in 0..16 {
+            if i != 5 {
+                // Exclude PC5 used for LED
+                w.set_moder(i, pac::gpio::vals::Moder::Analog);
+            }
+        }
+    });
+    pac::GPIOD.moder().write_value(pac::gpio::regs::Moder(0xFFFF_FFFF));
+    pac::GPIOH.moder().write_value(pac::gpio::regs::Moder(0xFFFF_FFFF));
+
+    info!("Unused pins set to Analog mode.");
+
+    // Configure PB0 as EXTI input with pull-down
+    let mut button = ExtiInput::new(p.PB0, p.EXTI0, Pull::Up, Irqs);
+
+    let mut led = Output::new(p.PC5, Level::Low, Speed::Low);
+
+    info!("Starting main low-power loop. WFI will automatically enter STOP mode.");
+
+    loop {
+        let exti_fut = button.wait_for_falling_edge();
+        let timeout_fut = Timer::after(Duration::from_secs(5));
+
+        match select(exti_fut, timeout_fut).await {
+            Either::First(_) => {
+                info!("Woke up by EXTI (PB0 falling edge).");
+            }
+            Either::Second(_) => {
+                info!("Woke up by 5s Timer timeout.");
+            }
+        }
+
+        led.set_high();
+        Timer::after(Duration::from_millis(300)).await;
+        led.set_low();
+    }
+}


### PR DESCRIPTION
Thanks to embassy already implementing time-driver pause and RTC handoff during stop mode, I have implemented low-power support for stm32f4.

With this PR, stm32f4 can also enter stop mode during idle by using `embassy_stm32::executor::Executor`.

I also wrote the `stm32f4-lp` example and added detailed comments.
The ~42uA stop power consumption on stm32f401 (as shown in the attached image) matches the expectations from [AN4365](https://www.st.com/resource/en/application_note/an4365-using-stm32f4-mcu-power-modes-with-best-dynamic-efficiency-stmicroelectronics.pdf), and wakeup works normally.

Additionally, if the `FPDS` bit in `PWR.CR1` is enabled, the power consumption can be further reduced to ~12uA, but it will extend the wakeup time. Since this behavior is not exclusive to stm32f4, I did not include it in this PR.
Later, I might open a new PR to introduce a new configuration option to control this, but that may require more discussion.

<img width="419" height="226" alt="image" src="https://github.com/user-attachments/assets/80de2bf8-dbd0-4907-b163-d55db8401dc7" />
