### PR TITLE
time: fix deadlock between schedule_wake() and the std alarm thread

### DIFF
--- a/embassy-time/CHANGELOG.md
+++ b/embassy-time/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add 27MHz tick rate support
 - Implement `core::error::Error` for `TimeoutError`.
+- driver_std: fix deadlock between `schedule_wake()` and the `alarm_thread()`
 
 ## 0.5.1 - 2026-03-11
 

--- a/embassy-time/src/driver_std.rs
+++ b/embassy-time/src/driver_std.rs
@@ -31,7 +31,8 @@ impl Driver for TimeDriver {
     fn schedule_wake(&self, at: u64, waker: &core::task::Waker) {
         let mut queue = self.queue.lock().unwrap();
         if queue.schedule_wake(at, waker) {
-            let next_alarm = critical_section::with(|_cs| queue.next_expiration(self.now()));
+            let next_alarm = queue.next_expiration(self.now());
+            drop(queue);
             if next_alarm < u64::MAX {
                 self.signaler.signal();
             }
@@ -44,7 +45,7 @@ fn alarm_thread() {
     loop {
         let now = DRIVER.now();
 
-        let next_alarm = critical_section::with(|_cs| DRIVER.queue.lock().unwrap().next_expiration(now));
+        let next_alarm = DRIVER.queue.lock().unwrap().next_expiration(now);
 
         // Ensure we don't overflow
         let until = zero

--- a/embassy-time/src/driver_std.rs
+++ b/embassy-time/src/driver_std.rs
@@ -95,3 +95,85 @@ impl Signaler {
         self.condvar.notify_one();
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Regression test for the deadlock between `schedule_wake()` and
+    //! the `alarm_thread()`.
+    //!
+    //! Root cause: the old code wrapped both `schedule_wake()` and
+    //! `alarm_thread()` in `critical_section::with()`, which acquires a
+    //! global CS mutex.  Because `schedule_wake()` locked the `queue` mutex
+    //! first and then entered the CS, while `alarm_thread()` entered the CS
+    //! first and then locked `queue`, concurrent calls could deadlock
+    //!
+    //! ```text
+    //!   schedule_wake():   queue (held) → CS (waiting)
+    //!   alarm_thread():    CS   (held) → queue (waiting)  ← deadlock
+    //! ```
+    //!
+    //! The test below would hang indefinitely (and be caught by the watchdog
+    //! thread) if the bug were reintroduced.
+
+    use std::sync::Arc;
+    use std::task::Wake;
+    use std::time::Duration as StdDuration;
+
+    use embassy_time_driver::Driver;
+
+    use super::DRIVER;
+
+    /// A no-op waker used to drive `schedule_wake` calls.
+    struct NoopWaker;
+    impl Wake for NoopWaker {
+        fn wake(self: Arc<Self>) {}
+    }
+
+    /// Regression test: `schedule_wake()` must never deadlock with the
+    /// background `alarm_thread`.
+    ///
+    /// Strategy: touch `DRIVER.zero_instant` to ensure the alarm thread is
+    /// running, then spam `schedule_wake()` from many concurrent threads.
+    /// A watchdog thread panics the process if the whole thing takes longer
+    /// than 5 seconds, which would clearly suggest deadlock.
+    #[test]
+    fn no_deadlock_between_schedule_wake_and_alarm_thread() {
+        let _ = DRIVER.now();
+
+        // Watchdog: panic if the test body takes longer than 5 s.
+        let watchdog = std::thread::spawn(|| {
+            std::thread::sleep(StdDuration::from_secs(5));
+            panic!(
+                "deadlock detected: schedule_wake() and alarm_thread() \
+                 appear to be stuck. Was critical_section::with() \
+                 reintroduced around a queue lock?"
+            );
+        });
+
+        const THREADS: usize = 16;
+        const CALLS_PER_THREAD: usize = 1_000;
+
+        let handles: Vec<_> = (0..THREADS)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    let waker: core::task::Waker = Arc::new(NoopWaker).into();
+                    for _ in 0..CALLS_PER_THREAD {
+                        // Schedule a wake far in the future so the alarm thread
+                        // keeps churning and re-locking the queue mutex.
+                        let at = DRIVER.now().saturating_add(1_000_000);
+                        DRIVER.schedule_wake(at, &waker);
+                    }
+                })
+            })
+            .collect();
+
+        for h in handles {
+            h.join().expect("worker thread panicked");
+        }
+
+        // If we reach this point without the watchdog firing, there was no
+        // deadlock.  Detach the watchdog so it doesn't outlive the test run
+        // and trigger a spurious panic later.
+        drop(watchdog);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a deadlock in the `std` time driver (`embassy-time/src/driver_std.rs`) between `TimeDriver::schedule_wake()` and `alarm_thread()`.

- `schedule_wake()`: locks the queue `Mutex` first, *then* enters the critical section.
- `alarm_thread()`: enters the critical section first, *then* locks the queue `Mutex`.


## Fix

Don't use the `critical_section::with()` wrappers around `next_expiration()` in both `schedule_wake()` and `alarm_thread()`

