### PR TITLE
stm32: add clear to spi and usart ring buffer

### DIFF
--- a/embassy-stm32/src/spi/ringbuffered.rs
+++ b/embassy-stm32/src/spi/ringbuffered.rs
@@ -180,6 +180,11 @@ impl<'d, W: Word> RingBufferedSpiRx<'d, W> {
         compiler_fence(Ordering::SeqCst);
     }
 
+    /// Clears ring buffer.
+    pub fn clear(&mut self) {
+        self.ring_buf.clear();
+    }
+
     /// (Re-)start DMA and SPI if it is not running (has not been started yet or has failed), and
     /// check for errors in status register. Error flags are checked/cleared first.
     fn start_or_check_errors(&mut self) -> Result<(), Error> {

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -195,6 +195,11 @@ impl<'d> RingBufferedUartRx<'d> {
         compiler_fence(Ordering::SeqCst);
     }
 
+    /// Clears ring buffer.
+    pub fn clear(&mut self) {
+        self.ring_buf.clear();
+    }
+
     /// (Re-)start DMA and Uart if it is not running (has not been started yet or has failed), and
     /// check for errors in status register. Error flags are checked/cleared first.
     fn start_dma_or_check_errors(&mut self) -> Result<(), Error> {


### PR DESCRIPTION
Like in ADC ring buffer:
https://github.com/embassy-rs/embassy/blob/7cb8662151e97f1c857f370bd76fca7af94496db/embassy-stm32/src/adc/ringbuffered.rs#L87-L89

Tested on STM32F411CE.