### PR TITLE
embassy-executor: Expose TaskRef::as_raw/from_raw

### DIFF
--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -169,6 +169,26 @@ impl TaskRef {
         self.ptr.as_ptr()
     }
 
+    /// An opaque pointer identifying this task.
+    ///
+    /// Lets a `TaskRef` be stored where only one word fits. Recover it with [`from_raw`](Self::from_raw).
+    ///
+    /// The pointer must not be dereferenced.
+    pub fn as_raw(self) -> NonNull<()> {
+        self.ptr.cast()
+    }
+
+    /// Recover the task that [`as_raw`](Self::as_raw) was called on.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must have been returned by `as_raw`, and the task it identifies must still be alive.
+    /// A task lives as long as its `TaskStorage`, which is `'static`, so this holds for any pointer taken
+    /// from a task that had been spawned.
+    pub unsafe fn from_raw(ptr: NonNull<()>) -> Self {
+        Self { ptr: ptr.cast() }
+    }
+
     /// Returns the task ID.
     /// This can be used in combination with rtos-trace to match task names with IDs
     pub fn id(&self) -> u32 {

--- a/embassy-executor/src/raw/mod.rs
+++ b/embassy-executor/src/raw/mod.rs
@@ -182,9 +182,7 @@ impl TaskRef {
     ///
     /// # Safety
     ///
-    /// `ptr` must have been returned by `as_raw`, and the task it identifies must still be alive.
-    /// A task lives as long as its `TaskStorage`, which is `'static`, so this holds for any pointer taken
-    /// from a task that had been spawned.
+    /// `ptr` must have been returned by `as_raw`.
     pub unsafe fn from_raw(ptr: NonNull<()>) -> Self {
         Self { ptr: ptr.cast() }
     }


### PR DESCRIPTION
# executor: let `TaskRef` be converted to/from a raw pointer

Adds `TaskRef::as_raw` and `TaskRef::from_raw`, so a `TaskRef` can be kept in a place that holds a single
pointer.

## Why

I'm working on a HAL that keeps a waker per event in an array. A regular per-pin `Waker` array costs 8 bytes
a pin, and on a CAS-less core each slot is guarded by a critical section because `AtomicWaker` degrades to
`CriticalSectionWaker` there.

`task_from_waker` and `wake_task` are already public, so the executor already uses a `TaskRef` as the
type for "the thing to wake". What is missing is a way to *store* one where only a pointer fits.

`turbowakers` solves the same problem globally, via `Waker::as_turbo_ptr`, but requires
patching core. This API allows a single driver to opt-in to the equivalent locally.

## Performance

Measured on an MSPM0G3507 (Cortex-M0+ at 32 MHz) with a logic analyser:

| | waker array (8 B/pin) | task slots (4 B/pin) |
|---|---|---|
| the wake call in the ISR | 6.658 µs | **5.079 µs** |
| executor dispatch to the task | 17.338 µs | **16.566 µs** |
| edge to the task's response | 49.207 µs | **46.053 µs** |
| flash | 6216 B | **6092 B** |

### What these methods add

`Option<TaskRef>` is already one word thanks to the `NonNull` niche, so the RAM saving above needs no new
API — a `Cell<Option<TaskRef>>` behind a critical section gets it. These methods let the slot be a bare
`AtomicPtr` instead, whose load and store need no CAS and so no critical section on Cortex-M0+.

Measured, that is worth less than expected, and it depends on how `portable-atomic` is configured:

| slot | `portable-atomic` | edge to response | flash |
|---|---|---|---|
| `Cell` + critical section | `critical-section` | 46.053 µs | 6092 B |
| `AtomicPtr` | `critical-section` | 46.353 µs | 6120 B |
| `Cell` + critical section | `unsafe-assume-single-core` | 39.819 µs | 5992 B |
| `AtomicPtr` | `unsafe-assume-single-core` | **39.237 µs** | **5972 B** |

The saving is 580 ns and 20 bytes with inline atomics, and slightly _worse_ with the `critical-section` backend.

The honest case for these methods is that they complete the API rather than that they provide a big performance
win: `task_from_waker` and `wake_task` already make `TaskRef` the public API for waking, and this
lets it be stored as what it is.
