### PR TITLE
embassy-stm32: always issue secure DMA transactions on STM32N6

### DIFF
--- a/embassy-stm32/src/dma/gpdma/mod.rs
+++ b/embassy-stm32/src/dma/gpdma/mod.rs
@@ -403,7 +403,7 @@ pub struct TransferOptions {
     /// attribute set (`TR1.SSEC = TR1.DSEC = 1`). Required when the channel
     /// is configured secure (`SECCFGR.SEC[n]=1`) and the slave is behind
     /// RISAF — without this the channel hits `ULEF` (user setting error)
-    /// after partial progress. Default `false`.
+    /// after partial progress. Default `true`.
     #[cfg(stm32n6)]
     pub secure: bool,
     /// DMA packing configuration
@@ -434,7 +434,7 @@ impl Default for TransferOptions {
             half_transfer_ir: false,
             complete_transfer_ir: true,
             #[cfg(stm32n6)]
-            secure: false,
+            secure: true,
             packing: vals::Pam::Pack,
 
             #[cfg(not(stm32c5))]


### PR DESCRIPTION
SPI transfers were not working properly when using DMA on N6
RIFSC filters non-secure accesses to a secure-granted SPI, so DMA transfers fail even with the GPDMA channel promoted secure.  So transfer should be marked secure too.

I have used the same approach already used for ADC (@jake-taf) and JPEG (@tarfu)
But in principle the same failure would be present for all peripherals that use GPDMA

Do you think it could make sense to just default `secure` to true?  This would solve the problem for all the peripherals without additional changes

https://github.com/embassy-rs/embassy/blob/6824656e486ac6e224b0c58e950eae96cfd73e3f/embassy-stm32/src/dma/gpdma/mod.rs#L437