### PR TITLE
stm32/eth: improve lp logic

### DIFF
--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -103,6 +103,8 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
         if let Some(rx) = self.rx.available()
             && let Some(tx) = self.tx.available()
         {
+            self.wake_guard.disable();
+
             Some((
                 RxToken {
                     pkt: rx,
@@ -114,6 +116,8 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
                 },
             ))
         } else {
+            self.wake_guard.enable();
+
             None
         }
     }
@@ -121,11 +125,15 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
     fn transmit(&mut self, cx: &mut Context) -> Option<Self::TxToken<'_>> {
         WAKER.register(cx.waker());
         if let Some(tx) = self.tx.available() {
+            self.wake_guard.disable();
+
             Some(TxToken {
                 pkt: tx,
                 tx: &mut self.tx,
             })
         } else {
+            self.wake_guard.enable();
+
             None
         }
     }
@@ -157,7 +165,15 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
     fn poll_timestamp(&mut self, cx: &mut Context) -> Option<embassy_net_driver::TxTimestamp> {
         WAKER.register(cx.waker());
 
-        self.tx.poll_timestamp()
+        if let Some(timestamp) = self.tx.poll_timestamp() {
+            self.wake_guard.disable();
+
+            Some(timestamp)
+        } else {
+            self.wake_guard.enable();
+
+            None
+        }
     }
 
     fn link_state(&mut self, cx: &mut Context) -> LinkState {

--- a/embassy-stm32/src/eth/v1/mod.rs
+++ b/embassy-stm32/src/eth/v1/mod.rs
@@ -30,7 +30,7 @@ use crate::pac::SYSCFG;
 use crate::pac::eth::vals::Ipco;
 use crate::pac::eth::vals::{Apcs, Dm, DmaomrSr, Fes, Ftf, Ifg, Pbl, Rsf, St, Tsf};
 use crate::pac::{ETH, RCC};
-use crate::rcc::WakeGuard;
+use crate::rcc::MaybeWakeGuard;
 
 /// Interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -58,7 +58,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 /// Ethernet driver.
 pub struct Ethernet<'d, T: Instance, P: Phy> {
     _peri: Peri<'d, T>,
-    _wake_guard: WakeGuard,
+    pub(crate) wake_guard: MaybeWakeGuard,
     pub(crate) link_state: LinkState,
     pub(crate) tx: TDesRing<'d>,
     pub(crate) rx: RDesRing<'d>,
@@ -323,10 +323,10 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
         let mut this = Self {
             _peri: peri,
-            _wake_guard: T::RCC_INFO.wake_guard(),
             _pins: pins,
             phy: phy,
             mac_addr,
+            wake_guard: T::RCC_INFO.wake_guard().into(),
             link_state: LinkState::Down,
             tx: TDesRing::new(
                 &mut queue.tx_desc,

--- a/embassy-stm32/src/eth/v2/mod.rs
+++ b/embassy-stm32/src/eth/v2/mod.rs
@@ -20,7 +20,7 @@ use crate::pac::ETH;
 #[cfg(any(eth_v2a, eth_v2b))]
 use crate::pac::ETH1 as ETH;
 use crate::peripherals::SYSCFG;
-use crate::rcc::WakeGuard;
+use crate::rcc::MaybeWakeGuard;
 use crate::{interrupt, rcc};
 
 /// Access a per-channel DMA/MTL register at channel 0.
@@ -66,7 +66,7 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
 /// Ethernet driver.
 pub struct Ethernet<'d, T: Instance, P: Phy> {
     _peri: Peri<'d, T>,
-    _wake_guard: WakeGuard,
+    pub(crate) wake_guard: MaybeWakeGuard,
     pub(crate) link_state: LinkState,
     pub(crate) tx: TDesRing<'d>,
     pub(crate) rx: RDesRing<'d>,
@@ -523,7 +523,7 @@ impl<'d, T: Instance, P: Phy> Ethernet<'d, T, P> {
 
         let mut this = Self {
             _peri: peri,
-            _wake_guard: T::RCC_INFO.wake_guard(),
+            wake_guard: T::RCC_INFO.wake_guard().into(),
             tx: TDesRing::new(
                 &mut queue.tx_desc,
                 &mut queue.tx_buf,

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -471,6 +471,49 @@ impl Drop for WakeGuard {
     }
 }
 
+impl From<WakeGuard> for MaybeWakeGuard {
+    fn from(wake_guard: WakeGuard) -> Self {
+        #[cfg(not(feature = "low-power"))]
+        let _ = wake_guard;
+
+        MaybeWakeGuard {
+            #[cfg(feature = "low-power")]
+            stop_mode: wake_guard.stop_mode,
+            #[cfg(feature = "low-power")]
+            enabled: false,
+        }
+    }
+}
+
+pub struct MaybeWakeGuard {
+    #[cfg(feature = "low-power")]
+    stop_mode: StopMode,
+    #[cfg(feature = "low-power")]
+    enabled: bool,
+}
+
+impl MaybeWakeGuard {
+    pub fn enable(&mut self) {
+        #[cfg(feature = "low-power")]
+        if !core::mem::replace(&mut self.enabled, true) {
+            critical_section::with(|cs| increment_stop_refcount(cs, self.stop_mode));
+        }
+    }
+
+    pub fn disable(&mut self) {
+        #[cfg(feature = "low-power")]
+        if core::mem::replace(&mut self.enabled, false) {
+            critical_section::with(|cs| decrement_stop_refcount(cs, self.stop_mode));
+        }
+    }
+}
+
+impl Drop for MaybeWakeGuard {
+    fn drop(&mut self) {
+        self.disable();
+    }
+}
+
 #[allow(unused)]
 mod util {
     use crate::time::Hertz;


### PR DESCRIPTION
adds a new MaybeWakeGuard that is zero-cost when lp is not enabled.