### PR TITLE
stm32/adc: reexport prescaler

### DIFF
--- a/embassy-stm32/src/adc/mod.rs
+++ b/embassy-stm32/src/adc/mod.rs
@@ -51,6 +51,8 @@ pub use crate::pac::adc::vals::Exten;
 #[cfg(not(any(adc_f1, adc_f3v3)))]
 pub use crate::pac::adc::vals::Res as Resolution;
 pub use crate::pac::adc::vals::SampleTime;
+#[cfg(any(adc_h5, adc_h7rs))]
+pub use crate::pac::adccommon::vals::Presc as Prescaler;
 #[allow(unused_imports)]
 use crate::{peripherals, rcc};
 


### PR DESCRIPTION
This type is required to set prescaler in `AdcConfig`:
https://github.com/embassy-rs/embassy/blob/7cb8662151e97f1c857f370bd76fca7af94496db/embassy-stm32/src/adc/v3.rs#L178-L180