### PR TITLE
stm32/adc: Restore `degrade_adc()` functionality on owned peripherals

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -815,7 +815,7 @@ pub trait SpecialConverter<T: SpecialChannel + Sized>: ConverterFor<T> {}
 
 impl<C: SpecialChannel + Sized, T: ConverterFor<C>> SpecialConverter<C> for T {}
 
-impl<C: SpecialChannel, T: Instance + ConverterFor<C>> AdcChannel<T> for C {}
+impl<'d, C: SpecialChannel, T: Instance + ConverterFor<C>> AdcChannel<'d, T> for C {}
 impl<C: SpecialChannel, T: Instance + ConverterFor<C>> SealedAdcChannel<T> for C {
     fn channel(&self) -> u8 {
         T::CHANNEL
@@ -871,10 +871,15 @@ pub trait Instance: SealedInstance + crate::PeripheralType + crate::rcc::RccPeri
 
 /// ADC channel.
 #[allow(private_bounds)]
-pub trait AdcChannel<T>: SealedAdcChannel<T> + Sized {
-    #[deprecated = "use `reborrow_adc`"]
-    fn degrade_adc<'a>(&'a mut self) -> BorrowedAdcChannel<'a, T> {
-        self.reborrow_adc()
+pub trait AdcChannel<'d, T>: SealedAdcChannel<T> + Sized {
+    fn degrade_adc(mut self) -> BorrowedAdcChannel<'d, T> {
+        self.setup();
+
+        BorrowedAdcChannel {
+            channel: self.channel(),
+            is_differential: self.is_differential(),
+            _marker: PhantomData,
+        }
     }
 
     #[allow(unused_mut)]
@@ -923,7 +928,11 @@ impl<'a, T: Instance> SealedAdcChannel<T> for BorrowedAdcChannel<'a, T> {
     }
 }
 
-impl<'a, T: Instance> AdcChannel<T> for BorrowedAdcChannel<'a, T> {
+impl<'a, T: Instance> AdcChannel<'a, T> for BorrowedAdcChannel<'a, T> {
+    fn degrade_adc(self) -> BorrowedAdcChannel<'a, T> {
+        self
+    }
+
     #[inline]
     fn reborrow_adc<'b>(&'b mut self) -> BorrowedAdcChannel<'b, T> {
         Self { ..*self }
@@ -938,7 +947,7 @@ trait SealedBorrowedChannel<'a, T> {
 pub trait BorrowedChannel<'a, T>: SealedBorrowedChannel<'a, T> {}
 impl<'a, T, C: SealedBorrowedChannel<'a, T>> BorrowedChannel<'a, T> for C {}
 
-impl<'a, T, C: AdcChannel<T>> SealedBorrowedChannel<'a, T> for &'a mut C {
+impl<'a, 'd, T, C: AdcChannel<'d, T>> SealedBorrowedChannel<'a, T> for &'a mut C {
     #[inline]
     fn reborrow_adc(self) -> BorrowedAdcChannel<'a, T> {
         self.reborrow_adc()
@@ -1113,7 +1122,7 @@ macro_rules! impl_analog_pin {
 
 macro_rules! impl_adc_pin {
     ($inst:ident, $pin:ident, $ch:expr) => {
-        impl crate::adc::AdcChannel<peripherals::$inst> for crate::Peri<'_, crate::peripherals::$pin> {}
+        impl<'d> crate::adc::AdcChannel<'d, peripherals::$inst> for crate::Peri<'d, crate::peripherals::$pin> {}
         impl crate::adc::SealedAdcChannel<peripherals::$inst> for crate::Peri<'_, crate::peripherals::$pin> {
             fn setup(&mut self) {
                 <crate::peripherals::$pin as crate::adc::AnalogPin>::set_as_analog(self);
@@ -1129,10 +1138,10 @@ macro_rules! impl_adc_pin {
 #[allow(unused_macros)]
 macro_rules! impl_adc_pair {
     ($inst:ident, $pin:ident, $npin:ident, $ch:expr) => {
-        impl crate::adc::AdcChannel<peripherals::$inst>
+        impl<'d> crate::adc::AdcChannel<'d, peripherals::$inst>
             for (
-                crate::Peri<'_, crate::peripherals::$pin>,
-                crate::Peri<'_, crate::peripherals::$npin>,
+                crate::Peri<'d, crate::peripherals::$pin>,
+                crate::Peri<'d, crate::peripherals::$npin>,
             )
         {
         }

--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -907,9 +907,26 @@ impl<'a, T: Instance> BorrowedAdcChannel<'a, T> {
         self.is_differential
     }
 
-    #[allow(unused)]
+    #[inline]
     pub fn get_hw_channel(&self) -> u8 {
         self.channel
+    }
+}
+
+impl<'a, T: Instance> SealedAdcChannel<T> for BorrowedAdcChannel<'a, T> {
+    fn channel(&self) -> u8 {
+        self.channel
+    }
+
+    fn is_differential(&self) -> bool {
+        self.is_differential
+    }
+}
+
+impl<'a, T: Instance> AdcChannel<T> for BorrowedAdcChannel<'a, T> {
+    #[inline]
+    fn reborrow_adc<'b>(&'b mut self) -> BorrowedAdcChannel<'b, T> {
+        Self { ..*self }
     }
 }
 
@@ -922,6 +939,7 @@ pub trait BorrowedChannel<'a, T>: SealedBorrowedChannel<'a, T> {}
 impl<'a, T, C: SealedBorrowedChannel<'a, T>> BorrowedChannel<'a, T> for C {}
 
 impl<'a, T, C: AdcChannel<T>> SealedBorrowedChannel<'a, T> for &'a mut C {
+    #[inline]
     fn reborrow_adc(self) -> BorrowedAdcChannel<'a, T> {
         self.reborrow_adc()
     }

--- a/embassy-stm32/src/adc/v3.rs
+++ b/embassy-stm32/src/adc/v3.rs
@@ -112,7 +112,7 @@ impl<T: Instance> super::ConverterFor<super::Vbat> for T {
 cfg_if! {
     if #[cfg(any(adc_h5, adc_h7rs))] {
         pub struct VddCore;
-        impl<T: Instance> super::AdcChannel<T> for VddCore {}
+        impl<'d, T: Instance> super::AdcChannel<'d, T> for VddCore {}
         impl<T: Instance> super::SealedAdcChannel<T> for VddCore {
             fn channel(&self) -> u8 {
                 17
@@ -124,7 +124,7 @@ cfg_if! {
 cfg_if! {
     if #[cfg(adc_u0)] {
         pub struct DacOut;
-        impl<T: Instance> super::AdcChannel<T> for DacOut {}
+        impl<'d, T: Instance> super::AdcChannel<'d, T> for DacOut {}
         impl<T: Instance> super::SealedAdcChannel<T> for DacOut {
             fn channel(&self) -> u8 {
                 19

--- a/embassy-stm32/src/adc/watchdog_adc4.rs
+++ b/embassy-stm32/src/adc/watchdog_adc4.rs
@@ -133,7 +133,7 @@ impl<T: Instance<Regs = crate::pac::adc::Adc4>> AnalogWatchdog<T> {
     pub async fn monitor(
         &mut self,
         _adc: &mut Adc<'_, T>,
-        channel: &mut impl AdcChannel<T>,
+        channel: &mut impl AdcChannel<'_, T>,
         sample_time: super::SampleTime,
     ) -> u16 {
         let _scoped_wake_guard = <T as crate::rcc::SealedRccPeripheral>::RCC_INFO.wake_guard();

--- a/embassy-stm32/src/adc/watchdog_v1.rs
+++ b/embassy-stm32/src/adc/watchdog_v1.rs
@@ -14,11 +14,11 @@ pub enum WatchdogChannels {
 }
 
 impl WatchdogChannels {
-    pub fn from_channel<T>(channel: &impl AdcChannel<T>) -> Self {
+    pub fn from_channel<'d, T>(channel: &impl AdcChannel<'d, T>) -> Self {
         Self::Single(channel.channel())
     }
 
-    pub fn add_channel<T>(self, channel: &impl AdcChannel<T>) -> Self {
+    pub fn add_channel<'d, T>(self, channel: &impl AdcChannel<'d, T>) -> Self {
         WatchdogChannels::Multiple(
             (match self {
                 WatchdogChannels::Single(ch) => 1 << ch,

--- a/embassy-stm32/src/opamp.rs
+++ b/embassy-stm32/src/opamp.rs
@@ -589,7 +589,7 @@ macro_rules! impl_opamp_external_output {
                     }
                 }
 
-                impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
+                impl<'d> crate::adc::AdcChannel<'d, crate::peripherals::$adc>
                     for crate::opamp::OpAmpOutput<'d, crate::peripherals::$inst>
                 {
                 }
@@ -611,7 +611,7 @@ macro_rules! impl_opamp_internal_output {
                     }
                 }
 
-                impl<'d> crate::adc::AdcChannel<crate::peripherals::$adc>
+                impl<'d> crate::adc::AdcChannel<'d, crate::peripherals::$adc>
                     for OpAmpInternalOutput<'d, crate::peripherals::$inst>
                 {
                 }

--- a/examples/stm32h5/src/bin/adc_dma.rs
+++ b/examples/stm32h5/src/bin/adc_dma.rs
@@ -76,8 +76,8 @@ async fn adc_task<'a, T, D, I>(
     adc: Peri<'a, T>,
     mut dma: Peri<'a, D>,
     irq: I,
-    mut pin1: impl AdcChannel<T>,
-    mut pin2: impl AdcChannel<T>,
+    mut pin1: impl AdcChannel<'_, T>,
+    mut pin2: impl AdcChannel<'_, T>,
 ) where
     T: adc::DefaultInstance,
     D: RxDma<T>,

--- a/examples/stm32h7/src/bin/adc_dma.rs
+++ b/examples/stm32h7/src/bin/adc_dma.rs
@@ -60,6 +60,7 @@ async fn main(_spawner: Spawner) {
 
     let mut dma = p.DMA1_CH1;
     let mut vrefint = adc.enable_vrefint();
+    let mut pc1 = p.PC1.degrade_adc();
 
     loop {
         adc.read(
@@ -68,6 +69,7 @@ async fn main(_spawner: Spawner) {
             [
                 (vrefint.reborrow_adc(), SampleTime::Cycles3875),
                 (p.PC0.reborrow_adc(), SampleTime::Cycles8105),
+                (pc1.reborrow_adc(), SampleTime::Cycles8105),
             ]
             .into_iter(),
             None,


### PR DESCRIPTION
This PR is based on #6708.

Restore the functionality that `degrade_adc()` used to have in the latest crates.io release: We can call it on a `Peri<'d, T>` by value, "moving" the peripheral into the degraded adc channel. Since the function was marked deprecated and called `reborrow_adc()`, no functionality is lost.