### PR TITLE
MSPM0:  update mspm0-metapac & internal temperature sensor

### DIFF
--- a/embassy-mspm0/CHANGELOG.md
+++ b/embassy-mspm0/CHANGELOG.md
@@ -26,3 +26,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix: feature guard pins used for NRST and SWD (#5257)
 - feat: Move from GPIO waker arrays to maitake-sync wait map
 - fix: Flush the I2C controller FIFOs on the NACK/error paths, to prevent stale data
+- feat: Add `TempSensorChannel` and `read_temp_calibration_constant()` for the internal temperature sensor

--- a/embassy-mspm0/Cargo.toml
+++ b/embassy-mspm0/Cargo.toml
@@ -74,7 +74,7 @@ critical-section = "1.2.0"
 micromath = "2.0.0"
 
 # mspm0-metapac = { version = "" }
-mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-f78bc71fcc6d74b25c2cae58220d8bf443fb12df" }
+mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-4be499610ef6e0d40ab18a5d362171e9a07310e1" }
 rand_core = "0.9"
 # Force no cache padding or the types are too large.
 maitake-sync = { version = "0.3.0", default-features = false, features = ["critical-section", "no-cache-pad"]}
@@ -88,7 +88,7 @@ quote = "1.0.40"
 cfg_aliases = "0.2.1"
 
 # mspm0-metapac = { version = "", default-features = false, features = ["metadata"] }
-mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-f78bc71fcc6d74b25c2cae58220d8bf443fb12df", default-features = false, features = ["metadata"] }
+mspm0-metapac = { git = "https://github.com/mspm0-rs/mspm0-data-generated/", tag = "mspm0-data-4be499610ef6e0d40ab18a5d362171e9a07310e1", default-features = false, features = ["metadata"] }
 
 [features]
 default = ["rt"]

--- a/embassy-mspm0/build.rs
+++ b/embassy-mspm0/build.rs
@@ -145,6 +145,29 @@ fn get_chip_cfgs(chip_name: &str) -> Vec<String> {
         cfgs.push("mspm0l222x".to_string());
     }
 
+    // Devices with an internal temperature sensor, see `TEMP_SENSOR_CHANNEL` in `adc.rs`.
+    const TEMP_SENSOR_FAMILIES: &[&str] = &[
+        "mspm0c110x",
+        "mspm0c1105_c1106",
+        "mspm0g110x",
+        "mspm0g150x",
+        "mspm0g151x",
+        "mspm0g310x",
+        "mspm0g350x",
+        "mspm0g351x",
+        "mspm0g518x",
+        "mspm0h321x",
+        "mspm0l110x",
+        "mspm0l122x",
+        "mspm0l130x",
+        "mspm0l134x",
+        "mspm0l222x",
+    ];
+
+    if cfgs.iter().any(|cfg| TEMP_SENSOR_FAMILIES.contains(&cfg.as_str())) {
+        cfgs.push("temp_sensor".to_string());
+    }
+
     cfgs
 }
 

--- a/embassy-mspm0/src/adc.rs
+++ b/embassy-mspm0/src/adc.rs
@@ -641,3 +641,35 @@ macro_rules! impl_adc_pin {
         }
     };
 }
+
+/// The ADC0 channel the temperature sensor is connected to.
+///
+/// See `SYS_TEMP_SENSE_CHANNEL` in the device specific data sheet. ADC1 uses a different
+/// channel (12 on the G-series), which is not exposed.
+#[cfg(any(
+    mspm0c110x, mspm0g110x, mspm0g150x, mspm0g151x, mspm0g310x, mspm0g350x, mspm0g351x, mspm0l110x, mspm0l130x,
+    mspm0l134x
+))]
+const TEMP_SENSOR_CHANNEL: u8 = 11;
+
+#[cfg(any(mspm0c1105_c1106, mspm0h321x))]
+const TEMP_SENSOR_CHANNEL: u8 = 28;
+
+#[cfg(any(mspm0g518x, mspm0l122x, mspm0l222x))]
+const TEMP_SENSOR_CHANNEL: u8 = 29;
+
+/// Internal temperature sensor channel.
+///
+/// Uses an internal ADC0 channel, no external pin is required. It can be sampled like a
+/// regular [`AdcChannel`].
+#[cfg(temp_sensor)]
+pub struct TempSensorChannel;
+
+#[cfg(temp_sensor)]
+impl crate::adc::AdcChannel<crate::peripherals::ADC0> for TempSensorChannel {}
+#[cfg(temp_sensor)]
+impl crate::adc::SealedAdcChannel<crate::peripherals::ADC0> for TempSensorChannel {
+    fn channel(&self) -> u8 {
+        TEMP_SENSOR_CHANNEL
+    }
+}

--- a/embassy-mspm0/src/lib.rs
+++ b/embassy-mspm0/src/lib.rs
@@ -359,3 +359,18 @@ pub fn read_reset_cause() -> Result<ResetCause, u8> {
         other => Err(other as u8),
     }
 }
+
+/// Read the factory-region temperature sensor calibration constant.
+///
+/// This reads `FACTORYREGION.TEMP_SENSE0`, the reading of the internal temperature sensor
+/// at the factory trim temperature, used to convert raw ADC readings to a temperature.
+///
+/// The value is a right-aligned 12-bit ADC code sampled with the 1.4V internal reference.
+///
+/// Only available on devices with an internal temperature sensor, see
+/// [`adc::TempSensorChannel`].
+#[cfg(temp_sensor)]
+#[must_use = "The calibration constant should be used to convert ADC readings to temperature"]
+pub fn read_temp_calibration_constant() -> u32 {
+    pac::FACTORYREGION.temp_sense0().read()
+}

--- a/examples/mspm0g3507/src/bin/adc_temp_sensor.rs
+++ b/examples/mspm0g3507/src/bin/adc_temp_sensor.rs
@@ -1,0 +1,70 @@
+//! Example of reading the internal temperature sensor of the MSPM0G3507.
+//!
+//! This ports the TI C example `adc12_internal_temp_sensor_mathacl` to embassy. It reads
+//! the factory calibration constant, samples the sensor and converts the result to degrees
+//! Celsius and Fahrenheit, using the MATHACL accelerator for the divisions.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_mspm0::adc::{self, Adc, Conversion, TempSensorChannel};
+use embassy_mspm0::mathacl::{IQType, Mathacl};
+use embassy_mspm0::{bind_interrupts, peripherals, read_temp_calibration_constant};
+use embassy_time::Timer;
+use panic_halt as _;
+
+bind_interrupts!(struct Irqs {
+    ADC0 => adc::InterruptHandler<peripherals::ADC0>;
+});
+
+// Temperature sensor trim parameters from the device datasheet ("Temperature Sensor").
+const TEMP_TS_TRIM_C: f32 = 30.0;
+// 1 / TSc, where TSc is the temperature sensor coefficient from the datasheet.
+const TEMP_TS_COEF_MV_C: f32 = -555.55;
+const ADC_VREF_VOLTAGE: f32 = 3.3;
+const ADC_BIT_RESOLUTION: f32 = 4096.0; // 2^12
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) -> ! {
+    info!("Hello world!");
+
+    let d = embassy_mspm0::init(Default::default());
+
+    let mut adc = Adc::new_async(d.ADC0, Irqs, Default::default());
+    let mut mathacl = Mathacl::new(d.MATHACL);
+    let mut temp_sensor = TempSensorChannel;
+
+    // 12-bit ADC code of the temp sensor at 30 C.
+    let cal = read_temp_calibration_constant();
+
+    // Vtrim = ADC_VREF * (TEMP_SENSE0 - 0.5) / 2^12, computed with MATHACL division.
+    let vtrim = mathacl
+        .div_iq(
+            IQType::from_f32((cal as f32 - 0.5) * ADC_VREF_VOLTAGE, 15, true).unwrap(),
+            IQType::from_f32(ADC_BIT_RESOLUTION, 15, true).unwrap(),
+        )
+        .unwrap();
+
+    loop {
+        let adc_result = adc.blocking_read(&mut temp_sensor, Conversion::default());
+
+        // Vsample = ADC_VREF * (adcResult - 0.5) / 2^12, computed with MATHACL division.
+        let vsample = mathacl
+            .div_iq(
+                IQType::from_f32((adc_result as f32 - 0.5) * ADC_VREF_VOLTAGE, 15, true).unwrap(),
+                IQType::from_f32(ADC_BIT_RESOLUTION, 15, true).unwrap(),
+            )
+            .unwrap();
+
+        // TSAMPLE = TEMP_TS_COEF_mV_C * (Vsample - Vtrim) + TEMP_TS_TRIM_C
+        let temp_deg_c = TEMP_TS_COEF_MV_C * (vsample - vtrim) + TEMP_TS_TRIM_C;
+        let temp_deg_f = temp_deg_c * 1.8 + 32.0;
+
+        info!("Temperature: {} C, {} F", temp_deg_c, temp_deg_f);
+
+        Timer::after_millis(500).await;
+    }
+}


### PR DESCRIPTION
Changes:
- Update mspm0-metapac to mspm0-data-4be4996
- mspm0: add internal temperature sensor channel
- mspm0: add internal temperature sensor example for g3507


Running on g3507 showed following print:
````
[INFO ] Temperature: 28.652153 C, 83.573875 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 28.652153 C, 83.573875 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 29.101437 C, 84.38258 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)    <--- here I started applying hair dryer :smile: 
[INFO ] Temperature: 29.101437 C, 84.38258 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 29.550718 C, 85.19129 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 30.0 C, 86.0 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 31.339369 C, 88.41086 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 32.237934 C, 90.028275 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 33.5773 C, 92.43914 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 34.925148 C, 94.865265 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
[INFO ] Temperature: 36.26452 C, 97.27613 F (adc_temp_sensor src/bin/adc_temp_sensor.rs:66)
...
```