### PR TITLE
 stm32/rcc/c0: add SYSDIV config, fix flash latency ordering

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -63,8 +63,9 @@ OSPI:
 - feat: stm32/ospi: add `Ospi::configure_hyperbus` + `HyperbusConfig`/`HyperbusLatencyMode` to program the HyperBus latency register (HLCR), enabling HyperBus/HyperRAM memory-mapped bring-up without reaching for `unstable-pac`
 
 RCC:
+- feat: stm32/rcc/c0: add `Config::sys_div` to configure the SYSDIV divider on chips that have it (C051, C071, C091/C092). It was previously never programmed and not accounted for in the reported SYSCLK
+- change: stm32/rcc/c0: rename `Hsi::sys_div` to `Hsi::div` and `HsiSysDiv` to `HsiDiv` (breaking change). The field sets HSIDIV, not SYSDIV; the old name suggested otherwise
 - fix: stm32/rcc/c0: raise the flash read access latency before anything that can raise the core frequency, so a configuration handed over from a bootloader without a reset cannot run above 24 MHz with too few wait states
-
 
 ## 0.6.0 - 2026-03-10
 

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -62,6 +62,10 @@ SAES:
 OSPI:
 - feat: stm32/ospi: add `Ospi::configure_hyperbus` + `HyperbusConfig`/`HyperbusLatencyMode` to program the HyperBus latency register (HLCR), enabling HyperBus/HyperRAM memory-mapped bring-up without reaching for `unstable-pac`
 
+RCC:
+- fix: stm32/rcc/c0: raise the flash read access latency before anything that can raise the core frequency, so a configuration handed over from a bootloader without a reset cannot run above 24 MHz with too few wait states
+
+
 ## 0.6.0 - 2026-03-10
 
 ADC:

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -1,6 +1,8 @@
 use crate::pac::flash::vals::Latency;
+#[cfg(rcc_c0v2)]
+pub use crate::pac::rcc::vals::Sysdiv as SysDiv;
 pub use crate::pac::rcc::vals::{
-    Hpre as AHBPrescaler, Hsidiv as HsiSysDiv, Hsikerdiv as HsiKerDiv, Ppre as APBPrescaler, Sw as Sysclk,
+    Hpre as AHBPrescaler, Hsidiv as HsiDiv, Hsikerdiv as HsiKerDiv, Ppre as APBPrescaler, Sw as Sysclk,
 };
 use crate::pac::{FLASH, RCC};
 use crate::rcc::LSI_FREQ;
@@ -30,8 +32,8 @@ pub struct Hse {
 /// HSI Configuration
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct Hsi {
-    /// Division factor for HSISYS clock. Default is 4.
-    pub sys_div: HsiSysDiv,
+    /// Division factor (HSIDIV) applied to HSI to produce HSISYS. Default is 4.
+    pub div: HsiDiv,
     /// Division factor for HSIKER clock. Default is 3.
     pub ker_div: HsiKerDiv,
 }
@@ -48,6 +50,10 @@ pub struct Config {
 
     /// System Clock Configuration
     pub sys: Sysclk,
+
+    /// Division factor (SYSDIV) applied to the output of the system clock mux to produce SYSCLK.
+    #[cfg(rcc_c0v2)]
+    pub sys_div: SysDiv,
 
     /// HSI48 Configuration
     #[cfg(crs)]
@@ -67,11 +73,13 @@ impl Config {
     pub const fn new() -> Self {
         Config {
             hsi: Some(Hsi {
-                sys_div: HsiSysDiv::Div4,
+                div: HsiDiv::Div4,
                 ker_div: HsiKerDiv::Div3,
             }),
             hse: None,
             sys: Sysclk::Hsisys,
+            #[cfg(rcc_c0v2)]
+            sys_div: SysDiv::Div1,
             #[cfg(crs)]
             hsi48: Some(crate::rcc::Hsi48Config::new()),
             ahb_pre: AHBPrescaler::Div1,
@@ -108,11 +116,7 @@ pub(crate) unsafe fn init(config: Config) {
     // Configure HSI
     let (hsi, hsisys, hsiker) = match config.hsi {
         None => (None, None, None),
-        Some(hsi) => (
-            Some(HSI_FREQ),
-            Some(HSI_FREQ / hsi.sys_div),
-            Some(HSI_FREQ / hsi.ker_div),
-        ),
+        Some(hsi) => (Some(HSI_FREQ), Some(HSI_FREQ / hsi.div), Some(HSI_FREQ / hsi.ker_div)),
     };
 
     // Configure HSE
@@ -140,6 +144,7 @@ pub(crate) unsafe fn init(config: Config) {
 
     let rtc = config.ls.init();
 
+    // Output of the system clock mux.
     let sys = match config.sys {
         Sysclk::Hsisys => unwrap!(hsisys),
         Sysclk::Hse => unwrap!(hse),
@@ -150,6 +155,10 @@ pub(crate) unsafe fn init(config: Config) {
         Sysclk::Lse => unwrap!(config.ls.lse).frequency,
         _ => unreachable!(),
     };
+
+    // SYSDIV divides the mux output to produce SYSCLK.
+    #[cfg(rcc_c0v2)]
+    let sys = sys / config.sys_div;
 
     rcc_assert!(max::SYSCLK.contains(&sys));
 
@@ -168,12 +177,20 @@ pub(crate) unsafe fn init(config: Config) {
     // Configure the HSI dividers.
     if let Some(hsi) = config.hsi {
         RCC.cr().modify(|w| {
-            w.set_hsidiv(hsi.sys_div);
+            w.set_hsidiv(hsi.div);
             w.set_hsikerdiv(hsi.ker_div);
         });
     }
 
-    // Now that the flash read access latency is configured, set up SYSCLK
+    // Now that the flash read access latency is configured, set up SYSCLK. SYSDIV has no ready
+    // flag; RM0490 documents reading a divider back to check its content, which also keeps the
+    // write from still being in flight when the latency is relaxed below.
+    #[cfg(rcc_c0v2)]
+    {
+        RCC.cr().modify(|w| w.set_sysdiv(config.sys_div));
+        while RCC.cr().read().sysdiv() != config.sys_div {}
+    }
+
     RCC.cfgr().modify(|w| {
         w.set_sw(config.sys);
         w.set_hpre(config.ahb_pre);

--- a/embassy-stm32/src/rcc/c0.rs
+++ b/embassy-stm32/src/rcc/c0.rs
@@ -89,18 +89,19 @@ impl Default for Config {
 }
 
 pub(crate) unsafe fn init(config: Config) {
-    // Turn on the HSI
-    match config.hsi {
-        None => RCC.cr().modify(|w| w.set_hsion(true)),
-        Some(hsi) => RCC.cr().modify(|w| {
-            w.set_hsidiv(hsi.sys_div);
-            w.set_hsikerdiv(hsi.ker_div);
-            w.set_hsion(true);
-        }),
-    }
+    // Configure the maximum flash read access latency up front, before anything that can raise the
+    // core frequency. Nothing below knows what the incoming configuration is: after a bootloader
+    // hands over without an intervening reset, HSIDIV may already be at /1, so even the switch to
+    // HSISYS a few lines down can take the core to 48 MHz. The latency is relaxed to the value the
+    // final HCLK actually requires once the clock tree has settled.
+    FLASH.acr().modify(|w| w.set_latency(Latency::Ws1));
+    while FLASH.acr().read().latency() != Latency::Ws1 {}
+
+    // Turn on the HSI and use it, at whatever divider it is currently set to, as system clock
+    // during the actual clock setup.
+    RCC.cr().modify(|w| w.set_hsion(true));
     while !RCC.cr().read().hsirdy() {}
 
-    // Use the HSI clock as system clock during the actual clock setup
     RCC.cfgr().modify(|w| w.set_sw(Sysclk::Hsisys));
     while RCC.cfgr().read().sws() != Sysclk::Hsisys {}
 
@@ -164,21 +165,28 @@ pub(crate) unsafe fn init(config: Config) {
         _ => Latency::Ws1,
     };
 
-    // Configure flash read access latency based on voltage scale and frequency
-    FLASH.acr().modify(|w| {
-        w.set_latency(latency);
-    });
+    // Configure the HSI dividers.
+    if let Some(hsi) = config.hsi {
+        RCC.cr().modify(|w| {
+            w.set_hsidiv(hsi.sys_div);
+            w.set_hsikerdiv(hsi.ker_div);
+        });
+    }
 
-    // Spin until the effective flash latency is set.
-    while FLASH.acr().read().latency() != latency {}
-
-    // Now that boost mode and flash read access latency are configured, set up SYSCLK
+    // Now that the flash read access latency is configured, set up SYSCLK
     RCC.cfgr().modify(|w| {
         w.set_sw(config.sys);
         w.set_hpre(config.ahb_pre);
         w.set_ppre(config.apb1_pre);
     });
     while RCC.cfgr().read().sws() != config.sys {}
+
+    // The clock tree has settled, so the flash read access latency can be relaxed to the value the
+    // final HCLK actually requires. Spin until the effective flash latency is set.
+    if latency != Latency::Ws1 {
+        FLASH.acr().modify(|w| w.set_latency(latency));
+        while FLASH.acr().read().latency() != latency {}
+    }
 
     // Disable HSI if not used
     if config.hsi.is_none() {

--- a/tests/stm32/src/common.rs
+++ b/tests/stm32/src/common.rs
@@ -469,10 +469,18 @@ pub fn config() -> Config {
     #[cfg(any(feature = "stm32c031c6", feature = "stm32c071rb"))]
     {
         config.rcc.hsi = Some(Hsi {
-            sys_div: HsiSysDiv::Div1, // 48Mhz
+            div: HsiDiv::Div1,        // 48Mhz
             ker_div: HsiKerDiv::Div3, // 16Mhz
         });
         config.rcc.sys = Sysclk::Hsisys;
+        // C071 is the only C0 board in the test rack with SYSDIV, so use it to prove the field
+        // reaches hardware: HSISYS stays at 48 MHz and SYSDIV halves it to a 24 MHz SYSCLK. If the
+        // write did not take effect the core would run at twice the frequency the driver assumes,
+        // and the timer and usart tests would fail. C031 has no SYSDIV and stays at 48 MHz.
+        #[cfg(feature = "stm32c071rb")]
+        {
+            config.rcc.sys_div = SysDiv::Div2; // 24Mhz
+        }
         config.rcc.ahb_pre = AHBPrescaler::Div1;
         config.rcc.apb1_pre = APBPrescaler::Div1;
     }


### PR DESCRIPTION
Fixes #4898.

  Per RM0490 figure 9, HSIDIV divides HSI to produce HSISYS; SYSDIV divides the
  sysclk mux output to produce SYSCLK.

  - Rename `Hsi::sys_div` to `Hsi::div` and `HsiSysDiv` to `HsiDiv`, to match the
    register they actually write (breaking).
  - Add `Config::sys_div` for SYSDIV, gated on the chips that have it (C051, C071,
    C091/C092). It was never programmed and never included in the reported SYSCLK.
