### PR TITLE
stm32/gpio: flex::reborrow

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -32,7 +32,6 @@ impl<'d> Flex<'d> {
         Self { pin: pin.into() }
     }
 
-
     /// Unsafely clone (duplicate) a Flex.
     pub unsafe fn clone_unchecked(&self) -> Flex<'d> {
         Flex {

--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -18,7 +18,6 @@ use crate::peripherals;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Flex<'d> {
     pub(crate) pin: Peri<'d, AnyPin>,
-    borrowed: bool,
 }
 
 impl<'d> Flex<'d> {
@@ -30,27 +29,14 @@ impl<'d> Flex<'d> {
     #[inline]
     pub fn new(pin: Peri<'d, impl Pin>) -> Self {
         // Pin will be in disconnected state.
-        Self {
-            pin: pin.into(),
-            borrowed: false,
-        }
+        Self { pin: pin.into() }
     }
 
-    /// Reborrow into a "child" Flex.
-    ///
-    /// `self` will stay borrowed until the child Peripheral is dropped.
-    pub fn reborrow(&mut self) -> Flex<'_> {
-        Flex {
-            pin: self.pin.reborrow(),
-            borrowed: true,
-        }
-    }
 
     /// Unsafely clone (duplicate) a Flex.
     pub unsafe fn clone_unchecked(&self) -> Flex<'d> {
         Flex {
             pin: self.pin.clone_unchecked(),
-            borrowed: self.borrowed,
         }
     }
 
@@ -257,9 +243,6 @@ impl<'d> Flex<'d> {
 impl<'d> Drop for Flex<'d> {
     #[inline]
     fn drop(&mut self) {
-        if self.borrowed {
-            return;
-        }
         trace!("gpio: dropping {}", self.pin);
         critical_section::with(|_| {
             self.pin.set_as_disconnected();

--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -1,8 +1,8 @@
 use core::future::poll_fn;
 use core::marker::PhantomData;
-use core::slice;
 use core::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
 use core::task::Poll;
+use core::{mem, slice};
 
 use embassy_embedded_hal::SetConfig;
 use embassy_hal_internal::Peri;
@@ -563,25 +563,27 @@ impl<'d> BufferedUart<'d> {
     /// which is particularly useful when having two tasks correlating to
     /// transmitting and receiving.
     pub fn split_ref(&mut self) -> (BufferedUartTx<'_>, BufferedUartRx<'_>) {
-        (
-            BufferedUartTx {
-                info: self.tx.info,
-                state: self.tx.state,
-                kernel_clock: self.tx.kernel_clock,
-                tx: self.tx.tx.as_mut().map(Flex::reborrow),
-                cts: self.tx.cts.as_mut().map(Flex::reborrow),
-                de: self.tx.de.as_mut().map(Flex::reborrow),
-                is_borrowed: true,
-            },
-            BufferedUartRx {
-                info: self.rx.info,
-                state: self.rx.state,
-                kernel_clock: self.rx.kernel_clock,
-                rx: self.rx.rx.as_mut().map(Flex::reborrow),
-                rts: self.rx.rts.as_mut().map(Flex::reborrow),
-                is_borrowed: true,
-            },
-        )
+        unsafe {
+            (
+                BufferedUartTx {
+                    info: self.tx.info,
+                    state: self.tx.state,
+                    kernel_clock: self.tx.kernel_clock,
+                    tx: self.tx.tx.as_mut().map(|p| p.clone_unchecked()),
+                    cts: self.tx.cts.as_mut().map(|p| p.clone_unchecked()),
+                    de: self.tx.de.as_mut().map(|p| p.clone_unchecked()),
+                    is_borrowed: true,
+                },
+                BufferedUartRx {
+                    info: self.rx.info,
+                    state: self.rx.state,
+                    kernel_clock: self.rx.kernel_clock,
+                    rx: self.rx.rx.as_mut().map(|p| p.clone_unchecked()),
+                    rts: self.rx.rts.as_mut().map(|p| p.clone_unchecked()),
+                    is_borrowed: true,
+                },
+            )
+        }
     }
 
     /// Reconfigure the driver
@@ -869,6 +871,9 @@ impl<'d> Drop for BufferedUartRx<'d> {
             }
 
             drop_tx_rx(self.info, state);
+        } else {
+            mem::forget(self.rts.take());
+            mem::forget(self.rx.take());
         }
     }
 }
@@ -887,6 +892,10 @@ impl<'d> Drop for BufferedUartTx<'d> {
                 }
             }
             drop_tx_rx(self.info, state);
+        } else {
+            mem::forget(self.tx.take());
+            mem::forget(self.cts.take());
+            mem::forget(self.de.take());
         }
     }
 }


### PR DESCRIPTION
partially reverts #6454 to save space on storing the pins.