### PR TITLE
stm32/dma: improve docs

### DIFF
--- a/embassy-stm32/src/dma/dma_bdma.rs
+++ b/embassy-stm32/src/dma/dma_bdma.rs
@@ -798,6 +798,9 @@ impl<'d> Channel<'d> {
         }
     }
 
+    /// Starts the channel by enabling it.
+    ///
+    /// This function also unsuspends (resumes) the channel.
     fn start(&self) {
         let info = self.info();
         match self.info().dma {
@@ -894,6 +897,7 @@ impl<'d> Channel<'d> {
         self.start()
     }
 
+    /// Resets the channel. The configuration is not preserved.
     fn request_reset(&self) {
         let info = self.info();
         match self.info().dma {
@@ -1336,6 +1340,8 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     /// Start the ring buffer operation.
     ///
     /// You must call this after creating it for it to work.
+    ///
+    /// It starts the channel and makes it run, even if earlier it was suspended (paused).
     pub fn start(&mut self) {
         self.channel.enable_circular_mode();
         self.channel.start();

--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -601,6 +601,9 @@ impl<'d> Channel<'d> {
         ch.br1().read().bndt() / word_size.bytes() as u16
     }
 
+    /// Configure a channel.
+    ///
+    /// This function also causes the channel to reset, which unsuspends (resumes) it.
     unsafe fn configure(
         &self,
         request: Request,
@@ -754,6 +757,8 @@ impl<'d> Channel<'d> {
     ///
     /// Accepts the raw table-derived values so that both `Table` and
     /// `TwoDTable` can share the same channel setup logic.
+    ///
+    /// This function also causes the channel to reset, which unsuspends (resumes) it.
     #[allow(clippy::too_many_arguments)]
     unsafe fn configure_linked_list_raw(
         &self,
@@ -826,6 +831,10 @@ impl<'d> Channel<'d> {
             .store(total_transfer_count, Ordering::Relaxed)
     }
 
+    /// Starts the channel by enabling it.
+    ///
+    /// If then channel was suspended (paused) earlier, it stays suspended.
+    /// The channel must be unsuspended (resumed) manually if needed.
     fn start(&self) {
         let info = self.info();
         let ch = info.dma.ch(info.num);
@@ -847,6 +856,9 @@ impl<'d> Channel<'d> {
         ch.cr().modify(|w| w.set_susp(false));
     }
 
+    /// Resets the channel. The configuration is not preserved.
+    ///
+    /// Additionally reset causes the channel to unsuspend (resume).
     fn request_reset(&self) {
         let info = self.info();
         let ch = info.dma.ch(info.num);

--- a/embassy-stm32/src/dma/gpdma/ringbuffered.rs
+++ b/embassy-stm32/src/dma/gpdma/ringbuffered.rs
@@ -123,6 +123,10 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     }
 
     /// Start the ring buffer operation.
+    ///
+    /// This function configures the channel which also causes it to reset.
+    /// Then it starts the channel and makes it run, even if earlier it was
+    /// suspended (paused), because reset unsuspends (resumes) the channel.
     pub fn start(&mut self) {
         unsafe {
             self.channel.configure_linked_list_raw(
@@ -221,6 +225,8 @@ impl<'a, W: Word> ReadableRingBuffer<'a, W> {
     ///
     /// The configuration for this channel will **not be preserved**. If you need to restart the transfer
     /// at a later point with the same configuration, see [`request_pause`](Self::request_pause) instead.
+    ///
+    /// Additionally reset causes the channel to unsuspend (resume).
     pub fn request_reset(&mut self) {
         self.channel.request_reset()
     }


### PR DESCRIPTION
This PR improves documentation of some parts of DMA driver. The main purpose is to highlight some differences in implementation behavior of different DMA types.

Some observations:
- In GPDMA `ReadableRingBuffer::start` configures the channel `Channel::configure_linked_list_raw` which causes it to reset. However, that reset only happens when channel is disabled or suspended (steady state). This seems to be the cause of #6592. When UART error is detected, then channel is suspended so reset is effective. 
- Continuing above. During configuration most registers are writable only in steady state. This means that subsequent `ReadableRingBuffer:start` calls try to configure the channel when it is in active state (so registers are read only). Reset does nothing, unless channel is suspended. `Channel::configure`, in contrast, suspends the channel, so the reset is always effective. Fix PR: #6707
- In DMA/BDMA `ReadableRingBuffer::start` does not reset the channel. It also does some configuration, but here state doesn't seem to matter.
