### PR TITLE
embassy-nrf/twim: prevent extra STOPs on ERROR

### DIFF
--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -96,17 +96,28 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
         let r = T::regs();
         let s = T::state();
 
-        if r.events_suspended().read() != 0 {
+        let suspended = r.events_suspended().read() != 0;
+        let stopped = r.events_stopped().read() != 0;
+        let error = r.events_error().read() != 0;
+
+        if suspended {
             s.end_waker.wake();
             r.intenclr().write(|w| w.set_suspended(true));
         }
-        if r.events_stopped().read() != 0 {
+        if stopped {
             s.end_waker.wake();
             r.intenclr().write(|w| w.set_stopped(true));
         }
-        if r.events_error().read() != 0 {
-            s.end_waker.wake();
+
+        // On error, instead of waking we will first issue a STOP (if it hasn't been issued yet).
+        if error {
             r.intenclr().write(|w| w.set_error(true));
+
+            // Explicitly issue a STOP if an error has occurred which has not yet resulted in a STOP.
+            // This can happen with for example an ANACK.
+            if !stopped {
+                r.tasks_stop().write_value(1);
+            }
         }
     }
 }
@@ -356,28 +367,16 @@ impl<'d> Twim<'d> {
         Ok(())
     }
 
-    /// Wait for stop or error
-    async fn async_wait(&mut self) -> Result<(), Error> {
+    /// Wait for suspend or stop
+    async fn async_wait(&mut self) {
         poll_fn(|cx| {
             let r = self.r;
             let s = self.state;
 
             s.end_waker.register(cx.waker());
             if r.events_suspended().read() != 0 || r.events_stopped().read() != 0 {
-                r.events_stopped().write_value(0);
-
-                return Poll::Ready(Ok(()));
-            }
-
-            // stop if an error occurred
-            if r.events_error().read() != 0 {
-                r.events_error().write_value(0);
-                r.tasks_stop().write_value(1);
-                if let Err(e) = self.check_errorsrc() {
-                    return Poll::Ready(Err(e));
-                } else {
-                    return Poll::Ready(Err(Error::Timeout));
-                }
+                // Events are cleared when setting up the next operation.
+                return Poll::Ready(());
             }
 
             Poll::Pending
@@ -618,7 +617,7 @@ impl<'d> Twim<'d> {
         while !operations.is_empty() {
             let ops = self.setup_operations(address, operations, last_op, true)?;
             let (in_progress, rest) = operations.split_at_mut(ops);
-            self.async_wait().await?;
+            self.async_wait().await;
             self.check_operations(in_progress)?;
             last_op = in_progress.last();
             operations = rest;


### PR DESCRIPTION
Solves #6722. Tested on NRF52840-DK and custom NRF9160 board.

The NRF TWIM can issue an ERROR event without a STOP event also being issued. This happens for example with an ANACK (address nack). The manual states:
> The TWI master does not stop by itself when the RAM buffer is full, or when an error occurs. The STOP task must be issued, using a local or PPI shortcut, or in software as part of the error handler.

What the manual does not say, that if you issue STOP when no transfer is happening, that the peripheral goes into a broken state. 
Thus we should prevent STOP from being issued by the driver, unless it is necessary.

This PR moves **only for the async driver** the issuance of STOP in the event of an ERROR to the interrupt handler. STOP is still being issued in the blocking API, as well as in the transaction loop when there are no more pending transactions.

This PR loses the ability to emit `Error::Timeout`, but it is not clear to me how this was ever going to be triggered. The ERROR event should never be pending without `errorsrc` also containing something.

## Further work
This PR does not fix the rule:
> The TWI master cannot be stopped while suspended, so the STOP task must be issued after the TWI master has been resumed.

We were already not following that rule currently, but peeking into [the nrfx implementation](https://github.com/nordicsemi/nrfx/blob/1b7bedb5c7f379a3ec3ece851796e94d7e5d0b2c/drivers/src/nrfx_twim.c#L752-L769) got me thinking whether we maybe should.

Please discuss if we should tackle that, and if so in this PR or in another PR.
