### PR TITLE
stm32: Fix I2C controller v2/v3 10-bit addressing

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -30,6 +30,7 @@ I2C:
 - feat: stm32/i2cv2: support zero-length transfers instead of returning `Error::ZeroLengthTransfer`, enabling bus scans via `transaction(addr, &mut [Operation::Write(&[])])`. On the slave side an empty `respond_to_write` accepts zero bytes and an empty `respond_to_read` sends `0xFF` filler, since I2C cannot encode "nothing to send"; both previously left ADDR set, holding SCL low and wedging the bus
 - fix: stm32/i2cv2: handle a master RESTART during async slave `respond_to_read` instead of stalling until the transaction times out
 - fix: stm32/i2cv2: re-enable TCIE after starting a DMA write group, so an async `transaction()` whose write group is not the first group completes instead of hanging until it times out
+- fix: stm32/i2cv2: program `CR2.SADD` without the 7-bit left shift when addressing a 10-bit target, which was putting every `Address::TenBit` on the bus one bit too far left and so addressing a different device
 
 ADC:
 - feat: stm32/adc: add `VrefInt::calibrated_value()` for additional chips

--- a/embassy-stm32/src/i2c/config.rs
+++ b/embassy-stm32/src/i2c/config.rs
@@ -60,6 +60,22 @@ impl Address {
     }
 }
 
+// Only used by v2, which addresses in hardware and so needs the address in the register layout rather
+// than as wire bytes. Gated so v1-only builds don't trigger dead_code.
+#[cfg(any(i2c_v2, i2c_v3, test))]
+impl Address {
+    /// The address as `CR2.SADD` and `OAR1.OA1` hold it.
+    pub(super) fn sadd(&self) -> u16 {
+        // A 7-bit address occupies bits 7:1 of those fields but a 10-bit one bits 9:0, so only the
+        // former is shifted. Shifting both moves the two bits a 10-bit header carries out of place,
+        // addressing a different device.
+        match self {
+            Address::SevenBit(addr) => (*addr as u16) << 1,
+            Address::TenBit(addr) => *addr,
+        }
+    }
+}
+
 // These methods are only used by the v1 software address sequencing (v2 handles
 // 10-bit addressing in hardware). Gated so v2-only builds don't trigger dead_code.
 #[cfg(any(i2c_v1, test))]
@@ -267,6 +283,41 @@ mod tests {
         assert_eq!(Address::SevenBit(0x79).write_header(), 0xF2);
         assert_eq!(Address::SevenBit(0x7A).write_header(), 0xF4);
         assert_eq!(Address::SevenBit(0x7B).write_header(), 0xF6);
+    }
+
+    #[test]
+    fn sadd_seven_bit_is_left_aligned() {
+        // SADD[7:1] holds a 7-bit address, so it is shifted up one.
+        assert_eq!(Address::SevenBit(0x00).sadd(), 0x000);
+        assert_eq!(Address::SevenBit(0x48).sadd(), 0x090);
+        assert_eq!(Address::SevenBit(0x7F).sadd(), 0x0FE);
+    }
+
+    #[test]
+    fn sadd_ten_bit_is_not_shifted() {
+        // SADD[9:0] holds a 10-bit address whole. Shifting it here is what moved the two high bits one
+        // place too far left, so that 0x148 addressed 0x290.
+        assert_eq!(Address::TenBit(0x000).sadd(), 0x000);
+        assert_eq!(Address::TenBit(0x148).sadd(), 0x148);
+        assert_eq!(Address::TenBit(0x3FF).sadd(), 0x3FF);
+    }
+
+    #[test]
+    fn sadd_ten_bit_keeps_the_header_bits_addressable() {
+        // The two bits the header carries are SADD[9:8], and each combination has to survive as itself.
+        for (addr, upper) in [(0x000u16, 0b00), (0x100, 0b01), (0x200, 0b10), (0x300, 0b11)] {
+            assert_eq!(Address::TenBit(addr).sadd() >> 8, upper);
+        }
+    }
+
+    #[test]
+    fn sadd_matches_the_wire_header_v1_builds() {
+        // The two versions program different hardware from the same address, so they must agree about
+        // which bits are which: v1 writes the header byte itself, v2 lets the peripheral build it.
+        for addr in [0x000u16, 0x001, 0x0FF, 0x148, 0x255, 0x3FF] {
+            let from_sadd = 0xF0 | ((Address::TenBit(addr).sadd() >> 7) as u8 & 0x06);
+            assert_eq!(from_sadd, Address::TenBit(addr).write_header());
+        }
     }
 
     #[test]

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -190,7 +190,7 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
         // is BUSY or I2C is in slave mode.
 
         info.regs.cr2().modify(|w| {
-            w.set_sadd(address.addr() << 1);
+            w.set_sadd(address.sadd());
             w.set_add10(address.add_mode());
             w.set_dir(i2c::vals::Dir::Read);
             w.set_nbytes(length as u8);
@@ -225,7 +225,7 @@ impl<'d, M: Mode, IM: MasterMode> I2c<'d, M, IM> {
         // START bit can be set even if the bus is BUSY or
         // I2C is in slave mode.
         info.regs.cr2().modify(|w| {
-            w.set_sadd(address.addr() << 1);
+            w.set_sadd(address.sadd());
             w.set_add10(address.add_mode());
             w.set_dir(i2c::vals::Dir::Write);
             w.set_nbytes(length as u8);


### PR DESCRIPTION
Found while testing 10-bit addressing in `embassy-mspm0`.

`I2cSlave::configure_oa1` and the controller's `master_read`/`master_write` disagreed about the layout of an
address register.

`CR2.SADD` and `OAR1.OA1` both hold a 7-bit address in bits 7:1 and a 10-bit address in bits 9:0. The target
side already distinguished them:

```rust
Address::SevenBit(addr) => { reg.set_oa1((addr << 1) as u16); reg.set_oa1mode(Addmode::Bit7); }
Address::TenBit(addr)   => { reg.set_oa1(addr);               reg.set_oa1mode(Addmode::Bit10); }
```

The controller side did not:

```rust
w.set_sadd(address.addr() << 1);
w.set_add10(address.add_mode());
```

Reproduced and validated against the MSPM0 and RP2040 target implementations.
