### PR TITLE
add ASRMicroelectronics ASR6601xx support

### DIFF
--- a/embassy-asr/Cargo.toml
+++ b/embassy-asr/Cargo.toml
@@ -17,10 +17,21 @@ features = ["asr6601", "time-driver-rtc"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
+embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
+embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver", optional = true }
 embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-utils", optional = true }
 
+embedded-hal = "1.0"
+embedded-hal-async = "1.0"
+embedded-io = "0.7.1"
+embedded-io-async = "0.7.0"
+embedded-storage = "0.3.1"
+rand_core = "0.9"
+
+defmt = { version = "1.0.1", optional = true }
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 critical-section = "1.1"
@@ -34,6 +45,14 @@ features = ["critical-section", "rt"]
 [features]
 default = ["asr6601", "time-driver-rtc"]
 
+defmt = [
+    "dep:defmt",
+    "embassy-embedded-hal/defmt",
+    "embassy-futures/defmt",
+    "embassy-hal-internal/defmt",
+    "embassy-sync/defmt",
+]
+
 _time-driver = ["dep:embassy-time-driver", "dep:embassy-time-queue-utils"]
 
 # RTC is clocked from the always-on XO32K domain. Its calendar provides the
@@ -44,4 +63,5 @@ time-driver-rtc = [
     "embassy-time-driver?/tick-hz-32_768",
 ]
 
-asr6601 = ["dep:asr6601-pac"]
+rt = []
+asr6601 = ["dep:asr6601-pac", "rt"]

--- a/embassy-asr/Cargo.toml
+++ b/embassy-asr/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "embassy-asr"
+version = "0.1.0"
+edition = "2024"
+description = "Embassy support for ASR microcontrollers"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/embassy-rs/embassy"
+documentation = "https://docs.embassy.dev/embassy-asr"
+
+[package.metadata.embassy]
+build = [
+    { target = "thumbv7em-none-eabihf", features = ["asr6601", "time-driver-rtc"] },
+]
+
+[package.metadata.docs.rs]
+features = ["asr6601", "time-driver-rtc"]
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-3"] }
+embassy-time-driver = { version = "0.2.2", path = "../embassy-time-driver", optional = true }
+embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-utils", optional = true }
+
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
+critical-section = "1.1"
+
+[dependencies.asr6601-pac]
+version = "0.1.0"
+git = "https://github.com/Kezii/ASR6601-PAC.git"
+optional = true
+features = ["critical-section", "rt"]
+
+[features]
+default = ["asr6601", "time-driver-rtc"]
+
+_time-driver = ["dep:embassy-time-driver", "dep:embassy-time-queue-utils"]
+
+# RTC is clocked from the always-on XO32K domain. Its calendar provides the
+# monotonic clock and its cyclic counter wakes the processor for deadlines.
+time-driver-rtc = [
+    "_time-driver",
+    "asr6601",
+    "embassy-time-driver?/tick-hz-32_768",
+]
+
+asr6601 = ["dep:asr6601-pac"]

--- a/embassy-asr/README.md
+++ b/embassy-asr/README.md
@@ -1,14 +1,15 @@
 # embassy-asr
 
-Minimal [Embassy](https://embassy.dev/) support for ASR microcontrollers.
+[Embassy](https://embassy.dev/) support for ASR microcontrollers.
 
 ## Current support
 
 - ASR6601
+- Peripheral ownership and type-level interrupt infrastructure
 - `embassy-time` driver using the always-on RTC at 32,768 Hz
 - Cortex-M thread executor support through `embassy-executor`
-
-There is no peripheral HAL yet.
+- Early HAL drivers for GPIO, UART, SPI, I2C, timers, DMA, ADC, DAC,
+  LPUART, LPTIMER, CRC, RNG, flash, power, AFEC, and RCC
 
 ## RTC time driver
 
@@ -19,7 +20,7 @@ The driver:
 
 - requires a working 32.768 kHz crystal on XO32K;
 - resets RTC and starts its calendar at `2000-01-01 00:00:00` during
-  `embassy_asr::init()`;
+  `embassy_asr::init(Config::default())`;
 - owns RTC exclusively, so application code must not access RTC through the
   raw PAC;
 - rounds hardware wakeups shorter than 164 ticks up to about 5 ms;

--- a/embassy-asr/README.md
+++ b/embassy-asr/README.md
@@ -1,0 +1,35 @@
+# embassy-asr
+
+Minimal [Embassy](https://embassy.dev/) support for ASR microcontrollers.
+
+## Current support
+
+- ASR6601
+- `embassy-time` driver using the always-on RTC at 32,768 Hz
+- Cortex-M thread executor support through `embassy-executor`
+
+There is no peripheral HAL yet.
+
+## RTC time driver
+
+Enable the `time-driver-rtc` feature to use the RTC calendar as Embassy's
+monotonic clock and its cyclic counter for wakeups.
+
+The driver:
+
+- requires a working 32.768 kHz crystal on XO32K;
+- resets RTC and starts its calendar at `2000-01-01 00:00:00` during
+  `embassy_asr::init()`;
+- owns RTC exclusively, so application code must not access RTC through the
+  raw PAC;
+- rounds hardware wakeups shorter than 164 ticks up to about 5 ms;
+- supports one global Embassy time driver; and
+- enables the RTC interrupt at NVIC priority 2.
+
+The application must provide a `critical-section` implementation. For a
+single-core Cortex-M application, enable `cortex-m`'s
+`critical-section-single-core` feature.
+
+The current initialization intentionally does not preserve a bootloader or
+previous low-power session's RTC calendar. Applications that need retained
+wall-clock state must save it before initialization and restore it separately.

--- a/embassy-asr/src/adc.rs
+++ b/embassy-asr/src/adc.rs
@@ -1,0 +1,827 @@
+//! Analog-to-digital converter (ADC).
+//!
+//! Register programming follows the vendor `tremo_adc` driver and the SDK
+//! `adc/single_mode` / `adc/continue_mode` examples. Analog power-up and
+//! reference selection use the AFEC analog window via [`crate::afec::analog`].
+//!
+//! # Documented external channels
+//!
+//! Datasheet GPIO mux (Analog column) and SDK sample-channel numbering
+//! (`ADC_SAMPLE_CHAN_0` is reserved, so `ADC_INn` maps to sample channel
+//! `n + 1`):
+//!
+//! | Datasheet | Pin   | [`SampleChannel`] |
+//! |-----------|-------|-------------------|
+//! | ADC_IN0   | PA11  | [`SampleChannel::In0`] |
+//! | ADC_IN1   | PA8   | [`SampleChannel::In1`] |
+//! | ADC_IN2   | PA5   | [`SampleChannel::In2`] |
+//! | ADC_IN3   | PA4   | [`SampleChannel::In3`] |
+//! | ADC_IN7   | PC15  | [`SampleChannel::In7`] |
+//!
+//! Pins are placed in GPIO analog mode (vendor `GPIO_MODE_ANALOG`) with AF0.
+//! The ADC path does not use a non-zero alternate-function number.
+//!
+//! # Calibration
+//!
+//! Factory gain/offset constants live at `0x1000_2030` / `0x1000_2034` (not in
+//! the PAC). Convert raw codes with [`Calibration::to_voltage`] using the
+//! internal 1.2 V reference assumed by the SDK examples.
+//!
+//! # DMA
+//!
+//! [`Adc::set_dma_enabled`] only toggles `CFGR.DMAEN`. Applications that need
+//! DMA should configure a peripheral-to-memory channel whose source is
+//! [`Adc::dr_address`] and whose request is [`crate::dma::Request::Adc`].
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::Priority;
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::afec::analog;
+use crate::gpio::{AlternateFunction, Flex, Pin};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, interrupt, pac, peripherals};
+
+/// Maximum useful sequence length (hardware slots 0..=15; slot value 0 ends).
+pub const MAX_SEQUENCE_LEN: usize = 16;
+
+/// 12-bit full-scale code.
+pub const MAX_VALUE: u16 = 0x0fff;
+
+/// Internal reference voltage used by the SDK calibration examples (volts).
+pub const INTERNAL_VREF_VOLTS: f32 = 1.2;
+
+const CR_ENABLE: u32 = 1 << 0;
+const CR_DISABLE: u32 = 1 << 1;
+const CR_START: u32 = 1 << 2;
+const CR_STOP: u32 = 1 << 3;
+
+const CFGR_CLK_DIV_MASK: u32 = 0x0fff;
+const CFGR_DMA_ENABLE: u32 = 1 << 12;
+const CFGR_TRG_SOURCE_MASK: u32 = 0x1e000;
+const CFGR_TRG_POLARITY_MASK: u32 = 0x60000;
+const CFGR_OVERRUN_MODE: u32 = 1 << 19;
+const CFGR_CONV_MODE_MASK: u32 = 0x300000;
+const CFGR_CONV_MODE_SINGLE: u32 = 0x0;
+const CFGR_CONV_MODE_CONTINUE: u32 = 0x100000;
+const CFGR_WAIT_MODE: u32 = 1 << 22;
+
+/// Vendor `adc_init()`: clear AFEC analog REG_11 bits `[9:6]`.
+const ANALOG_11_ADC_INIT_MASK: u32 = 0xf << 6;
+/// Vendor `adc_config_ref_voltage(INTERNAL)`: REG_12 bit 6.
+const ANALOG_12_INTERNAL_REF: u32 = 1 << 6;
+/// Vendor `adc_enable_vbat31`: REG_2C bit 25.
+const ANALOG_2C_VBAT31: u32 = 1 << 25;
+
+const CALIB_GAIN_ADDR: usize = 0x1000_2030;
+const CALIB_DCO_ADDR: usize = 0x1000_2034;
+
+static WAKER: AtomicWaker = AtomicWaker::new();
+static OVERRUN: AtomicBool = AtomicBool::new(false);
+
+/// ADC interrupt handler.
+///
+/// Bind with [`crate::bind_interrupts!`]:
+///
+/// ```ignore
+/// bind_interrupts!(struct Irqs {
+///     ADC => embassy_asr::adc::InterruptHandler;
+/// });
+/// ```
+pub struct InterruptHandler {
+    _private: (),
+}
+
+impl Handler<interrupt::typelevel::ADC> for InterruptHandler {
+    unsafe fn on_interrupt() {
+        let regs = pac::Adc::steal();
+        let isr = regs.isr().read();
+
+        if isr.overrun().bit_is_set() {
+            OVERRUN.store(true, Ordering::Relaxed);
+            // PAC gap: ISR has no `Resettable` impl; write-1-to-clear via bits.
+            unsafe {
+                regs.isr().write_with_zero(|w| w.bits(1 << 2));
+            }
+        }
+
+        if isr.eoc().bit_is_set() || isr.eos().bit_is_set() {
+            // Mask further IRQs; the waiter re-enables as needed.
+            regs.ier().modify(|_, w| {
+                w.eoc().clear_bit();
+                w.eos().clear_bit();
+                w.overrun().clear_bit()
+            });
+            WAKER.wake();
+        }
+    }
+}
+
+/// ADC kernel clock source (`RCC.CR2.ADC_CLK_SEL`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ClockSource {
+    /// PCLK1.
+    Pclk1,
+    /// SYSCLK.
+    Sysclk,
+    /// PLL output (PAC enumerant; not used by the SDK ADC examples).
+    Pll,
+    /// Internal 48 MHz RC oscillator (SDK examples).
+    Rco48m,
+}
+
+/// Reference voltage selection (`adc_config_ref_voltage`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum RefVoltage {
+    /// External reference.
+    External,
+    /// Internal reference (SDK default after `adc_config_ref_voltage(INTERNAL)`).
+    Internal,
+}
+
+/// Conversion mode (`adc_config_conv_mode`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ConversionMode {
+    /// Convert the programmed sequence once per start.
+    Single,
+    /// Convert the programmed sequence repeatedly until stopped.
+    Continuous,
+}
+
+/// Hardware sample-channel index written into `SEQR0` / `SEQR1`.
+///
+/// Values match `adc_sample_chan_t`. Channel 0 is reserved by the vendor and
+/// terminates a programmed sequence when left in an unused slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum SampleChannel {
+    /// Datasheet `ADC_IN0` on PA11 → sample channel 1.
+    In0 = 0x1,
+    /// Datasheet `ADC_IN1` on PA8 → sample channel 2.
+    In1 = 0x2,
+    /// Datasheet `ADC_IN2` on PA5 → sample channel 3.
+    In2 = 0x3,
+    /// Datasheet `ADC_IN3` on PA4 → sample channel 4.
+    In3 = 0x4,
+    /// Datasheet `ADC_IN7` on PC15 → sample channel 8.
+    In7 = 0x8,
+}
+
+impl SampleChannel {
+    /// Raw SEQR nibble (`1..=15`). Channel `0` is reserved.
+    #[inline]
+    pub const fn raw(self) -> u8 {
+        self as u8
+    }
+
+    /// Construct from a raw sample-channel index.
+    ///
+    /// Returns [`None`] for the reserved channel `0` or values above `15`.
+    #[inline]
+    pub const fn from_raw(raw: u8) -> Option<Self> {
+        match raw {
+            0x1 => Some(Self::In0),
+            0x2 => Some(Self::In1),
+            0x3 => Some(Self::In2),
+            0x4 => Some(Self::In3),
+            0x8 => Some(Self::In7),
+            _ => None,
+        }
+    }
+
+    /// Any non-reserved sample-channel index for advanced / undocumented muxes
+    /// (for example after enabling the VBAT/3 path).
+    #[inline]
+    pub const fn from_raw_unchecked(raw: u8) -> Option<RawSampleChannel> {
+        RawSampleChannel::new(raw)
+    }
+}
+
+/// Unchecked sample-channel index in `1..=15`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RawSampleChannel(u8);
+
+impl RawSampleChannel {
+    /// Create a raw channel index, rejecting the reserved `0` and values `> 15`.
+    #[inline]
+    pub const fn new(raw: u8) -> Option<Self> {
+        if raw == 0 || raw > 15 { None } else { Some(Self(raw)) }
+    }
+
+    /// Raw SEQR nibble.
+    #[inline]
+    pub const fn raw(self) -> u8 {
+        self.0
+    }
+}
+
+impl From<SampleChannel> for RawSampleChannel {
+    #[inline]
+    fn from(value: SampleChannel) -> Self {
+        Self(value.raw())
+    }
+}
+
+/// Pins that map to a documented ADC input.
+pub trait AdcPin: Pin {
+    /// Documented sample channel for this pin.
+    const CHANNEL: SampleChannel;
+}
+
+macro_rules! impl_adc_pin {
+    ($pin:ident, $channel:expr) => {
+        impl AdcPin for peripherals::$pin {
+            const CHANNEL: SampleChannel = $channel;
+        }
+    };
+}
+
+impl_adc_pin!(PA11, SampleChannel::In0);
+impl_adc_pin!(PA8, SampleChannel::In1);
+impl_adc_pin!(PA5, SampleChannel::In2);
+impl_adc_pin!(PA4, SampleChannel::In3);
+impl_adc_pin!(PC15, SampleChannel::In7);
+
+/// Owned analog input pin configured for ADC sampling.
+pub struct AdcChannel<'d> {
+    _pin: Flex<'d>,
+    channel: SampleChannel,
+}
+
+impl<'d> AdcChannel<'d> {
+    /// Put `pin` into analog mode with AF0 and retain its sample channel.
+    pub fn new<P: AdcPin>(pin: Peri<'d, P>) -> Self {
+        make_adc_channel(pin)
+    }
+
+    /// Sample channel served by this pin.
+    #[inline]
+    pub fn channel(&self) -> SampleChannel {
+        self.channel
+    }
+}
+
+fn make_adc_channel<'d, P: AdcPin>(pin: Peri<'d, P>) -> AdcChannel<'d> {
+    let channel = P::CHANNEL;
+    let mut pin = Flex::new(pin);
+    pin.set_alternate_function(AlternateFunction::Function0);
+    pin.set_as_analog();
+    AdcChannel { _pin: pin, channel }
+}
+
+/// Factory calibration constants from `adc_get_calibration_value`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Calibration {
+    /// Gain correction factor.
+    pub gain: f32,
+    /// DC offset in volts.
+    pub dco: f32,
+    /// Whether the differential OTP fields were used.
+    pub differential: bool,
+}
+
+impl Calibration {
+    /// Read factory calibration (`adc_get_calibration_value`).
+    pub fn read(differential: bool) -> Self {
+        // SAFETY: fixed factory OTP addresses used by the vendor SDK.
+        let gain_word = unsafe { core::ptr::read_volatile(CALIB_GAIN_ADDR as *const u32) };
+        let dco_word = unsafe { core::ptr::read_volatile(CALIB_DCO_ADDR as *const u32) };
+
+        let (gain, dco) = if differential {
+            let gain = 1.0 + 0.002 * (((gain_word & 0x1fe000) >> 13) as f32);
+            let dco = -0.256 + 0.001 * (((dco_word & 0x3fe000) >> 13) as f32);
+            (gain, dco)
+        } else {
+            let gain = 1.0 + 0.002 * (((gain_word & 0x1fe0) >> 5) as f32);
+            let dco = -0.256 + 0.001 * (((dco_word & 0x1ff0) >> 4) as f32);
+            (gain, dco)
+        };
+
+        Self {
+            gain,
+            dco,
+            differential,
+        }
+    }
+
+    /// Convert a single-ended raw code to volts (SDK formula, 1.2 V Vref).
+    pub fn to_voltage(self, raw: u16) -> f32 {
+        let code = f32::from(raw & MAX_VALUE);
+        ((INTERNAL_VREF_VOLTS / 4096.0) * code - self.dco) / self.gain
+    }
+
+    /// Convert a differential raw code to volts (SDK `single_mode_diff` formula).
+    pub fn to_voltage_diff(self, raw: u16) -> f32 {
+        let code = raw & MAX_VALUE;
+        let signed = if code >= 0x800 {
+            (code - 0x800) as i32
+        } else {
+            -((0x800 - code) as i32)
+        };
+        ((INTERNAL_VREF_VOLTS / 2048.0) * (signed as f32) - self.dco) / self.gain
+    }
+}
+
+/// ADC configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Kernel clock source. SDK examples use [`ClockSource::Rco48m`].
+    pub clock_source: ClockSource,
+    /// `CFGR` clock divider (`0..=0xFFF`). SDK examples use `20` (~150 kHz).
+    pub clock_division: u16,
+    /// Reference voltage selection.
+    pub ref_voltage: RefVoltage,
+    /// When true, keep the previous sample on overrun (clear `OVERRUN_MODE`).
+    pub retain_on_overrun: bool,
+    /// Wait mode (`CFGR.WAIT_MODE`).
+    pub wait_mode: bool,
+}
+
+impl Config {
+    /// Defaults matching the SDK ADC examples after `adc_init` + clock div 20
+    /// and an internal reference.
+    pub const fn new() -> Self {
+        Self {
+            clock_source: ClockSource::Rco48m,
+            clock_division: 20,
+            ref_voltage: RefVoltage::Internal,
+            retain_on_overrun: true,
+            wait_mode: false,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// ADC driver error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Sequence was empty or longer than [`MAX_SEQUENCE_LEN`].
+    InvalidSequence,
+    /// Clock divider exceeded `0xFFF`.
+    InvalidClockDivision,
+    /// Differential mode is only defined for sample channels 1..=8.
+    InvalidDifferentialChannel,
+    /// Data register was overwritten before it was read.
+    Overrun,
+    /// Continuous conversion is already running.
+    Busy,
+    /// Continuous conversion is not running.
+    NotRunning,
+}
+
+/// Owned ASR6601 ADC.
+pub struct Adc<'d, M: Mode = Blocking> {
+    _peri: Peri<'d, peripherals::ADC>,
+    continuous: bool,
+    _mode: PhantomData<M>,
+}
+
+impl<'d> Adc<'d, Blocking> {
+    /// Enable clocks, apply `config`, run vendor `adc_init`, and leave the ADC
+    /// disabled until a conversion is started.
+    pub fn new_blocking(peri: Peri<'d, peripherals::ADC>, config: Config) -> Result<Self, Error> {
+        Self::new_inner(peri, config)
+    }
+}
+
+impl<'d> Adc<'d, Async> {
+    /// Create an interrupt-driven ADC.
+    ///
+    /// `irq` proves the ADC vector is bound to [`InterruptHandler`].
+    pub fn new(
+        peri: Peri<'d, peripherals::ADC>,
+        _irq: impl Binding<interrupt::typelevel::ADC, InterruptHandler> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let this = Self::new_inner(peri, config)?;
+        interrupt::typelevel::ADC::unpend();
+        interrupt::typelevel::ADC::set_priority(Priority::P3);
+        unsafe {
+            interrupt::typelevel::ADC::enable();
+        }
+        Ok(this)
+    }
+}
+
+impl<'d, M: Mode> Adc<'d, M> {
+    fn new_inner(peri: Peri<'d, peripherals::ADC>, config: Config) -> Result<Self, Error> {
+        if config.clock_division as u32 > CFGR_CLK_DIV_MASK {
+            return Err(Error::InvalidClockDivision);
+        }
+
+        set_adc_clock_source(config.clock_source);
+        let _ = rcc::enable_peripheral(Peripheral::Adc);
+        let _ = rcc::reset_peripheral(Peripheral::Adc);
+
+        // Vendor `adc_init()`.
+        analog::REG_11.modify(ANALOG_11_ADC_INIT_MASK, 0);
+        delay_us(100);
+
+        match config.ref_voltage {
+            RefVoltage::External => analog::REG_12.clear_bits(ANALOG_12_INTERNAL_REF),
+            RefVoltage::Internal => analog::REG_12.set_bits(ANALOG_12_INTERNAL_REF),
+        }
+
+        let this = Self {
+            _peri: peri,
+            continuous: false,
+            _mode: PhantomData,
+        };
+        this.apply_cfgr_defaults(config);
+        Ok(this)
+    }
+
+    fn apply_cfgr_defaults(&self, config: Config) {
+        let regs = Self::regs();
+        regs.cfgr().modify(|r, w| {
+            let mut bits = r.bits();
+            bits = (bits & !CFGR_CLK_DIV_MASK) | u32::from(config.clock_division);
+            // Soft trigger, rising/falling cleared.
+            bits &= !CFGR_TRG_SOURCE_MASK;
+            bits &= !CFGR_TRG_POLARITY_MASK;
+            if config.retain_on_overrun {
+                bits &= !CFGR_OVERRUN_MODE;
+            } else {
+                bits |= CFGR_OVERRUN_MODE;
+            }
+            if config.wait_mode {
+                bits |= CFGR_WAIT_MODE;
+            } else {
+                bits &= !CFGR_WAIT_MODE;
+            }
+            bits = (bits & !CFGR_CONV_MODE_MASK) | CFGR_CONV_MODE_SINGLE;
+            unsafe { w.bits(bits) }
+        });
+    }
+
+    /// Configure a documented pin as an ADC input.
+    pub fn configure_pin<P: AdcPin>(&mut self, pin: Peri<'d, P>) -> AdcChannel<'d> {
+        make_adc_channel(pin)
+    }
+
+    /// Enable or disable the VBAT/3 measurement path (`adc_enable_vbat31`).
+    ///
+    /// The datasheet / SDK do not document which sample channel reads VBAT/3;
+    /// use [`RawSampleChannel`] once the channel is known for your silicon.
+    pub fn set_vbat31_enabled(&mut self, enabled: bool) {
+        if enabled {
+            analog::REG_2C.set_bits(ANALOG_2C_VBAT31);
+        } else {
+            analog::REG_2C.clear_bits(ANALOG_2C_VBAT31);
+        }
+    }
+
+    /// Enable or disable differential sampling for a channel (`adc_config_sample_chan_diff`).
+    ///
+    /// Only sample channels 1..=8 have `DIFFSEL` bits.
+    pub fn set_differential(&mut self, channel: impl Into<RawSampleChannel>, differential: bool) -> Result<(), Error> {
+        let ch = channel.into().raw();
+        if !(1..=8).contains(&ch) {
+            return Err(Error::InvalidDifferentialChannel);
+        }
+        let mask = 1u32 << ch;
+        let regs = Self::regs();
+        regs.diffsel().modify(|r, w| {
+            let bits = if differential {
+                r.bits() | mask
+            } else {
+                r.bits() & !mask
+            };
+            unsafe { w.bits(bits) }
+        });
+        Ok(())
+    }
+
+    /// Program the sample sequence (`adc_config_sample_sequence` for each slot).
+    ///
+    /// Unused slots are cleared to `0` so the hardware sequence ends after
+    /// `channels.len()` conversions (matching SDK examples).
+    pub fn set_sequence(&mut self, channels: &[RawSampleChannel]) -> Result<(), Error> {
+        if channels.is_empty() || channels.len() > MAX_SEQUENCE_LEN {
+            return Err(Error::InvalidSequence);
+        }
+
+        let mut seqr0 = 0u32;
+        let mut seqr1 = 0u32;
+        for (i, ch) in channels.iter().enumerate() {
+            let nibble = u32::from(ch.raw()) & 0xf;
+            if i < 8 {
+                seqr0 |= nibble << (4 * i);
+            } else {
+                seqr1 |= nibble << (4 * (i - 8));
+            }
+        }
+
+        let regs = Self::regs();
+        unsafe {
+            regs.seqr0().write_with_zero(|w| w.bits(seqr0));
+            regs.seqr1().write_with_zero(|w| w.bits(seqr1));
+        }
+        Ok(())
+    }
+
+    /// Enable or disable ADC DMA requests (`adc_enable_dma`).
+    pub fn set_dma_enabled(&mut self, enabled: bool) {
+        Self::regs().cfgr().modify(|r, w| {
+            let bits = if enabled {
+                r.bits() | CFGR_DMA_ENABLE
+            } else {
+                r.bits() & !CFGR_DMA_ENABLE
+            };
+            unsafe { w.bits(bits) }
+        });
+    }
+
+    /// Address of `DR` for DMA source programming.
+    #[inline]
+    pub fn dr_address(&self) -> *const u32 {
+        Self::regs().dr().as_ptr()
+    }
+
+    /// Read factory calibration for the current single/diff preference.
+    #[inline]
+    pub fn calibration(&self, differential: bool) -> Calibration {
+        Calibration::read(differential)
+    }
+
+    fn set_conversion_mode(&self, mode: ConversionMode) {
+        let mode_bits = match mode {
+            ConversionMode::Single => CFGR_CONV_MODE_SINGLE,
+            ConversionMode::Continuous => CFGR_CONV_MODE_CONTINUE,
+        };
+        Self::regs().cfgr().modify(|r, w| {
+            let bits = (r.bits() & !CFGR_CONV_MODE_MASK) | mode_bits;
+            unsafe { w.bits(bits) }
+        });
+    }
+
+    fn enable(&self) {
+        let regs = Self::regs();
+        if regs.cr().read().bits() == 0 {
+            regs.cr().modify(|r, w| unsafe { w.bits(r.bits() | CR_ENABLE) });
+        }
+    }
+
+    fn disable(&self) {
+        let regs = Self::regs();
+        let cr = regs.cr().read().bits();
+        if cr & CR_ENABLE != 0 && cr & CR_START == 0 {
+            regs.cr().modify(|r, w| unsafe { w.bits(r.bits() | CR_DISABLE) });
+        }
+    }
+
+    fn start(&self) {
+        let regs = Self::regs();
+        let cr = regs.cr().read().bits();
+        if cr & CR_ENABLE != 0 && cr & CR_DISABLE == 0 {
+            regs.cr().modify(|r, w| unsafe { w.bits(r.bits() | CR_START) });
+        }
+    }
+
+    fn stop(&self) {
+        let regs = Self::regs();
+        if regs.cr().read().bits() & CR_START != 0 {
+            regs.cr().modify(|r, w| unsafe { w.bits(r.bits() | CR_STOP) });
+        }
+    }
+
+    fn read_dr(&self) -> u16 {
+        (Self::regs().dr().read().bits() & u32::from(MAX_VALUE)) as u16
+    }
+
+    fn clear_status(&self) {
+        let regs = Self::regs();
+        // ISR is write-1-to-clear for documented flags.
+        // PAC gap: ISR is not `Resettable`, so use `write_with_zero`.
+        unsafe {
+            regs.isr().write_with_zero(|w| w.bits((1 << 0) | (1 << 1) | (1 << 2)));
+        }
+    }
+
+    fn take_overrun(&self) -> bool {
+        let hw = Self::regs().isr().read().overrun().bit_is_set();
+        let soft = OVERRUN.swap(false, Ordering::Relaxed);
+        if hw {
+            unsafe {
+                Self::regs().isr().write_with_zero(|w| w.bits(1 << 2));
+            }
+        }
+        hw || soft
+    }
+
+    /// Stop conversion and disable the ADC digital enable bit.
+    pub fn stop_conversion(&mut self) {
+        self.stop();
+        self.continuous = false;
+        self.disable();
+        // PAC gap: IER is not `Resettable`.
+        unsafe {
+            Self::regs().ier().write_with_zero(|w| w.bits(0));
+        }
+        self.clear_status();
+    }
+
+    /// Start continuous conversion of `channels` (SDK `ADC_CONV_MODE_CONTINUE`).
+    pub fn start_continuous(&mut self, channels: &[RawSampleChannel]) -> Result<(), Error> {
+        if self.continuous {
+            return Err(Error::Busy);
+        }
+        self.set_sequence(channels)?;
+        self.set_conversion_mode(ConversionMode::Continuous);
+        self.clear_status();
+        self.enable();
+        self.start();
+        self.continuous = true;
+        Ok(())
+    }
+
+    /// Convenience: continuous conversion of documented channels.
+    pub fn start_continuous_channels(&mut self, channels: &[SampleChannel]) -> Result<(), Error> {
+        let mut raw = [RawSampleChannel(0); MAX_SEQUENCE_LEN];
+        if channels.is_empty() || channels.len() > MAX_SEQUENCE_LEN {
+            return Err(Error::InvalidSequence);
+        }
+        for (i, ch) in channels.iter().enumerate() {
+            raw[i] = (*ch).into();
+        }
+        self.start_continuous(&raw[..channels.len()])
+    }
+
+    fn blocking_wait_eoc(&self) -> Result<(), Error> {
+        let regs = Self::regs();
+        loop {
+            if self.take_overrun() {
+                return Err(Error::Overrun);
+            }
+            if regs.isr().read().eoc().bit_is_set() {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Blocking single-shot conversion of one channel (SDK single-mode subset).
+    pub fn blocking_read(&mut self, channel: impl Into<RawSampleChannel>) -> Result<u16, Error> {
+        if self.continuous {
+            return Err(Error::Busy);
+        }
+        let ch = channel.into();
+        self.set_sequence(&[ch])?;
+        self.set_conversion_mode(ConversionMode::Single);
+        self.clear_status();
+        self.enable();
+        self.start();
+        self.blocking_wait_eoc()?;
+        let value = self.read_dr();
+        self.stop();
+        self.disable();
+        Ok(value)
+    }
+
+    /// Blocking single-shot conversion of an owned ADC pin.
+    pub fn blocking_read_channel(&mut self, channel: &AdcChannel<'_>) -> Result<u16, Error> {
+        self.blocking_read(channel.channel())
+    }
+
+    /// Blocking read of the next sample while continuous conversion is running.
+    pub fn blocking_read_continuous(&mut self) -> Result<u16, Error> {
+        if !self.continuous {
+            return Err(Error::NotRunning);
+        }
+        self.blocking_wait_eoc()?;
+        Ok(self.read_dr())
+    }
+
+    #[inline]
+    fn regs() -> pac::Adc {
+        unsafe { pac::Adc::steal() }
+    }
+}
+
+impl<'d> Adc<'d, Async> {
+    async fn wait_eoc(&self) -> Result<(), Error> {
+        poll_fn(|cx| {
+            if self.take_overrun() {
+                return Poll::Ready(Err(Error::Overrun));
+            }
+
+            let regs = Self::regs();
+            if regs.isr().read().eoc().bit_is_set() {
+                return Poll::Ready(Ok(()));
+            }
+
+            WAKER.register(cx.waker());
+            // Enable EOC (+ overrun) after registering to avoid lost wakes.
+            regs.ier().modify(|_, w| {
+                w.eoc().set_bit();
+                w.overrun().set_bit()
+            });
+
+            if self.take_overrun() {
+                regs.ier().modify(|_, w| {
+                    w.eoc().clear_bit();
+                    w.eos().clear_bit();
+                    w.overrun().clear_bit()
+                });
+                return Poll::Ready(Err(Error::Overrun));
+            }
+            if regs.isr().read().eoc().bit_is_set() {
+                regs.ier().modify(|_, w| {
+                    w.eoc().clear_bit();
+                    w.eos().clear_bit();
+                    w.overrun().clear_bit()
+                });
+                return Poll::Ready(Ok(()));
+            }
+
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Async single-shot conversion of one channel.
+    pub async fn read(&mut self, channel: impl Into<RawSampleChannel>) -> Result<u16, Error> {
+        if self.continuous {
+            return Err(Error::Busy);
+        }
+        let ch = channel.into();
+        self.set_sequence(&[ch])?;
+        self.set_conversion_mode(ConversionMode::Single);
+        self.clear_status();
+        self.enable();
+        self.start();
+        self.wait_eoc().await?;
+        let value = self.read_dr();
+        self.stop();
+        self.disable();
+        Ok(value)
+    }
+
+    /// Async single-shot conversion of an owned ADC pin.
+    pub async fn read_channel(&mut self, channel: &AdcChannel<'_>) -> Result<u16, Error> {
+        self.read(channel.channel()).await
+    }
+
+    /// Async read of the next sample while continuous conversion is running.
+    pub async fn read_continuous(&mut self) -> Result<u16, Error> {
+        if !self.continuous {
+            return Err(Error::NotRunning);
+        }
+        self.wait_eoc().await?;
+        Ok(self.read_dr())
+    }
+}
+
+impl<'d, M: Mode> Drop for Adc<'d, M> {
+    fn drop(&mut self) {
+        self.stop_conversion();
+        analog::REG_2C.clear_bits(ANALOG_2C_VBAT31);
+        let _ = rcc::disable_peripheral(Peripheral::Adc);
+    }
+}
+
+fn set_adc_clock_source(source: ClockSource) {
+    let sel = match source {
+        ClockSource::Pclk1 => pac::rcc::cr2::AdcClkSel::Pclk1,
+        ClockSource::Sysclk => pac::rcc::cr2::AdcClkSel::Sysclk,
+        ClockSource::Pll => pac::rcc::cr2::AdcClkSel::Pll,
+        ClockSource::Rco48m => pac::rcc::cr2::AdcClkSel::Rco48m,
+    };
+
+    critical_section::with(|_| {
+        let rcc = unsafe { pac::Rcc::steal() };
+        // Vendor `rcc_set_adc_clk_source`: gate off, wait sync, then select.
+        if rcc.sr1().read().adc_clk_en_sync().bit_is_set() {
+            rcc.cgr0().modify(|_, w| w.adc_clk_en().clear_bit());
+            while rcc.sr1().read().adc_clk_en_sync().bit_is_set() {
+                core::hint::spin_loop();
+            }
+        }
+        rcc.cr2().modify(|_, w| w.adc_clk_sel().variant(sel));
+    });
+}
+
+fn delay_us(us: u32) {
+    let hz = rcc::clocks().map(|c| c.hclk_hz).unwrap_or(48_000_000);
+    let cycles = (u64::from(hz) * u64::from(us)).div_ceil(1_000_000);
+    cortex_m::asm::delay(cycles.min(u64::from(u32::MAX)) as u32);
+}

--- a/embassy-asr/src/afec.rs
+++ b/embassy-asr/src/afec.rs
@@ -1,0 +1,246 @@
+//! Analog front-end controller (AFEC).
+//!
+//! The PAC describes the digital AFEC registers at `0x4000_8200`. The vendor
+//! SDK also accesses an analog register window starting at `0x4000_8000`,
+//! where register index `n` is located at byte offset `n * 4`. That window is
+//! not present in the current SVD, so its volatile accesses are kept in the
+//! crate-private [`analog`] module below.
+//!
+//! The SDK publishes bit assignments for three raw status signals. It does not
+//! publish bit assignments or write semantics for `CR` or `INT_SR`; therefore
+//! this module exposes an opaque interrupt-status snapshot, but no control,
+//! interrupt-enable, or interrupt-acknowledge operations.
+
+use crate::{Peri, pac, peripherals};
+
+/// Snapshot of the documented AFEC raw status signals.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RawStatus {
+    rco24m_ready: bool,
+    pll_unlocked: bool,
+    rco4m_ready: bool,
+}
+
+impl RawStatus {
+    /// Whether the SDK's `RCO24M_READY` signal is asserted.
+    ///
+    /// The vendor RCC driver uses this signal while enabling or disabling the
+    /// oscillator exposed there as RCO48M.
+    #[inline]
+    pub const fn rco24m_ready(self) -> bool {
+        self.rco24m_ready
+    }
+
+    /// Whether the PLL-unlock signal is asserted.
+    #[inline]
+    pub const fn pll_unlocked(self) -> bool {
+        self.pll_unlocked
+    }
+
+    /// Whether the RCO4M-ready signal is asserted.
+    #[inline]
+    pub const fn rco4m_ready(self) -> bool {
+        self.rco4m_ready
+    }
+}
+
+/// Opaque snapshot of the AFEC interrupt status register.
+///
+/// The vendor SDK identifies `INT_SR` as a read/write interrupt-status
+/// register, but publishes neither bit assignments nor write semantics for it.
+/// Consequently, the value can be inspected, but this driver does not provide
+/// field accessors or a way to write it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct InterruptStatus(u32);
+
+impl InterruptStatus {
+    /// Return the unmodified `INT_SR` register value.
+    #[inline]
+    pub const fn bits(self) -> u32 {
+        self.0
+    }
+
+    /// Whether no AFEC interrupt-status bit is asserted.
+    #[inline]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+}
+
+/// ASR6601 analog front-end controller.
+///
+/// Creating the driver enables the AFEC peripheral clock. The clock remains
+/// enabled when the driver is dropped because the analog register window is
+/// shared by the RCC, ADC, DAC, power, and LCD blocks.
+pub struct Afec<'d> {
+    _peri: Peri<'d, peripherals::AFEC>,
+}
+
+impl<'d> Afec<'d> {
+    /// Create an AFEC driver.
+    ///
+    /// This deliberately does not reset AFEC: the analog window controls
+    /// oscillators that may already be supplying system clocks.
+    pub fn new(peri: Peri<'d, peripherals::AFEC>) -> Self {
+        analog::enable_clock();
+        Self { _peri: peri }
+    }
+
+    /// Read the documented raw AFEC status signals.
+    #[inline]
+    pub fn raw_status(&self) -> RawStatus {
+        let status = Self::regs().raw_sr().read();
+        RawStatus {
+            rco24m_ready: status.rco24m_ready().bit_is_set(),
+            pll_unlocked: status.pll_unlock().bit_is_set(),
+            rco4m_ready: status.rco4m_ready().bit_is_set(),
+        }
+    }
+
+    /// Read the opaque AFEC interrupt status register.
+    #[inline]
+    pub fn interrupt_status(&self) -> InterruptStatus {
+        InterruptStatus(Self::regs().int_sr().read().bits())
+    }
+
+    #[inline]
+    fn regs() -> pac::Afec {
+        // The lifetime-owned AFEC token guarantees exclusive public driver
+        // ownership. `steal` is used only to obtain the PAC register handle.
+        unsafe { pac::Afec::steal() }
+    }
+}
+
+/// Safe crate-internal access to the vendor-defined AFEC analog window.
+///
+/// Only register indices used by the vendor RCC, ADC, DAC, power, and LCD
+/// drivers are constructible. All read-modify-write operations preserve bits
+/// outside the supplied mask and run in a critical section so interrupt-side
+/// analog updates cannot be lost.
+pub(crate) mod analog {
+    use core::ptr::{read_volatile, write_volatile};
+
+    use crate::pac;
+
+    const BASE: usize = 0x4000_8000;
+
+    /// A validated register in the AFEC analog window.
+    ///
+    /// The private field prevents other crate modules from constructing
+    /// arbitrary analog-window addresses.
+    #[derive(Clone, Copy)]
+    pub(crate) struct Register<const INDEX: usize> {
+        _private: (),
+    }
+
+    impl<const INDEX: usize> Register<INDEX> {
+        const fn new() -> Self {
+            Self { _private: () }
+        }
+
+        #[inline]
+        const fn address(self) -> usize {
+            BASE + INDEX * core::mem::size_of::<u32>()
+        }
+
+        /// Read the complete analog register.
+        #[inline]
+        pub(crate) fn read(self) -> u32 {
+            critical_section::with(|_| {
+                enable_clock_unlocked();
+
+                // SAFETY: only the validated constants below can be
+                // constructed, and each address follows TREMO_ANALOG_RD.
+                unsafe { read_volatile(self.address() as *const u32) }
+            })
+        }
+
+        /// Replace the selected bits and preserve every other bit.
+        ///
+        /// Bits in `value` outside `mask` are ignored.
+        #[inline]
+        pub(crate) fn modify(self, mask: u32, value: u32) {
+            critical_section::with(|_| {
+                enable_clock_unlocked();
+
+                // SAFETY: only the validated constants below can be
+                // constructed, and each address follows TREMO_ANALOG_RD/WR.
+                unsafe {
+                    let address = self.address() as *mut u32;
+                    let old = read_volatile(address);
+                    write_volatile(address, (old & !mask) | (value & mask));
+                }
+            });
+        }
+
+        /// Set the selected bits and preserve every other bit.
+        #[inline]
+        pub(crate) fn set_bits(self, mask: u32) {
+            self.modify(mask, mask);
+        }
+
+        /// Clear the selected bits and preserve every other bit.
+        #[inline]
+        pub(crate) fn clear_bits(self, mask: u32) {
+            self.modify(mask, 0);
+        }
+    }
+
+    /// Enable the AFEC clock without requiring ownership of its digital block.
+    ///
+    /// Analog settings are shared by several otherwise independent
+    /// peripherals, so their drivers use this function before analog access.
+    pub(crate) fn enable_clock() {
+        critical_section::with(|_| enable_clock_unlocked());
+    }
+
+    #[inline]
+    fn enable_clock_unlocked() {
+        // SAFETY: this handle is used for one critical-section-protected,
+        // idempotent clock-bit update and is not retained.
+        let rcc = unsafe { pac::Rcc::steal() };
+        rcc.cgr0().modify(|_, w| w.afec_clk_en().set_bit());
+    }
+
+    // These are exactly the indices touched through TREMO_ANALOG_RD/WR in the
+    // vendor files named below. Purpose descriptions summarize those accesses;
+    // they do not assign undocumented register or field names.
+
+    /// Vendor `tremo_rcc.c`: RCO32K and XO32K control.
+    pub(crate) const REG_02: Register<0x02> = Register::new();
+
+    /// Vendor `tremo_pwr.c`: XO32K low-power control.
+    pub(crate) const REG_03: Register<0x03> = Register::new();
+
+    /// Vendor `tremo_pwr.c`: low-power-run control.
+    pub(crate) const REG_05: Register<0x05> = Register::new();
+
+    /// Vendor `tremo_rcc.c`, `tremo_pwr.c`, and `tremo_lcd.c`: oscillator,
+    /// low-power-run, and LCD analog control.
+    pub(crate) const REG_06: Register<0x06> = Register::new();
+
+    /// Vendor `tremo_lcd.c`: LCD COM-count control.
+    pub(crate) const REG_09: Register<0x09> = Register::new();
+
+    /// Vendor `tremo_lcd.c`: LCD COM analog control.
+    pub(crate) const REG_0A: Register<0x0a> = Register::new();
+
+    /// Vendor `tremo_lcd.c`: LCD drive, COM, and segment control.
+    pub(crate) const REG_0B: Register<0x0b> = Register::new();
+
+    /// Vendor `tremo_pwr.c`: STOP3 preparation.
+    pub(crate) const REG_0C: Register<0x0c> = Register::new();
+
+    /// Vendor `tremo_adc.c` and `tremo_dac.c`: ADC and DAC analog control.
+    pub(crate) const REG_11: Register<0x11> = Register::new();
+
+    /// Vendor `tremo_adc.c` and `tremo_dac.c`: ADC reference and DAC analog
+    /// control.
+    pub(crate) const REG_12: Register<0x12> = Register::new();
+
+    /// Vendor `tremo_dac.c`: DAC analog output control.
+    pub(crate) const REG_27: Register<0x27> = Register::new();
+
+    /// Vendor `tremo_adc.c`: VBAT/3 measurement-path control.
+    pub(crate) const REG_2C: Register<0x2c> = Register::new();
+}

--- a/embassy-asr/src/bstimer.rs
+++ b/embassy-asr/src/bstimer.rs
@@ -1,0 +1,362 @@
+//! Basic timers (BSTIMER0 / BSTIMER1).
+//!
+//! Register programming follows the vendor `tremo_bstimer` driver and the
+//! `bstimer/onepulse` / DAC trigger examples.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::Priority;
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt as TypelevelInterrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, PeripheralType, interrupt, pac, peripherals};
+
+const INSTANCE_COUNT: usize = 2;
+
+const CR2_MMS_MASK: u32 = 0x70;
+const SR_UIF: u32 = 1 << 0;
+
+static WAKERS: [AtomicWaker; INSTANCE_COUNT] = [const { AtomicWaker::new() }; INSTANCE_COUNT];
+static UPDATE_PENDING: [AtomicBool; INSTANCE_COUNT] = [const { AtomicBool::new(false) }; INSTANCE_COUNT];
+
+/// Master-mode selection for the TRGO output (`CR2.MMS`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum MasterMode {
+    /// `EGR.UG` is used as the trigger output.
+    Reset = 0x00,
+    /// `CR1.CEN` is used as the trigger output.
+    Enable = 0x10,
+    /// The update event is used as the trigger output.
+    Update = 0x20,
+}
+
+/// BSTIMER configuration matching `bstimer_init_t`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Prescaler loaded into `PSC` (`0..=0xFFFF`). Counter clock is
+    /// `timer_clk / (prescaler + 1)`.
+    pub prescaler: u16,
+    /// Auto-reload value loaded into `ARR` (`0..=0xFFFF`).
+    pub period: u16,
+    /// Master-mode selection for TRGO.
+    pub master_mode: MasterMode,
+    /// When true, `ARR` is buffered (`CR1.ARPE`).
+    pub autoreload_preload: bool,
+}
+
+impl Config {
+    /// Create a default configuration (free-running, update TRGO, no preload).
+    pub const fn new() -> Self {
+        Self {
+            prescaler: 0,
+            period: 0xffff,
+            master_mode: MasterMode::Update,
+            autoreload_preload: false,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+mod sealed {
+    use crate::pac::bstimer0::RegisterBlock;
+    use crate::rcc::Peripheral;
+
+    pub trait Instance {
+        fn regs() -> &'static RegisterBlock;
+        fn peripheral() -> Peripheral;
+        fn number() -> usize;
+        fn sr_ptr() -> *mut u32;
+    }
+}
+
+/// BSTIMER peripheral instance.
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// Update interrupt for this timer.
+    type Interrupt: TypelevelInterrupt;
+}
+
+macro_rules! impl_instance {
+    ($name:ident, $pac:ident, $interrupt:ident, $peripheral:ident, $number:expr, $base:expr) => {
+        impl sealed::Instance for peripherals::$name {
+            #[inline]
+            fn regs() -> &'static pac::bstimer0::RegisterBlock {
+                unsafe { &*pac::$pac::PTR }
+            }
+
+            #[inline]
+            fn peripheral() -> Peripheral {
+                Peripheral::$peripheral
+            }
+
+            #[inline]
+            fn number() -> usize {
+                $number
+            }
+
+            #[inline]
+            fn sr_ptr() -> *mut u32 {
+                ($base + 0x10) as *mut u32
+            }
+        }
+
+        impl Instance for peripherals::$name {
+            type Interrupt = interrupt::typelevel::$interrupt;
+        }
+    };
+}
+
+impl_instance!(BSTIMER0, Bstimer0, BSTIMER0, Bstimer0, 0, 0x4000_c000);
+impl_instance!(BSTIMER1, Bstimer1, BSTIMER1, Bstimer1, 1, 0x4001_c000);
+
+/// Interrupt handler for one BSTIMER instance.
+///
+/// Bind this to `BSTIMER0` / `BSTIMER1` with [`crate::bind_interrupts!`] before
+/// constructing an asynchronous timer.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        if !regs.sr().read().uif().bit_is_set() {
+            return;
+        }
+
+        // Clear UIF (PAC marks `SR` read-only; GPTIMER uses the same write-0 clear).
+        clear_update_flag_raw(T::sr_ptr());
+        regs.dier().modify(|_, w| w.uie().clear_bit());
+        UPDATE_PENDING[T::number()].store(true, Ordering::Release);
+        WAKERS[T::number()].wake();
+    }
+}
+
+/// Owned basic timer.
+pub struct BsTimer<'d, T: Instance, M: Mode = Blocking> {
+    _peri: Peri<'d, T>,
+    _mode: PhantomData<M>,
+}
+
+impl<'d, T: Instance> BsTimer<'d, T, Blocking> {
+    /// Enable clocks, release reset, apply `config`, and leave the timer stopped.
+    pub fn new(peri: Peri<'d, T>, config: Config) -> Self {
+        let this = Self::create(peri);
+        this.configure(config);
+        this
+    }
+
+    /// Busy-wait until the update interrupt flag is set, then clear it.
+    pub fn wait_for_update(&mut self) {
+        while !self.update_flag() {}
+        self.clear_update_flag();
+    }
+}
+
+impl<'d, T: Instance> BsTimer<'d, T, Async> {
+    /// Enable clocks, release reset, apply `config`, and bind the update IRQ.
+    pub fn new(peri: Peri<'d, T>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd, config: Config) -> Self {
+        UPDATE_PENDING[T::number()].store(false, Ordering::Release);
+        T::Interrupt::unpend();
+        T::Interrupt::set_priority(Priority::P3);
+        unsafe { T::Interrupt::enable() };
+
+        let this = Self::create(peri);
+        this.configure(config);
+        this
+    }
+
+    /// Wait for the next update event.
+    ///
+    /// Enables `DIER.UIE` until [`InterruptHandler`] observes `SR.UIF`.
+    pub async fn wait_for_update(&mut self) {
+        let index = T::number();
+        UPDATE_PENDING[index].store(false, Ordering::Release);
+        clear_update_flag_raw(T::sr_ptr());
+
+        let _uie = UpdateInterruptGuard::<T>::arm();
+
+        poll_fn(|cx| {
+            WAKERS[index].register(cx.waker());
+
+            if UPDATE_PENDING[index].swap(false, Ordering::AcqRel) {
+                return Poll::Ready(());
+            }
+
+            // Already latched before / while UIE was armed.
+            if T::regs().sr().read().uif().bit_is_set() {
+                clear_update_flag_raw(T::sr_ptr());
+                return Poll::Ready(());
+            }
+
+            Poll::Pending
+        })
+        .await;
+    }
+}
+
+impl<'d, T: Instance, M: Mode> BsTimer<'d, T, M> {
+    fn create(peri: Peri<'d, T>) -> Self {
+        let _ = rcc::enable_peripheral(T::peripheral());
+        let _ = rcc::reset_peripheral(T::peripheral());
+        Self {
+            _peri: peri,
+            _mode: PhantomData,
+        }
+    }
+
+    /// Apply configuration while the counter is left as-is (vendor `bstimer_init`).
+    pub fn configure(&self, config: Config) {
+        let regs = T::regs();
+
+        regs.cr2().modify(|r, w| unsafe {
+            let bits = (r.bits() & !CR2_MMS_MASK) | (config.master_mode as u32);
+            w.bits(bits)
+        });
+
+        regs.cr1().modify(|_, w| w.arpe().bit(config.autoreload_preload));
+
+        unsafe {
+            regs.arr().write_with_zero(|w| w.bits(u32::from(config.period)));
+            regs.psc().write_with_zero(|w| w.bits(u32::from(config.prescaler)));
+        }
+    }
+
+    /// Start the counter (`CR1.CEN`).
+    pub fn start(&self) {
+        T::regs().cr1().modify(|_, w| w.cen().set_bit());
+    }
+
+    /// Stop the counter (`CR1.CEN`).
+    pub fn stop(&self) {
+        T::regs().cr1().modify(|_, w| w.cen().clear_bit());
+    }
+
+    /// Enable or disable one-pulse mode (`CR1.OPM`).
+    pub fn set_one_pulse(&self, enabled: bool) {
+        T::regs().cr1().modify(|_, w| w.opm().bit(enabled));
+    }
+
+    /// When enabled, only counter overflow/underflow generates update events
+    /// that set UIF (`CR1.URS`, vendor `bstimer_config_overflow_update`).
+    pub fn set_overflow_update(&self, enabled: bool) {
+        T::regs().cr1().modify(|_, w| w.urs().bit(enabled));
+    }
+
+    /// Disable generation of update events (`CR1.UDIS`).
+    pub fn set_update_disabled(&self, disabled: bool) {
+        T::regs().cr1().modify(|_, w| w.udis().bit(disabled));
+    }
+
+    /// Enable or disable DMA requests on update (`DIER.UDE`).
+    pub fn set_dma_request(&self, enabled: bool) {
+        T::regs().dier().modify(|_, w| w.ude().bit(enabled));
+    }
+
+    /// Enable or disable the update interrupt (`DIER.UIE`).
+    pub fn set_update_interrupt(&self, enabled: bool) {
+        T::regs().dier().modify(|_, w| w.uie().bit(enabled));
+    }
+
+    /// Whether `SR.UIF` is set.
+    pub fn update_flag(&self) -> bool {
+        T::regs().sr().read().uif().bit_is_set()
+    }
+
+    /// Clear `SR.UIF`.
+    ///
+    /// The vendor BSTIMER driver never clears this flag; GPTIMER does via
+    /// `SR &= ~UIF`. This uses the same write-clear sequence through a raw
+    /// pointer because the PAC marks `SR` read-only.
+    pub fn clear_update_flag(&self) {
+        clear_update_flag_raw(T::sr_ptr());
+    }
+
+    /// Generate an update event (`EGR.UG`), reloading the prescaler shadow.
+    pub fn generate_update(&self) {
+        unsafe {
+            T::regs().egr().write_with_zero(|w| w.ug().set_bit());
+        }
+    }
+
+    /// Current counter value.
+    pub fn counter(&self) -> u32 {
+        T::regs().cnt().read().bits()
+    }
+
+    /// Write the counter register.
+    pub fn set_counter(&self, value: u32) {
+        unsafe {
+            T::regs().cnt().write_with_zero(|w| w.bits(value));
+        }
+    }
+
+    /// Current auto-reload value.
+    pub fn period(&self) -> u32 {
+        T::regs().arr().read().bits()
+    }
+
+    /// Current prescaler value.
+    pub fn prescaler(&self) -> u32 {
+        T::regs().psc().read().bits()
+    }
+
+    /// Configure one-pulse mode as in the vendor `bstimer/onepulse` example:
+    /// OPM + overflow-only updates, then force an update so `PSC` takes effect
+    /// on the first period. Does not start the counter or enable the IRQ.
+    pub fn setup_one_pulse(&self) {
+        self.set_one_pulse(true);
+        self.set_overflow_update(true);
+        self.generate_update();
+    }
+}
+
+impl<'d, T: Instance, M: Mode> Drop for BsTimer<'d, T, M> {
+    fn drop(&mut self) {
+        self.stop();
+        self.set_update_interrupt(false);
+        self.clear_update_flag();
+        T::Interrupt::disable();
+        UPDATE_PENDING[T::number()].store(false, Ordering::Release);
+        let _ = rcc::disable_peripheral(T::peripheral());
+    }
+}
+
+struct UpdateInterruptGuard<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> UpdateInterruptGuard<T> {
+    fn arm() -> Self {
+        T::regs().dier().modify(|_, w| w.uie().set_bit());
+        Self { _phantom: PhantomData }
+    }
+}
+
+impl<T: Instance> Drop for UpdateInterruptGuard<T> {
+    fn drop(&mut self) {
+        T::regs().dier().modify(|_, w| w.uie().clear_bit());
+    }
+}
+
+#[inline]
+fn clear_update_flag_raw(sr: *mut u32) {
+    // Mirror GPTIMER `timer_clear_status` / embassy-asr `timer.rs`: write 0 to
+    // the flag being cleared (rc_w0). BSTIMER PAC `SR` is read-only.
+    unsafe {
+        core::ptr::write_volatile(sr, !SR_UIF);
+    }
+}

--- a/embassy-asr/src/crc.rs
+++ b/embassy-asr/src/crc.rs
@@ -1,0 +1,159 @@
+//! Hardware CRC unit.
+//!
+//! Register programming follows the vendor `tremo_crc` driver.
+
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, pac, peripherals};
+
+const CRC_DR_ADDR: usize = 0x4002_2004;
+
+const CR_CALC_FLAG: u32 = 1 << 6;
+const CR_CALC_INIT: u32 = 1 << 5;
+const CR_REVERSE_OUT: u32 = 1 << 0;
+
+/// Polynomial width programmed into CRC_CR.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum PolySize {
+    /// 32-bit polynomial.
+    Bits32 = 0x00,
+    /// 16-bit polynomial.
+    Bits16 = 0x08,
+    /// 8-bit polynomial.
+    Bits8 = 0x10,
+    /// 7-bit polynomial.
+    Bits7 = 0x18,
+}
+
+/// Input bit-order reversal mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum ReverseIn {
+    /// Do not reverse input bits.
+    None = 0x00,
+    /// Reverse each input byte.
+    Byte = 0x02,
+    /// Reverse each input half-word.
+    HalfWord = 0x04,
+    /// Reverse each input word.
+    Word = 0x06,
+}
+
+/// CRC configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Initial CRC value written to INIT before calculation.
+    pub init_value: u32,
+    /// Polynomial width.
+    pub poly_size: PolySize,
+    /// Polynomial value.
+    pub poly: u32,
+    /// Input bit-order reversal.
+    pub reverse_in: ReverseIn,
+    /// Reverse the CRC result bits.
+    pub reverse_out: bool,
+}
+
+impl Config {
+    /// CRC-32/ISO-HDLC style defaults matching common SDK examples.
+    pub const fn new() -> Self {
+        Self {
+            init_value: 0xffff_ffff,
+            poly_size: PolySize::Bits32,
+            poly: 0x04c1_1db7,
+            reverse_in: ReverseIn::Word,
+            reverse_out: true,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Owned CRC peripheral.
+pub struct Crc<'d> {
+    _peri: Peri<'d, peripherals::CRC>,
+}
+
+impl<'d> Crc<'d> {
+    /// Enable the CRC clock, release reset, and apply `config`.
+    pub fn new(peri: Peri<'d, peripherals::CRC>, config: Config) -> Self {
+        let _ = rcc::enable_peripheral(Peripheral::Crc);
+        let _ = rcc::reset_peripheral(Peripheral::Crc);
+        let this = Self { _peri: peri };
+        this.configure(config);
+        this
+    }
+
+    /// Reconfigure the CRC engine and latch the initial value.
+    pub fn configure(&self, config: Config) {
+        let regs = Self::regs();
+        let mut cr = config.poly_size as u32 | config.reverse_in as u32;
+        if config.reverse_out {
+            cr |= CR_REVERSE_OUT;
+        }
+        cr |= CR_CALC_INIT;
+
+        unsafe {
+            regs.init().write_with_zero(|w| w.bits(config.init_value));
+            regs.poly().write_with_zero(|w| w.bits(config.poly));
+            regs.cr().write_with_zero(|w| w.bits(cr));
+        }
+    }
+
+    /// Feed 32-bit words and return the CRC result.
+    pub fn feed_u32(&self, data: &[u32]) -> u32 {
+        let regs = Self::regs();
+        for word in data {
+            unsafe {
+                regs.dr().write_with_zero(|w| w.bits(*word));
+            }
+        }
+        Self::wait_done();
+        regs.dr().read().bits()
+    }
+
+    /// Feed 16-bit half-words and return the CRC result.
+    pub fn feed_u16(&self, data: &[u16]) -> u32 {
+        for half in data {
+            unsafe {
+                core::ptr::write_volatile(CRC_DR_ADDR as *mut u16, *half);
+            }
+        }
+        Self::wait_done();
+        Self::regs().dr().read().bits()
+    }
+
+    /// Feed bytes and return the CRC result.
+    pub fn feed_u8(&self, data: &[u8]) -> u32 {
+        for byte in data {
+            unsafe {
+                core::ptr::write_volatile(CRC_DR_ADDR as *mut u8, *byte);
+            }
+        }
+        Self::wait_done();
+        Self::regs().dr().read().bits()
+    }
+
+    fn wait_done() {
+        let regs = Self::regs();
+        while regs.cr().read().bits() & CR_CALC_FLAG != 0 {}
+    }
+
+    #[inline]
+    fn regs() -> pac::Crc {
+        unsafe { pac::Crc::steal() }
+    }
+}
+
+impl Drop for Crc<'_> {
+    fn drop(&mut self) {
+        let _ = rcc::disable_peripheral(Peripheral::Crc);
+    }
+}

--- a/embassy-asr/src/dac.rs
+++ b/embassy-asr/src/dac.rs
@@ -1,0 +1,370 @@
+//! Digital-to-analog converter (DAC).
+//!
+//! Register programming follows the vendor `tremo_dac` driver and the SDK
+//! `dac/sw_trigger` / `dac/sine_wave` examples. Enabling the converter also
+//! programs the AFEC analog window registers used by `dac_cmd()`.
+//!
+//! The fixed analog output is **GPIO09** (`PA9`). This driver places that pin
+//! in analog mode while the DAC is owned.
+//!
+//! # DMA
+//!
+//! [`Dac::set_dma_enabled`] only toggles `CR.DMA_EN`. Buffered waveform
+//! playback is not implemented here. Applications that need the sine-wave
+//! pattern should configure a memory-to-peripheral DMA channel whose
+//! destination is [`Dac::dhr_address`] and whose request selection is
+//! [`crate::dma::Request::Dac`] (vendor handshake `DMA_HANDSHAKE_DACCTRL`),
+//! typically paced by a BSTIMER TRGO trigger.
+
+use crate::afec::analog;
+use crate::gpio::Flex;
+use crate::pac::dac::cr::{MaskAmpSel, TrigSrcSel, TrigTypeSel, WaveSel};
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, pac, peripherals};
+
+/// Maximum 12-bit sample accepted by [`Dac::set_holding`] / [`Dac::set`].
+pub const MAX_VALUE: u16 = 0x0fff;
+
+const SWTRIG: u32 = 1 << 0;
+const SR_UNDERFLOW: u32 = 1 << 0;
+const SR_EMPTY: u32 = 1 << 1;
+
+/// Analog-window bits touched by vendor `dac_cmd()`.
+const ANALOG_11_POWERDOWN: u32 = 3 << 24;
+const ANALOG_12_POWERDOWN: u32 = 1 << 8;
+const ANALOG_27_OUTPUT_ENABLE: u32 = 3 << 11;
+
+/// DAC trigger source (`CR.TRIG_SRC_SEL` / `TRIG_EN`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TriggerSource {
+    /// GPTIMER1 TRGO.
+    Gptimer1Trgo,
+    /// GPTIMER0 TRGO.
+    Gptimer0Trgo,
+    /// BSTIMER1 TRGO.
+    Bstimer1Trgo,
+    /// BSTIMER0 TRGO.
+    Bstimer0Trgo,
+    /// External GPIO6 edge.
+    Gpio6,
+    /// External GPIO24 edge.
+    Gpio24,
+    /// External GPIO43 edge.
+    Gpio43,
+    /// Software trigger via [`Dac::software_trigger`].
+    Software,
+    /// No external/software trigger (`TRIG_EN` cleared).
+    None,
+}
+
+/// Edge polarity for hardware trigger sources (`CR.TRIG_TYPE_SEL`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TriggerType {
+    /// Rising edge.
+    RisingEdge,
+    /// Falling edge.
+    FallingEdge,
+    /// Both edges.
+    RisingFallingEdge,
+}
+
+/// Built-in wave generator selection (`CR.WAVE_SEL`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WaveType {
+    /// No wave generation; convert programmed samples.
+    None,
+    /// Pseudo-noise wave.
+    Noise,
+    /// Triangle wave.
+    Triangle,
+}
+
+/// Wave amplitude / LFSR mask (`CR.MASK_AMP_SEL`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum WaveLevel {
+    /// Amplitude / mask 1.
+    Level1,
+    /// Amplitude / mask 3.
+    Level3,
+    /// Amplitude / mask 7.
+    Level7,
+    /// Amplitude / mask 15.
+    Level15,
+    /// Amplitude / mask 31.
+    Level31,
+    /// Amplitude / mask 63.
+    Level63,
+    /// Amplitude / mask 127.
+    Level127,
+    /// Amplitude / mask 255.
+    Level255,
+    /// Amplitude / mask 511.
+    Level511,
+    /// Amplitude / mask 1023.
+    Level1023,
+}
+
+/// DAC interrupt / status flags (`SR`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Interrupt {
+    /// Holding-buffer underflow.
+    Underflow,
+    /// Holding buffer empty.
+    Empty,
+}
+
+/// DAC configuration matching `dac_config_t`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Trigger source.
+    pub trigger_source: TriggerSource,
+    /// Trigger edge type (meaningful for GPIO / timer sources).
+    pub trigger_type: TriggerType,
+    /// Built-in wave type.
+    pub wave_type: WaveType,
+    /// Wave amplitude / mask level.
+    pub wave_level: WaveLevel,
+}
+
+impl Config {
+    /// Defaults used by the vendor software-trigger example after `memset` +
+    /// `trigger_src = SOFTWARE`: software trigger, rising edge, no wave.
+    pub const fn new() -> Self {
+        Self {
+            trigger_source: TriggerSource::Software,
+            trigger_type: TriggerType::RisingEdge,
+            wave_type: WaveType::None,
+            wave_level: WaveLevel::Level1,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// DAC driver error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Sample is outside the 12-bit range `0..=4095`.
+    InvalidData,
+    /// [`Dac::software_trigger`] / [`Dac::set`] requires [`TriggerSource::Software`].
+    TriggerNotSoftware,
+}
+
+/// Owned ASR6601 DAC.
+pub struct Dac<'d> {
+    _peri: Peri<'d, peripherals::DAC>,
+    _pin: Flex<'d>,
+    trigger_source: TriggerSource,
+}
+
+impl<'d> Dac<'d> {
+    /// Enable the DAC clock, apply `config`, put `PA9` in analog mode, and
+    /// enable the converter (digital `DAC_EN` plus vendor analog sequence).
+    pub fn new(peri: Peri<'d, peripherals::DAC>, pin: Peri<'d, peripherals::PA9>, config: Config) -> Self {
+        let _ = rcc::enable_peripheral(Peripheral::Dac);
+        let _ = rcc::reset_peripheral(Peripheral::Dac);
+
+        let mut pin = Flex::new(pin);
+        pin.set_as_analog();
+
+        let mut this = Self {
+            _peri: peri,
+            _pin: pin,
+            trigger_source: config.trigger_source,
+        };
+        this.configure(config);
+        this.enable();
+        this
+    }
+
+    /// Reconfigure trigger and wave settings (`dac_init`).
+    ///
+    /// Does not change the enable state or analog window.
+    pub fn configure(&mut self, config: Config) {
+        self.trigger_source = config.trigger_source;
+
+        let trig_src = match config.trigger_source {
+            TriggerSource::Gptimer1Trgo => Some(TrigSrcSel::Gptimer1Trgo),
+            TriggerSource::Gptimer0Trgo => Some(TrigSrcSel::Gptimer0Trgo),
+            TriggerSource::Bstimer1Trgo => Some(TrigSrcSel::Bstimer1Trgo),
+            TriggerSource::Bstimer0Trgo => Some(TrigSrcSel::Bstimer0Trgo),
+            TriggerSource::Gpio6 => Some(TrigSrcSel::Gpio6),
+            TriggerSource::Gpio24 => Some(TrigSrcSel::Gpio24),
+            TriggerSource::Gpio43 => Some(TrigSrcSel::Gpio43),
+            TriggerSource::Software => Some(TrigSrcSel::Software),
+            TriggerSource::None => None,
+        };
+        let trig_type = match config.trigger_type {
+            TriggerType::RisingEdge => TrigTypeSel::RisingEdge,
+            TriggerType::FallingEdge => TrigTypeSel::FallingEdge,
+            TriggerType::RisingFallingEdge => TrigTypeSel::RisingFallingEdge,
+        };
+        let wave = match config.wave_type {
+            WaveType::None => WaveSel::None,
+            WaveType::Noise => WaveSel::Noise,
+            WaveType::Triangle => WaveSel::Triangle,
+        };
+        let level = match config.wave_level {
+            WaveLevel::Level1 => MaskAmpSel::Value1,
+            WaveLevel::Level3 => MaskAmpSel::Value3,
+            WaveLevel::Level7 => MaskAmpSel::Value7,
+            WaveLevel::Level15 => MaskAmpSel::Value15,
+            WaveLevel::Level31 => MaskAmpSel::Value31,
+            WaveLevel::Level63 => MaskAmpSel::Value63,
+            WaveLevel::Level127 => MaskAmpSel::Value127,
+            WaveLevel::Level255 => MaskAmpSel::Value255,
+            WaveLevel::Level511 => MaskAmpSel::Value511,
+            WaveLevel::Level1023 => MaskAmpSel::Value1023,
+        };
+
+        Self::regs().cr().modify(|_, w| {
+            match trig_src {
+                Some(src) => {
+                    w.trig_src_sel().variant(src);
+                    w.trig_en().set_bit();
+                }
+                None => {
+                    w.trig_en().clear_bit();
+                }
+            }
+            w.trig_type_sel().variant(trig_type);
+            w.wave_sel().variant(wave);
+            w.mask_amp_sel().variant(level);
+            w
+        });
+    }
+
+    /// Enable the DAC channel (`dac_cmd(true)`).
+    pub fn enable(&mut self) {
+        // Vendor order: clear power-down bits, enable analog output, then DAC_EN.
+        analog::REG_11.clear_bits(ANALOG_11_POWERDOWN);
+        analog::REG_12.clear_bits(ANALOG_12_POWERDOWN);
+        analog::REG_27.set_bits(ANALOG_27_OUTPUT_ENABLE);
+
+        Self::regs().cr().modify(|_, w| w.dac_en().set_bit());
+    }
+
+    /// Disable the DAC channel (`dac_cmd(false)`).
+    pub fn disable(&mut self) {
+        Self::regs().cr().modify(|_, w| w.dac_en().clear_bit());
+
+        analog::REG_11.set_bits(ANALOG_11_POWERDOWN);
+        analog::REG_12.set_bits(ANALOG_12_POWERDOWN);
+        analog::REG_27.clear_bits(ANALOG_27_OUTPUT_ENABLE);
+    }
+
+    /// Write a 12-bit sample into the data-holding register (`dac_write_data`).
+    ///
+    /// With a trigger source enabled, the value is transferred to the output
+    /// register on the next trigger.
+    pub fn set_holding(&mut self, value: u16) -> Result<(), Error> {
+        if value > MAX_VALUE {
+            return Err(Error::InvalidData);
+        }
+        // PAC gap: DHR has no field accessors.
+        unsafe {
+            Self::regs().dhr().write_with_zero(|w| w.bits(u32::from(value)));
+        }
+        Ok(())
+    }
+
+    /// Pulse the software trigger (`dac_software_trigger_cmd(true)`).
+    pub fn software_trigger(&mut self) -> Result<(), Error> {
+        if self.trigger_source != TriggerSource::Software {
+            return Err(Error::TriggerNotSoftware);
+        }
+        // PAC gap: SWTRIGR has no field accessors. Vendor writes bit 0.
+        unsafe {
+            Self::regs().swtrigr().write_with_zero(|w| w.bits(SWTRIG));
+        }
+        Ok(())
+    }
+
+    /// Write a sample and, for [`TriggerSource::Software`], immediately
+    /// trigger conversion (SDK `sw_trigger` sequence).
+    pub fn set(&mut self, value: u16) -> Result<(), Error> {
+        self.set_holding(value)?;
+        if self.trigger_source == TriggerSource::Software {
+            self.software_trigger()?;
+        }
+        Ok(())
+    }
+
+    /// Read the data-output register (`dac_read_output_data`).
+    pub fn read_output(&self) -> u16 {
+        // PAC gap: DOR has no field accessors.
+        (Self::regs().dor().read().bits() & u32::from(MAX_VALUE)) as u16
+    }
+
+    /// Enable or disable DAC DMA requests (`dac_dma_cmd`).
+    ///
+    /// See the module-level DMA note: this does not start a transfer.
+    pub fn set_dma_enabled(&mut self, enabled: bool) {
+        Self::regs().cr().modify(|_, w| w.dma_en().bit(enabled));
+    }
+
+    /// Whether `CR.DMA_EN` is set.
+    pub fn is_dma_enabled(&self) -> bool {
+        Self::regs().cr().read().dma_en().bit_is_set()
+    }
+
+    /// Address of `DHR` for DMA destination programming.
+    #[inline]
+    pub fn dhr_address(&self) -> *mut u32 {
+        Self::regs().dhr().as_ptr()
+    }
+
+    /// Enable or disable a DAC interrupt source (`dac_config_interrupt`).
+    pub fn set_interrupt_enabled(&mut self, interrupt: Interrupt, enabled: bool) {
+        Self::regs().cr().modify(|_, w| match interrupt {
+            Interrupt::Underflow => w.intr_underflow_en().bit(enabled),
+            Interrupt::Empty => w.intr_empty_en().bit(enabled),
+        });
+    }
+
+    /// Whether a status flag is set (`dac_get_interrupt_status`).
+    pub fn interrupt_status(&self, interrupt: Interrupt) -> bool {
+        // PAC gap: SR has no field accessors.
+        let sr = Self::regs().sr().read().bits();
+        match interrupt {
+            Interrupt::Underflow => sr & SR_UNDERFLOW != 0,
+            Interrupt::Empty => sr & SR_EMPTY != 0,
+        }
+    }
+
+    /// Clear a status flag by writing its bit (`dac_clear_interrupt`).
+    pub fn clear_interrupt(&mut self, interrupt: Interrupt) {
+        let bit = match interrupt {
+            Interrupt::Underflow => SR_UNDERFLOW,
+            Interrupt::Empty => SR_EMPTY,
+        };
+        // PAC gap: SR has no field accessors.
+        unsafe {
+            Self::regs().sr().write_with_zero(|w| w.bits(bit));
+        }
+    }
+
+    #[inline]
+    fn regs() -> pac::Dac {
+        // Owned Peri token proves exclusivity; steal only obtains the handle.
+        unsafe { pac::Dac::steal() }
+    }
+}
+
+impl Drop for Dac<'_> {
+    fn drop(&mut self) {
+        self.disable();
+        let _ = rcc::disable_peripheral(Peripheral::Dac);
+    }
+}

--- a/embassy-asr/src/dma.rs
+++ b/embassy-asr/src/dma.rs
@@ -1,0 +1,1459 @@
+//! Direct memory access (DMA) driver for the ASR6601.
+//!
+//! The two DMA controllers are Synopsys DesignWare AHB DMAC instances. Each
+//! controller has four channels and one shared interrupt.
+
+use core::fmt;
+use core::future::Future;
+use core::marker::PhantomData;
+use core::pin::Pin;
+use core::sync::atomic::{AtomicU8, Ordering, compiler_fence};
+use core::task::{Context, Poll};
+
+use embassy_hal_internal::interrupt::{InterruptExt, Priority};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt as TypelevelInterrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::{Peri, PeripheralType, interrupt, pac, peripherals};
+
+const CONTROLLER_COUNT: usize = 2;
+const CHANNELS_PER_CONTROLLER: usize = 4;
+const CHANNEL_COUNT: usize = CONTROLLER_COUNT * CHANNELS_PER_CONTROLLER;
+const MAX_TRANSFER_COUNT: usize = 0x0fff;
+
+const DMA0_BASE: usize = 0x4002_3000;
+const DMA1_BASE: usize = 0x4002_4000;
+
+// These three standard DW_ahb_dmac registers are omitted from the PAC/SVD.
+const STATUS_ERR_OFFSET: usize = 0x0308;
+const MASK_ERR_OFFSET: usize = 0x0330;
+
+const MASK_TFR_OFFSET: usize = 0x0310;
+const MASK_BLOCK_OFFSET: usize = 0x0318;
+const CLEAR_TFR_OFFSET: usize = 0x0338;
+const CLEAR_BLOCK_OFFSET: usize = 0x0340;
+const CLEAR_SRC_TRAN_OFFSET: usize = 0x0348;
+const CLEAR_DST_TRAN_OFFSET: usize = 0x0350;
+const CLEAR_ERR_OFFSET: usize = 0x0358;
+
+const CTL_INT_ENABLE: u32 = 1 << 0;
+const CTL_LLP_DEST_ENABLE: u32 = 1 << 27;
+const CTL_LLP_SOURCE_ENABLE: u32 = 1 << 28;
+const CTL_H_DONE: u32 = 1 << 12;
+
+const CFG_L_CHANNEL_SUSPEND: u32 = 1 << 8;
+const CFG_L_FIFO_EMPTY: u32 = 1 << 9;
+const CFG_L_SOURCE_RELOAD: u32 = 1 << 30;
+const CFG_L_DESTINATION_RELOAD: u32 = 1 << 31;
+
+const RESULT_IDLE: u8 = 0;
+const RESULT_ACTIVE: u8 = 1;
+const RESULT_COMPLETE: u8 = 2;
+const RESULT_ERROR: u8 = 3;
+
+const EVENT_TRANSFER: u8 = 0;
+const EVENT_BLOCK: u8 = 1;
+
+/// Width of one DMA transfer item.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum DataWidth {
+    /// 8-bit transfer.
+    Bits8 = 0,
+    /// 16-bit transfer.
+    Bits16 = 1,
+    /// 32-bit transfer.
+    Bits32 = 2,
+}
+
+impl DataWidth {
+    const fn bytes(self) -> usize {
+        1 << self as usize
+    }
+}
+
+/// Number of items in a DMA burst.
+///
+/// These are the burst sizes documented by the ASR vendor driver.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum BurstSize {
+    /// One item per burst.
+    One = 0,
+    /// Four items per burst.
+    Four = 1,
+    /// Eight items per burst.
+    Eight = 2,
+}
+
+/// Address update performed after each transfer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum AddressMode {
+    /// Increment by the configured transfer width.
+    Increment = 0,
+    /// Decrement by the configured transfer width.
+    Decrement = 1,
+    /// Keep the address fixed.
+    Fixed = 2,
+}
+
+/// DMA transfer direction and flow controller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum Direction {
+    /// Memory to memory, with the DMA as flow controller.
+    MemoryToMemory = 0,
+    /// Memory to peripheral, with the DMA as flow controller.
+    MemoryToPeripheral = 1,
+    /// Peripheral to memory, with the DMA as flow controller.
+    PeripheralToMemory = 2,
+    /// Peripheral to peripheral, with the DMA as flow controller.
+    PeripheralToPeripheral = 3,
+}
+
+/// ASR6601 DMA request mux selection.
+///
+/// One request is routed to each DMA channel through `SYSCFG.CR0` (DMA0) or
+/// `SYSCFG.CR1` (DMA1). Consequently, peripheral-to-peripheral transfers can
+/// only use one request selection for both sides.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum Request {
+    /// LoRa controller transmit.
+    LoracTx = 4,
+    /// LoRa controller receive.
+    LoracRx = 5,
+    /// DAC controller.
+    Dac = 6,
+    /// ADC controller.
+    Adc = 7,
+    /// Security coprocessor.
+    Scc = 9,
+    /// I2C2 transmit.
+    I2c2Tx = 10,
+    /// I2C2 receive.
+    I2c2Rx = 11,
+    /// I2C1 transmit.
+    I2c1Tx = 12,
+    /// I2C1 receive.
+    I2c1Rx = 13,
+    /// I2C0 transmit.
+    I2c0Tx = 14,
+    /// I2C0 receive.
+    I2c0Rx = 15,
+    /// SSP2 transmit.
+    Ssp2Tx = 16,
+    /// SSP2 receive.
+    Ssp2Rx = 17,
+    /// SSP1 transmit.
+    Ssp1Tx = 18,
+    /// SSP1 receive.
+    Ssp1Rx = 19,
+    /// SSP0 transmit.
+    Ssp0Tx = 20,
+    /// SSP0 receive.
+    Ssp0Rx = 21,
+    /// Low-power UART transmit.
+    LpuartTx = 22,
+    /// Low-power UART receive.
+    LpuartRx = 23,
+    /// UART3 transmit.
+    Uart3Tx = 24,
+    /// UART3 receive.
+    Uart3Rx = 25,
+    /// UART2 transmit.
+    Uart2Tx = 26,
+    /// UART2 receive.
+    Uart2Rx = 27,
+    /// UART1 transmit.
+    Uart1Tx = 28,
+    /// UART1 receive.
+    Uart1Rx = 29,
+    /// UART0 transmit.
+    Uart0Tx = 30,
+    /// UART0 receive.
+    Uart0Rx = 31,
+    /// Timer0 channel 3.
+    Timer0Channel3 = 32,
+    /// Timer0 channel 2.
+    Timer0Channel2 = 33,
+    /// Timer0 channel 1.
+    Timer0Channel1 = 34,
+    /// Timer0 channel 0.
+    Timer0Channel0 = 35,
+    /// Timer0 trigger.
+    Timer0Trigger = 36,
+    /// Timer0 update.
+    Timer0Update = 37,
+    /// Timer1 channel 3.
+    Timer1Channel3 = 38,
+    /// Timer1 channel 2.
+    Timer1Channel2 = 39,
+    /// Timer1 channel 1.
+    Timer1Channel1 = 40,
+    /// Timer1 channel 0.
+    Timer1Channel0 = 41,
+    /// Timer1 trigger.
+    Timer1Trigger = 42,
+    /// Timer1 update.
+    Timer1Update = 43,
+    /// Timer2 channel 1.
+    Timer2Channel1 = 44,
+    /// Timer2 channel 0.
+    Timer2Channel0 = 45,
+    /// Timer2 trigger.
+    Timer2Trigger = 46,
+    /// Timer2 update.
+    Timer2Update = 47,
+    /// Timer3 channel 1.
+    Timer3Channel1 = 48,
+    /// Timer3 channel 0.
+    Timer3Channel0 = 49,
+    /// Timer3 trigger.
+    Timer3Trigger = 50,
+    /// Timer3 update.
+    Timer3Update = 51,
+    /// Basic timer 1 update.
+    BasicTimer1Update = 52,
+    /// Basic timer 0 update.
+    BasicTimer0Update = 53,
+}
+
+/// Automatic source and destination reload configuration.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Reload {
+    /// Reload the source address after each block.
+    pub source: bool,
+    /// Reload the destination address after each block.
+    pub destination: bool,
+}
+
+impl Reload {
+    const fn enabled(self) -> bool {
+        self.source || self.destination
+    }
+}
+
+/// Complete configuration for one DMA block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TransferConfig {
+    /// Transfer direction.
+    pub direction: Direction,
+    /// Peripheral request. This must be `None` for memory-to-memory transfers.
+    pub request: Option<Request>,
+    /// Source item width.
+    pub source_width: DataWidth,
+    /// Destination item width.
+    pub destination_width: DataWidth,
+    /// Source burst size.
+    pub source_burst: BurstSize,
+    /// Destination burst size.
+    pub destination_burst: BurstSize,
+    /// Source address update.
+    pub source_address: AddressMode,
+    /// Destination address update.
+    pub destination_address: AddressMode,
+    /// Automatic block reload.
+    pub reload: Reload,
+}
+
+impl TransferConfig {
+    /// Create a memory-to-memory configuration.
+    pub const fn memory_to_memory(width: DataWidth) -> Self {
+        Self {
+            direction: Direction::MemoryToMemory,
+            request: None,
+            source_width: width,
+            destination_width: width,
+            source_burst: BurstSize::One,
+            destination_burst: BurstSize::One,
+            source_address: AddressMode::Increment,
+            destination_address: AddressMode::Increment,
+            reload: Reload {
+                source: false,
+                destination: false,
+            },
+        }
+    }
+
+    /// Create a memory-to-peripheral configuration.
+    pub const fn memory_to_peripheral(width: DataWidth, request: Request) -> Self {
+        Self {
+            direction: Direction::MemoryToPeripheral,
+            request: Some(request),
+            source_width: width,
+            destination_width: width,
+            source_burst: BurstSize::One,
+            destination_burst: BurstSize::One,
+            source_address: AddressMode::Increment,
+            destination_address: AddressMode::Fixed,
+            reload: Reload {
+                source: false,
+                destination: false,
+            },
+        }
+    }
+
+    /// Create a peripheral-to-memory configuration.
+    pub const fn peripheral_to_memory(width: DataWidth, request: Request) -> Self {
+        Self {
+            direction: Direction::PeripheralToMemory,
+            request: Some(request),
+            source_width: width,
+            destination_width: width,
+            source_burst: BurstSize::One,
+            destination_burst: BurstSize::One,
+            source_address: AddressMode::Fixed,
+            destination_address: AddressMode::Increment,
+            reload: Reload {
+                source: false,
+                destination: false,
+            },
+        }
+    }
+
+    /// Create a peripheral-to-peripheral configuration.
+    pub const fn peripheral_to_peripheral(width: DataWidth, request: Request) -> Self {
+        Self {
+            direction: Direction::PeripheralToPeripheral,
+            request: Some(request),
+            source_width: width,
+            destination_width: width,
+            source_burst: BurstSize::One,
+            destination_burst: BurstSize::One,
+            source_address: AddressMode::Fixed,
+            destination_address: AddressMode::Fixed,
+            reload: Reload {
+                source: false,
+                destination: false,
+            },
+        }
+    }
+}
+
+impl Default for TransferConfig {
+    fn default() -> Self {
+        Self::memory_to_memory(DataWidth::Bits8)
+    }
+}
+
+/// Burst options used by the typed convenience methods.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct TransferOptions {
+    /// Source burst size.
+    pub source_burst: BurstSize,
+    /// Destination burst size.
+    pub destination_burst: BurstSize,
+}
+
+impl Default for BurstSize {
+    fn default() -> Self {
+        Self::One
+    }
+}
+
+/// DMA configuration or transfer error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The transfer contains no items.
+    EmptyTransfer,
+    /// A block exceeds the hardware limit of 4095 source transfers.
+    TooManyTransfers,
+    /// The source address is not aligned to the source width.
+    SourceMisaligned,
+    /// The destination address is not aligned to the destination width.
+    DestinationMisaligned,
+    /// A peripheral transfer was configured without a request.
+    MissingRequest,
+    /// A memory-to-memory transfer was configured with a request.
+    UnexpectedRequest,
+    /// A pointer cannot be represented by the ASR6601's 32-bit DMA.
+    AddressOutOfRange,
+    /// The selected channel is already enabled.
+    ChannelBusy,
+    /// Source and destination slice lengths differ.
+    LengthMismatch,
+    /// The linked-list descriptor and block slice lengths differ.
+    LinkedListLengthMismatch,
+    /// A linked-list transfer has incompatible per-block routing settings.
+    IncompatibleLinkedListConfig,
+    /// Reload and linked-list modes were requested together.
+    ReloadWithLinkedList,
+    /// The DMA reported a bus or descriptor error.
+    Bus,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyTransfer => f.write_str("empty DMA transfer"),
+            Self::TooManyTransfers => f.write_str("DMA block exceeds 4095 transfers"),
+            Self::SourceMisaligned => f.write_str("DMA source address is misaligned"),
+            Self::DestinationMisaligned => f.write_str("DMA destination address is misaligned"),
+            Self::MissingRequest => f.write_str("DMA peripheral request is missing"),
+            Self::UnexpectedRequest => f.write_str("memory-to-memory DMA cannot use a peripheral request"),
+            Self::AddressOutOfRange => f.write_str("DMA address is outside the 32-bit address space"),
+            Self::ChannelBusy => f.write_str("DMA channel is busy"),
+            Self::LengthMismatch => f.write_str("DMA source and destination lengths differ"),
+            Self::LinkedListLengthMismatch => f.write_str("DMA linked-list lengths differ"),
+            Self::IncompatibleLinkedListConfig => f.write_str("DMA linked-list routing differs between blocks"),
+            Self::ReloadWithLinkedList => f.write_str("DMA reload and linked-list modes cannot be combined"),
+            Self::Bus => f.write_str("DMA bus or descriptor error"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+mod word_sealed {
+    pub trait Sealed {}
+}
+
+/// A type that can be transferred by the DMA.
+#[allow(private_bounds)]
+pub trait Word: word_sealed::Sealed + Copy + 'static {
+    /// DMA width for this type.
+    const WIDTH: DataWidth;
+}
+
+impl word_sealed::Sealed for u8 {}
+impl Word for u8 {
+    const WIDTH: DataWidth = DataWidth::Bits8;
+}
+
+impl word_sealed::Sealed for u16 {}
+impl Word for u16 {
+    const WIDTH: DataWidth = DataWidth::Bits16;
+}
+
+impl word_sealed::Sealed for u32 {}
+impl Word for u32 {
+    const WIDTH: DataWidth = DataWidth::Bits32;
+}
+
+/// One block used to build a linked-list transfer.
+#[derive(Clone, Copy, Debug)]
+pub struct LinkedListBlock {
+    /// Source address used for the block.
+    pub source: *const u8,
+    /// Destination address used for the block.
+    pub destination: *mut u8,
+    /// Number of source transfers in the block.
+    pub transfer_count: usize,
+    /// Block configuration.
+    pub config: TransferConfig,
+}
+
+impl LinkedListBlock {
+    /// Create a linked-list block from raw addresses.
+    pub const fn new(source: *const u8, destination: *mut u8, transfer_count: usize, config: TransferConfig) -> Self {
+        Self {
+            source,
+            destination,
+            transfer_count,
+            config,
+        }
+    }
+}
+
+/// Hardware linked-list descriptor.
+///
+/// Keep descriptors in DMA-accessible RAM and do not move them while a linked
+/// transfer is active. The transfer APIs enforce this for the descriptor slice.
+#[derive(Clone, Copy, Debug)]
+#[repr(C, align(4))]
+pub struct LinkedListItem {
+    source: u32,
+    destination: u32,
+    next: u32,
+    control_low: u32,
+    control_high: u32,
+    source_status: u32,
+    destination_status: u32,
+}
+
+impl LinkedListItem {
+    /// Create an empty descriptor suitable for array initialization.
+    pub const fn new() -> Self {
+        Self {
+            source: 0,
+            destination: 0,
+            next: 0,
+            control_low: 0,
+            control_high: 0,
+            source_status: 0,
+            destination_status: 0,
+        }
+    }
+}
+
+impl Default for LinkedListItem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct ChannelState {
+    waker: AtomicWaker,
+    result: AtomicU8,
+    event: AtomicU8,
+}
+
+impl ChannelState {
+    const fn new() -> Self {
+        Self {
+            waker: AtomicWaker::new(),
+            result: AtomicU8::new(RESULT_IDLE),
+            event: AtomicU8::new(EVENT_TRANSFER),
+        }
+    }
+}
+
+static STATE: [ChannelState; CHANNEL_COUNT] = [const { ChannelState::new() }; CHANNEL_COUNT];
+
+mod sealed {
+    pub trait ControllerInstance {}
+    pub trait ChannelInstance {}
+}
+
+/// DMA controller instance.
+#[allow(private_bounds)]
+pub trait ControllerInstance: sealed::ControllerInstance + PeripheralType + 'static {
+    /// Shared interrupt for this controller.
+    type Interrupt: TypelevelInterrupt;
+
+    /// Controller number, zero or one.
+    const NUMBER: usize;
+}
+
+/// DMA channel singleton instance.
+#[allow(private_bounds)]
+pub trait ChannelInstance: sealed::ChannelInstance + PeripheralType + 'static {
+    /// DMA controller containing this channel.
+    type Controller: ControllerInstance;
+
+    /// Channel number within the controller.
+    const NUMBER: usize;
+}
+
+/// Interrupt handler for one DMA controller.
+pub struct InterruptHandler<T: ControllerInstance> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: ControllerInstance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        on_interrupt(T::NUMBER);
+    }
+}
+
+/// Owned DMA channel.
+pub struct Channel<'d, M: Mode> {
+    controller: usize,
+    channel: usize,
+    _lifetime: PhantomData<&'d mut M>,
+}
+
+impl<'d> Channel<'d, Blocking> {
+    /// Create a channel for polling and blocking transfers.
+    pub fn new_blocking<T: ChannelInstance>(_channel: Peri<'d, T>) -> Self {
+        Self::from_instance::<T>()
+    }
+
+    /// Start a raw transfer without enabling its interrupt.
+    ///
+    /// # Safety
+    ///
+    /// The source and destination must remain valid, correctly sized, and
+    /// accessible by DMA until the returned transfer is dropped or completes.
+    /// The caller must also uphold any peripheral-specific DMA requirements.
+    pub unsafe fn start_transfer_raw<'a>(
+        &'a mut self,
+        source: *const u8,
+        destination: *mut u8,
+        transfer_count: usize,
+        config: TransferConfig,
+    ) -> Result<Transfer<'a, Blocking>, Error> {
+        self.start_raw(source, destination, transfer_count, config, false)
+    }
+
+    /// Execute a raw transfer and wait for it to finish.
+    ///
+    /// # Safety
+    ///
+    /// The same requirements as [`Self::start_transfer_raw`] apply.
+    pub unsafe fn blocking_transfer_raw(
+        &mut self,
+        source: *const u8,
+        destination: *mut u8,
+        transfer_count: usize,
+        config: TransferConfig,
+    ) -> Result<(), Error> {
+        unsafe { self.start_transfer_raw(source, destination, transfer_count, config) }?.blocking_wait()
+    }
+
+    /// Start a memory-to-memory copy.
+    pub fn start_copy<'a, W: Word>(
+        &'a mut self,
+        source: &'a [W],
+        destination: &'a mut [W],
+        options: TransferOptions,
+    ) -> Result<Transfer<'a, Blocking>, Error> {
+        self.start_copy_inner(source, destination, options, false)
+    }
+
+    /// Copy a slice and wait for completion.
+    pub fn blocking_copy<W: Word>(
+        &mut self,
+        source: &[W],
+        destination: &mut [W],
+        options: TransferOptions,
+    ) -> Result<(), Error> {
+        self.start_copy(source, destination, options)?.blocking_wait()
+    }
+
+    /// Start a peripheral-to-memory transfer.
+    ///
+    /// # Safety
+    ///
+    /// `source` must be a readable peripheral register of width `W` and must
+    /// remain valid for the transfer.
+    pub unsafe fn start_read<'a, W: Word>(
+        &'a mut self,
+        source: *const W,
+        destination: &'a mut [W],
+        request: Request,
+        options: TransferOptions,
+    ) -> Result<Transfer<'a, Blocking>, Error> {
+        unsafe { self.start_read_inner(source, destination, request, options, false) }
+    }
+
+    /// Start a memory-to-peripheral transfer.
+    ///
+    /// # Safety
+    ///
+    /// `destination` must be a writable peripheral register of width `W` and
+    /// must remain valid for the transfer.
+    pub unsafe fn start_write<'a, W: Word>(
+        &'a mut self,
+        source: &'a [W],
+        destination: *mut W,
+        request: Request,
+        options: TransferOptions,
+    ) -> Result<Transfer<'a, Blocking>, Error> {
+        unsafe { self.start_write_inner(source, destination, request, options, false) }
+    }
+
+    /// Start a raw linked-list transfer without enabling its interrupt.
+    ///
+    /// # Safety
+    ///
+    /// Every block address must remain valid and DMA-accessible until the
+    /// returned transfer is dropped or completes. Descriptors must be in
+    /// DMA-accessible RAM.
+    pub unsafe fn start_linked_transfer_raw<'a>(
+        &'a mut self,
+        descriptors: &'a mut [LinkedListItem],
+        blocks: &'a [LinkedListBlock],
+    ) -> Result<Transfer<'a, Blocking>, Error> {
+        self.start_linked_raw(descriptors, blocks, false)
+    }
+}
+
+impl<'d> Channel<'d, Async> {
+    /// Create an interrupt-driven DMA channel.
+    pub fn new<T: ChannelInstance>(
+        _channel: Peri<'d, T>,
+        _irq: impl Binding<<T::Controller as ControllerInstance>::Interrupt, InterruptHandler<T::Controller>> + 'd,
+    ) -> Self {
+        unsafe {
+            <T::Controller as ControllerInstance>::Interrupt::enable();
+        }
+        Self::from_instance::<T>()
+    }
+
+    /// Start an asynchronous raw transfer.
+    ///
+    /// # Safety
+    ///
+    /// The source and destination must remain valid, correctly sized, and
+    /// accessible by DMA until the returned future is dropped or completes.
+    /// The caller must also uphold any peripheral-specific DMA requirements.
+    pub unsafe fn transfer_raw<'a>(
+        &'a mut self,
+        source: *const u8,
+        destination: *mut u8,
+        transfer_count: usize,
+        config: TransferConfig,
+    ) -> Result<Transfer<'a, Async>, Error> {
+        self.start_raw(source, destination, transfer_count, config, true)
+    }
+
+    /// Start an asynchronous memory-to-memory copy.
+    pub fn copy<'a, W: Word>(
+        &'a mut self,
+        source: &'a [W],
+        destination: &'a mut [W],
+        options: TransferOptions,
+    ) -> Result<Transfer<'a, Async>, Error> {
+        self.start_copy_inner(source, destination, options, true)
+    }
+
+    /// Start an asynchronous peripheral-to-memory transfer.
+    ///
+    /// # Safety
+    ///
+    /// `source` must be a readable peripheral register of width `W` and must
+    /// remain valid for the transfer.
+    pub unsafe fn read<'a, W: Word>(
+        &'a mut self,
+        source: *const W,
+        destination: &'a mut [W],
+        request: Request,
+        options: TransferOptions,
+    ) -> Result<Transfer<'a, Async>, Error> {
+        unsafe { self.start_read_inner(source, destination, request, options, true) }
+    }
+
+    /// Start an asynchronous memory-to-peripheral transfer.
+    ///
+    /// # Safety
+    ///
+    /// `destination` must be a writable peripheral register of width `W` and
+    /// must remain valid for the transfer.
+    pub unsafe fn write<'a, W: Word>(
+        &'a mut self,
+        source: &'a [W],
+        destination: *mut W,
+        request: Request,
+        options: TransferOptions,
+    ) -> Result<Transfer<'a, Async>, Error> {
+        unsafe { self.start_write_inner(source, destination, request, options, true) }
+    }
+
+    /// Start an asynchronous raw linked-list transfer.
+    ///
+    /// # Safety
+    ///
+    /// Every block address must remain valid and DMA-accessible until the
+    /// returned future is dropped or completes. Descriptors must be in
+    /// DMA-accessible RAM.
+    pub unsafe fn linked_transfer_raw<'a>(
+        &'a mut self,
+        descriptors: &'a mut [LinkedListItem],
+        blocks: &'a [LinkedListBlock],
+    ) -> Result<Transfer<'a, Async>, Error> {
+        self.start_linked_raw(descriptors, blocks, true)
+    }
+}
+
+impl<'d, M: Mode> Channel<'d, M> {
+    fn from_instance<T: ChannelInstance>() -> Self {
+        Self {
+            controller: T::Controller::NUMBER,
+            channel: T::NUMBER,
+            _lifetime: PhantomData,
+        }
+    }
+
+    /// Controller number, zero or one.
+    pub fn controller(&self) -> usize {
+        self.controller
+    }
+
+    /// Channel number within the controller.
+    pub fn number(&self) -> usize {
+        self.channel
+    }
+
+    /// Reborrow this channel.
+    pub fn reborrow(&mut self) -> Channel<'_, M> {
+        Channel {
+            controller: self.controller,
+            channel: self.channel,
+            _lifetime: PhantomData,
+        }
+    }
+
+    fn state_index(&self) -> usize {
+        self.controller * CHANNELS_PER_CONTROLLER + self.channel
+    }
+
+    fn state(&self) -> &'static ChannelState {
+        &STATE[self.state_index()]
+    }
+
+    fn regs(&self) -> &'static pac::dma0::RegisterBlock {
+        controller_regs(self.controller)
+    }
+
+    fn channel_regs(&self) -> &'static pac::dma0::Ch {
+        self.regs().ch(self.channel)
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.regs().chenreg_l().read().bits() & channel_bit(self.channel) != 0
+    }
+
+    fn start_copy_inner<'a, W: Word>(
+        &'a mut self,
+        source: &'a [W],
+        destination: &'a mut [W],
+        options: TransferOptions,
+        interrupts: bool,
+    ) -> Result<Transfer<'a, M>, Error> {
+        if source.len() != destination.len() {
+            return Err(Error::LengthMismatch);
+        }
+        let mut config = TransferConfig::memory_to_memory(W::WIDTH);
+        config.source_burst = options.source_burst;
+        config.destination_burst = options.destination_burst;
+        self.start_raw(
+            source.as_ptr().cast(),
+            destination.as_mut_ptr().cast(),
+            source.len(),
+            config,
+            interrupts,
+        )
+    }
+
+    unsafe fn start_read_inner<'a, W: Word>(
+        &'a mut self,
+        source: *const W,
+        destination: &'a mut [W],
+        request: Request,
+        options: TransferOptions,
+        interrupts: bool,
+    ) -> Result<Transfer<'a, M>, Error> {
+        let mut config = TransferConfig::peripheral_to_memory(W::WIDTH, request);
+        config.source_burst = options.source_burst;
+        config.destination_burst = options.destination_burst;
+        self.start_raw(
+            source.cast(),
+            destination.as_mut_ptr().cast(),
+            destination.len(),
+            config,
+            interrupts,
+        )
+    }
+
+    unsafe fn start_write_inner<'a, W: Word>(
+        &'a mut self,
+        source: &'a [W],
+        destination: *mut W,
+        request: Request,
+        options: TransferOptions,
+        interrupts: bool,
+    ) -> Result<Transfer<'a, M>, Error> {
+        let mut config = TransferConfig::memory_to_peripheral(W::WIDTH, request);
+        config.source_burst = options.source_burst;
+        config.destination_burst = options.destination_burst;
+        self.start_raw(
+            source.as_ptr().cast(),
+            destination.cast(),
+            source.len(),
+            config,
+            interrupts,
+        )
+    }
+
+    fn start_raw<'a>(
+        &'a mut self,
+        source: *const u8,
+        destination: *mut u8,
+        transfer_count: usize,
+        config: TransferConfig,
+        interrupts: bool,
+    ) -> Result<Transfer<'a, M>, Error> {
+        let event = if config.reload.enabled() {
+            EVENT_BLOCK
+        } else {
+            EVENT_TRANSFER
+        };
+        self.prepare(source, destination, transfer_count, config, event, interrupts)?;
+        self.enable();
+        Ok(Transfer {
+            channel: self.reborrow(),
+        })
+    }
+
+    fn start_linked_raw<'a>(
+        &'a mut self,
+        descriptors: &'a mut [LinkedListItem],
+        blocks: &'a [LinkedListBlock],
+        interrupts: bool,
+    ) -> Result<Transfer<'a, M>, Error> {
+        if descriptors.len() != blocks.len() {
+            return Err(Error::LinkedListLengthMismatch);
+        }
+        let first = blocks.first().ok_or(Error::EmptyTransfer)?;
+        if first.config.reload.enabled() {
+            return Err(Error::ReloadWithLinkedList);
+        }
+
+        for block in blocks {
+            if block.config.reload.enabled() {
+                return Err(Error::ReloadWithLinkedList);
+            }
+            if block.config.direction != first.config.direction || block.config.request != first.config.request {
+                return Err(Error::IncompatibleLinkedListConfig);
+            }
+            validate_transfer(block.source, block.destination, block.transfer_count, block.config)?;
+        }
+
+        let descriptor_base = address_to_u32(descriptors.as_ptr() as usize)?;
+        if descriptor_base & 0x03 != 0 {
+            return Err(Error::AddressOutOfRange);
+        }
+
+        for index in 0..blocks.len() {
+            let block = &blocks[index];
+            let last = index + 1 == blocks.len();
+            let next = if last {
+                0
+            } else {
+                address_to_u32((&descriptors[index + 1]) as *const LinkedListItem as usize)?
+            };
+            descriptors[index] = LinkedListItem {
+                source: address_to_u32(block.source as usize)?,
+                destination: address_to_u32(block.destination as usize)?,
+                next,
+                control_low: control_low(block.config, !last),
+                control_high: control_high(block.transfer_count),
+                source_status: 0,
+                destination_status: 0,
+            };
+        }
+
+        self.prepare(
+            first.source,
+            first.destination,
+            first.transfer_count,
+            first.config,
+            EVENT_TRANSFER,
+            interrupts,
+        )?;
+
+        let channel = self.channel_regs();
+        unsafe {
+            channel.llp_l().write_with_zero(|w| w.bits(descriptor_base));
+            channel.llp_h().write_with_zero(|w| w.bits(0));
+            channel
+                .ctl_l()
+                .write_with_zero(|w| w.bits(control_low(first.config, true)));
+        }
+        compiler_fence(Ordering::SeqCst);
+        self.enable();
+
+        Ok(Transfer {
+            channel: self.reborrow(),
+        })
+    }
+
+    fn prepare(
+        &self,
+        source: *const u8,
+        destination: *mut u8,
+        transfer_count: usize,
+        config: TransferConfig,
+        event: u8,
+        interrupts: bool,
+    ) -> Result<(), Error> {
+        validate_transfer(source, destination, transfer_count, config)?;
+        if self.is_enabled() {
+            return Err(Error::ChannelBusy);
+        }
+
+        if let Some(request) = config.request {
+            route_request(self.controller, self.channel, request);
+        }
+
+        self.mask_interrupts();
+        self.clear_pending();
+
+        let state = self.state();
+        state.event.store(event, Ordering::Relaxed);
+        state.result.store(RESULT_ACTIVE, Ordering::Release);
+
+        let source_peripheral = if matches!(
+            config.direction,
+            Direction::PeripheralToMemory | Direction::PeripheralToPeripheral
+        ) {
+            self.channel as u32
+        } else {
+            0
+        };
+        let destination_peripheral = if matches!(
+            config.direction,
+            Direction::MemoryToPeripheral | Direction::PeripheralToPeripheral
+        ) {
+            self.channel as u32
+        } else {
+            0
+        };
+
+        let mut cfg_low = 0;
+        if config.reload.source {
+            cfg_low |= CFG_L_SOURCE_RELOAD;
+        }
+        if config.reload.destination {
+            cfg_low |= CFG_L_DESTINATION_RELOAD;
+        }
+        let cfg_high = (source_peripheral << 7) | (destination_peripheral << 11);
+
+        let source_addr = address_to_u32(source as usize)?;
+        let destination_addr = address_to_u32(destination as usize)?;
+        let channel = self.channel_regs();
+        unsafe {
+            channel.sar_l().write_with_zero(|w| w.bits(source_addr));
+            channel.sar_h().write_with_zero(|w| w.bits(0));
+            channel.dar_l().write_with_zero(|w| w.bits(destination_addr));
+            channel.dar_h().write_with_zero(|w| w.bits(0));
+            channel.llp_l().write_with_zero(|w| w.bits(0));
+            channel.llp_h().write_with_zero(|w| w.bits(0));
+            channel.ctl_l().write_with_zero(|w| w.bits(control_low(config, false)));
+            channel
+                .ctl_h()
+                .write_with_zero(|w| w.bits(control_high(transfer_count)));
+            channel.cfg_l().write_with_zero(|w| w.bits(cfg_low));
+            channel.cfg_h().write_with_zero(|w| w.bits(cfg_high));
+        }
+
+        compiler_fence(Ordering::SeqCst);
+
+        if interrupts {
+            set_mask(self.controller, MASK_ERR_OFFSET, self.channel, true);
+            set_mask(
+                self.controller,
+                if event == EVENT_BLOCK {
+                    MASK_BLOCK_OFFSET
+                } else {
+                    MASK_TFR_OFFSET
+                },
+                self.channel,
+                true,
+            );
+        }
+
+        Ok(())
+    }
+
+    fn enable(&self) {
+        compiler_fence(Ordering::SeqCst);
+        let regs = self.regs();
+        if regs.dmacfgreg_l().read().bits() & 1 == 0 {
+            unsafe {
+                regs.dmacfgreg_l().write_with_zero(|w| w.bits(1));
+            }
+        }
+        let bit = channel_bit(self.channel);
+        unsafe {
+            regs.chenreg_l().write_with_zero(|w| w.bits(bit | (bit << 8)));
+        }
+        compiler_fence(Ordering::SeqCst);
+    }
+
+    fn poll_result(&self) -> Option<Result<(), Error>> {
+        match self.state().result.load(Ordering::Acquire) {
+            RESULT_COMPLETE => return Some(Ok(())),
+            RESULT_ERROR => return Some(Err(Error::Bus)),
+            _ => {}
+        }
+
+        let bit = channel_bit(self.channel);
+        if read_register(self.controller, STATUS_ERR_OFFSET) & bit != 0 {
+            write_register(self.controller, CLEAR_ERR_OFFSET, bit);
+            self.state().result.store(RESULT_ERROR, Ordering::Release);
+            return Some(Err(Error::Bus));
+        }
+
+        let complete = if self.state().event.load(Ordering::Relaxed) == EVENT_BLOCK {
+            self.regs().status_block_l().read().bits() & bit != 0
+        } else {
+            self.regs().status_tfr_l().read().bits() & bit != 0
+        };
+
+        if complete || !self.is_enabled() {
+            write_register(
+                self.controller,
+                if self.state().event.load(Ordering::Relaxed) == EVENT_BLOCK {
+                    CLEAR_BLOCK_OFFSET
+                } else {
+                    CLEAR_TFR_OFFSET
+                },
+                bit,
+            );
+            self.state().result.store(RESULT_COMPLETE, Ordering::Release);
+            return Some(Ok(()));
+        }
+
+        None
+    }
+
+    fn mask_interrupts(&self) {
+        set_mask(self.controller, MASK_TFR_OFFSET, self.channel, false);
+        set_mask(self.controller, MASK_BLOCK_OFFSET, self.channel, false);
+        set_mask(self.controller, MASK_ERR_OFFSET, self.channel, false);
+    }
+
+    fn clear_pending(&self) {
+        let bit = channel_bit(self.channel);
+        write_register(self.controller, CLEAR_TFR_OFFSET, bit);
+        write_register(self.controller, CLEAR_BLOCK_OFFSET, bit);
+        write_register(self.controller, CLEAR_SRC_TRAN_OFFSET, bit);
+        write_register(self.controller, CLEAR_DST_TRAN_OFFSET, bit);
+        write_register(self.controller, CLEAR_ERR_OFFSET, bit);
+    }
+
+    /// Stop the channel and wait until it can no longer access memory.
+    pub fn abort(&mut self) {
+        self.mask_interrupts();
+
+        if self.is_enabled() {
+            let channel = self.channel_regs();
+            channel
+                .cfg_l()
+                .modify(|r, w| unsafe { w.bits(r.bits() | CFG_L_CHANNEL_SUSPEND) });
+            while channel.cfg_l().read().bits() & CFG_L_FIFO_EMPTY == 0 {}
+
+            let bit = channel_bit(self.channel);
+            unsafe {
+                self.regs().chenreg_l().write_with_zero(|w| w.bits(bit << 8));
+            }
+            while self.is_enabled() {}
+
+            channel
+                .cfg_l()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !CFG_L_CHANNEL_SUSPEND) });
+        }
+
+        self.clear_pending();
+        self.state().result.store(RESULT_IDLE, Ordering::Release);
+        compiler_fence(Ordering::SeqCst);
+    }
+}
+
+/// An in-progress DMA transfer.
+///
+/// Dropping this value is cancellation-safe: the channel is suspended, its FIFO
+/// is drained, and the channel is disabled before borrowed memory is released.
+#[must_use = "a DMA transfer stops when dropped"]
+pub struct Transfer<'a, M: Mode> {
+    channel: Channel<'a, M>,
+}
+
+impl<'a, M: Mode> Transfer<'a, M> {
+    /// Return whether the transfer has reached its completion event.
+    pub fn is_finished(&self) -> bool {
+        self.channel.poll_result().is_some()
+    }
+
+    /// Wait synchronously for completion.
+    ///
+    /// With automatic reload enabled, completion means the first block has
+    /// completed. Dropping `self` then stops the repeating transfer.
+    pub fn blocking_wait(self) -> Result<(), Error> {
+        compiler_fence(Ordering::SeqCst);
+        let result = loop {
+            if let Some(result) = self.channel.poll_result() {
+                break result;
+            }
+        };
+        compiler_fence(Ordering::SeqCst);
+        result
+    }
+
+    /// Explicitly cancel the transfer.
+    pub fn cancel(mut self) {
+        self.channel.abort();
+    }
+}
+
+impl<'a, M: Mode> Drop for Transfer<'a, M> {
+    fn drop(&mut self) {
+        self.channel.abort();
+    }
+}
+
+impl<'a> Unpin for Transfer<'a, Async> {}
+
+impl<'a> Future for Transfer<'a, Async> {
+    type Output = Result<(), Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let state = self.channel.state();
+        state.waker.register(cx.waker());
+        compiler_fence(Ordering::SeqCst);
+
+        match self.channel.poll_result() {
+            Some(result) => Poll::Ready(result),
+            None => Poll::Pending,
+        }
+    }
+}
+
+fn validate_transfer(
+    source: *const u8,
+    destination: *mut u8,
+    transfer_count: usize,
+    config: TransferConfig,
+) -> Result<(), Error> {
+    if transfer_count == 0 {
+        return Err(Error::EmptyTransfer);
+    }
+    if transfer_count > MAX_TRANSFER_COUNT {
+        return Err(Error::TooManyTransfers);
+    }
+    if source as usize % config.source_width.bytes() != 0 {
+        return Err(Error::SourceMisaligned);
+    }
+    if destination as usize % config.destination_width.bytes() != 0 {
+        return Err(Error::DestinationMisaligned);
+    }
+    address_to_u32(source as usize)?;
+    address_to_u32(destination as usize)?;
+
+    match (config.direction, config.request) {
+        (Direction::MemoryToMemory, Some(_)) => Err(Error::UnexpectedRequest),
+        (Direction::MemoryToMemory, None) => Ok(()),
+        (_, None) => Err(Error::MissingRequest),
+        (_, Some(_)) => Ok(()),
+    }
+}
+
+fn address_to_u32(address: usize) -> Result<u32, Error> {
+    u32::try_from(address).map_err(|_| Error::AddressOutOfRange)
+}
+
+fn control_low(config: TransferConfig, linked: bool) -> u32 {
+    let (source_master, destination_master) = masters(config.direction);
+    let mut value = CTL_INT_ENABLE
+        | ((config.destination_width as u32) << 1)
+        | ((config.source_width as u32) << 4)
+        | ((config.destination_address as u32) << 7)
+        | ((config.source_address as u32) << 9)
+        | ((config.destination_burst as u32) << 11)
+        | ((config.source_burst as u32) << 14)
+        | ((config.direction as u32) << 20)
+        | ((destination_master as u32) << 23)
+        | ((source_master as u32) << 25);
+    if linked {
+        value |= CTL_LLP_DEST_ENABLE | CTL_LLP_SOURCE_ENABLE;
+    }
+    value
+}
+
+fn control_high(transfer_count: usize) -> u32 {
+    transfer_count as u32 | CTL_H_DONE
+}
+
+fn masters(direction: Direction) -> (u8, u8) {
+    match direction {
+        Direction::MemoryToMemory => (1, 1),
+        Direction::MemoryToPeripheral => (1, 0),
+        Direction::PeripheralToMemory | Direction::PeripheralToPeripheral => (0, 0),
+    }
+}
+
+fn route_request(controller: usize, channel: usize, request: Request) {
+    let shift = 8 * (CHANNELS_PER_CONTROLLER - channel - 1);
+    let mask = 0x3f_u32 << shift;
+    let value = (request as u32) << shift;
+    critical_section::with(|_| {
+        let syscfg = unsafe { pac::Syscfg::steal() };
+        if controller == 0 {
+            syscfg
+                .cr0()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | value) });
+        } else {
+            syscfg
+                .cr1()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | value) });
+        }
+    });
+}
+
+fn controller_base(controller: usize) -> usize {
+    match controller {
+        0 => DMA0_BASE,
+        1 => DMA1_BASE,
+        _ => unreachable!(),
+    }
+}
+
+fn controller_regs(controller: usize) -> &'static pac::dma0::RegisterBlock {
+    unsafe { &*(controller_base(controller) as *const pac::dma0::RegisterBlock) }
+}
+
+fn channel_bit(channel: usize) -> u32 {
+    1 << channel
+}
+
+fn read_register(controller: usize, offset: usize) -> u32 {
+    unsafe { core::ptr::read_volatile((controller_base(controller) + offset) as *const u32) }
+}
+
+fn write_register(controller: usize, offset: usize, value: u32) {
+    unsafe {
+        core::ptr::write_volatile((controller_base(controller) + offset) as *mut u32, value);
+    }
+}
+
+fn set_mask(controller: usize, offset: usize, channel: usize, enabled: bool) {
+    let bit = channel_bit(channel);
+    // DW_ahb_dmac mask registers use bits 8..11 as write enables.
+    write_register(controller, offset, (bit << 8) | if enabled { bit } else { 0 });
+}
+
+fn on_interrupt(controller: usize) {
+    let regs = controller_regs(controller);
+    let errors = read_register(controller, STATUS_ERR_OFFSET) & 0x0f;
+    let transfers = regs.status_tfr_l().read().bits() & 0x0f;
+    let blocks = regs.status_block_l().read().bits() & 0x0f;
+
+    if errors != 0 {
+        write_register(controller, CLEAR_ERR_OFFSET, errors);
+    }
+    if transfers != 0 {
+        write_register(controller, CLEAR_TFR_OFFSET, transfers);
+    }
+    if blocks != 0 {
+        write_register(controller, CLEAR_BLOCK_OFFSET, blocks);
+    }
+
+    for channel in 0..CHANNELS_PER_CONTROLLER {
+        let bit = channel_bit(channel);
+        let state = &STATE[controller * CHANNELS_PER_CONTROLLER + channel];
+        let complete = if state.event.load(Ordering::Relaxed) == EVENT_BLOCK {
+            blocks & bit != 0
+        } else {
+            transfers & bit != 0
+        };
+
+        if errors & bit != 0 {
+            state.result.store(RESULT_ERROR, Ordering::Release);
+        } else if complete {
+            state.result.store(RESULT_COMPLETE, Ordering::Release);
+        } else {
+            continue;
+        }
+
+        set_mask(controller, MASK_TFR_OFFSET, channel, false);
+        set_mask(controller, MASK_BLOCK_OFFSET, channel, false);
+        set_mask(controller, MASK_ERR_OFFSET, channel, false);
+        state.waker.wake();
+    }
+}
+
+/// Initialize both ASR6601 DMA controllers.
+///
+/// # Safety
+///
+/// This must be called exactly once, before any DMA channel is constructed.
+pub(crate) unsafe fn init() {
+    let rcc = unsafe { pac::Rcc::steal() };
+    rcc.cgr0().modify(|_, w| {
+        w.dmac0_clk_en()
+            .set_bit()
+            .dmac1_clk_en()
+            .set_bit()
+            .syscfg_clk_en()
+            .set_bit()
+    });
+
+    // Reset is active low. Reset both controllers before exposing channels.
+    rcc.rst1()
+        .modify(|_, w| w.dmac0_rst_n().clear_bit().dmac1_rst_n().clear_bit());
+    rcc.rst1()
+        .modify(|_, w| w.dmac0_rst_n().set_bit().dmac1_rst_n().set_bit());
+
+    pac::Interrupt::DMA0.disable();
+    pac::Interrupt::DMA1.disable();
+
+    for controller in 0..CONTROLLER_COUNT {
+        let regs = controller_regs(controller);
+        unsafe {
+            // Disable all four channels using the CH_EN write-enable bits.
+            regs.chenreg_l().write_with_zero(|w| w.bits(0x0f00));
+        }
+        while regs.chenreg_l().read().bits() & 0x0f != 0 {}
+
+        set_mask(controller, MASK_TFR_OFFSET, 0, false);
+        set_mask(controller, MASK_TFR_OFFSET, 1, false);
+        set_mask(controller, MASK_TFR_OFFSET, 2, false);
+        set_mask(controller, MASK_TFR_OFFSET, 3, false);
+        set_mask(controller, MASK_BLOCK_OFFSET, 0, false);
+        set_mask(controller, MASK_BLOCK_OFFSET, 1, false);
+        set_mask(controller, MASK_BLOCK_OFFSET, 2, false);
+        set_mask(controller, MASK_BLOCK_OFFSET, 3, false);
+        set_mask(controller, MASK_ERR_OFFSET, 0, false);
+        set_mask(controller, MASK_ERR_OFFSET, 1, false);
+        set_mask(controller, MASK_ERR_OFFSET, 2, false);
+        set_mask(controller, MASK_ERR_OFFSET, 3, false);
+
+        write_register(controller, CLEAR_TFR_OFFSET, 0x0f);
+        write_register(controller, CLEAR_BLOCK_OFFSET, 0x0f);
+        write_register(controller, CLEAR_SRC_TRAN_OFFSET, 0x0f);
+        write_register(controller, CLEAR_DST_TRAN_OFFSET, 0x0f);
+        write_register(controller, CLEAR_ERR_OFFSET, 0x0f);
+
+        unsafe {
+            regs.dmacfgreg_l().write_with_zero(|w| w.bits(1));
+        }
+    }
+
+    for state in &STATE {
+        state.result.store(RESULT_IDLE, Ordering::Relaxed);
+        state.event.store(EVENT_TRANSFER, Ordering::Relaxed);
+    }
+
+    pac::Interrupt::DMA0.unpend();
+    pac::Interrupt::DMA1.unpend();
+    pac::Interrupt::DMA0.set_priority(Priority::P2);
+    pac::Interrupt::DMA1.set_priority(Priority::P2);
+}
+
+macro_rules! controller {
+    ($name:ident, $number:expr, $interrupt:ident) => {
+        impl sealed::ControllerInstance for peripherals::$name {}
+
+        impl ControllerInstance for peripherals::$name {
+            type Interrupt = interrupt::typelevel::$interrupt;
+            const NUMBER: usize = $number;
+        }
+    };
+}
+
+macro_rules! channel {
+    ($name:ident, $controller:ident, $number:expr) => {
+        impl sealed::ChannelInstance for peripherals::$name {}
+
+        impl ChannelInstance for peripherals::$name {
+            type Controller = peripherals::$controller;
+            const NUMBER: usize = $number;
+        }
+    };
+}
+
+controller!(DMA0, 0, DMA0);
+controller!(DMA1, 1, DMA1);
+
+channel!(DMA0_CH0, DMA0, 0);
+channel!(DMA0_CH1, DMA0, 1);
+channel!(DMA0_CH2, DMA0, 2);
+channel!(DMA0_CH3, DMA0, 3);
+channel!(DMA1_CH0, DMA1, 0);
+channel!(DMA1_CH1, DMA1, 1);
+channel!(DMA1_CH2, DMA1, 2);
+channel!(DMA1_CH3, DMA1, 3);

--- a/embassy-asr/src/flash.rs
+++ b/embassy-asr/src/flash.rs
@@ -1,0 +1,243 @@
+//! Embedded flash controller (EFC).
+//!
+//! Sequences follow the vendor `tremo_flash` driver and the local flash
+//! algorithm used by probe-rs.
+
+use core::ptr::{read_volatile, write_volatile};
+
+use embedded_storage::nor_flash::{
+    ErrorType, MultiwriteNorFlash, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
+};
+
+use crate::sec::flash_access;
+use crate::{Peri, pac, peripherals};
+
+const FLASH_BASE: u32 = 0x0800_0000;
+const FLASH_SIZE_TAG_ADDR: u32 = 0x1000_2010;
+const PAGE_SIZE: u32 = 0x1000;
+const WRITE_SIZE: u32 = 8;
+const PROTECT_SEQ0: u32 = 0x8c9d_aebf;
+const PROTECT_SEQ1: u32 = 0x1314_1516;
+
+/// Flash driver error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Address is outside the main flash array or misaligned.
+    Address,
+    /// Length is invalid for the requested operation.
+    Length,
+    /// Flash security policy rejected the operation.
+    Security,
+}
+
+impl NorFlashError for Error {
+    fn kind(&self) -> NorFlashErrorKind {
+        match self {
+            Self::Address | Self::Length => NorFlashErrorKind::OutOfBounds,
+            Self::Security => NorFlashErrorKind::Other,
+        }
+    }
+}
+
+/// Owned flash controller for the main array at `0x0800_0000`.
+pub struct Flash<'d> {
+    _peri: Peri<'d, peripherals::EFC>,
+    size: u32,
+}
+
+impl<'d> Flash<'d> {
+    /// Create a flash driver.
+    ///
+    /// Flash size is derived from the vendor INFO tag at `0x1000_2010`, matching
+    /// the SDK / flash algorithm: bits `[1:0] == 0` means 128 KiB, otherwise
+    /// 256 KiB.
+    pub fn new(peri: Peri<'d, peripherals::EFC>) -> Self {
+        let tag = unsafe { read_volatile(FLASH_SIZE_TAG_ADDR as *const u32) } & 0x3;
+        let size = if tag == 0 { 0x2_0000 } else { 0x4_0000 };
+        Self { _peri: peri, size }
+    }
+
+    /// Main flash capacity in bytes.
+    pub fn capacity(&self) -> u32 {
+        self.size
+    }
+
+    /// Erase one 4 KiB page.
+    pub fn erase_page(&mut self, offset: u32) -> Result<(), Error> {
+        if offset % PAGE_SIZE != 0 || offset >= self.size {
+            return Err(Error::Address);
+        }
+        let addr = FLASH_BASE + offset;
+        flash_access::clear_error();
+        let efc = Self::regs();
+        let ecc_disable = efc.cr().read().ecc_disable().bit_is_set();
+        unlock(&efc);
+        unsafe {
+            efc.cr().write_with_zero(|w| {
+                w.page_erase_en().set_bit();
+                w.prefetch_en().set_bit();
+                if ecc_disable {
+                    w.ecc_disable().set_bit();
+                }
+                w
+            });
+        }
+        lock(&efc);
+        unsafe {
+            write_volatile(addr as *mut u32, 0xffff_ffff);
+        }
+        if flash_access::take_error() {
+            return Err(Error::Security);
+        }
+        wait_done(&efc);
+        Ok(())
+    }
+
+    /// Erase the entire main flash array page by page.
+    pub fn erase_all(&mut self) -> Result<(), Error> {
+        let mut offset = 0;
+        while offset < self.size {
+            self.erase_page(offset)?;
+            offset += PAGE_SIZE;
+        }
+        Ok(())
+    }
+
+    /// Program `data` starting at byte `offset`.
+    ///
+    /// The offset must be 8-byte aligned. Trailing bytes that do not fill an
+    /// 8-byte unit are padded with `0xFF`, matching the vendor driver.
+    pub fn program(&mut self, offset: u32, data: &[u8]) -> Result<(), Error> {
+        if offset % WRITE_SIZE != 0 || offset >= self.size {
+            return Err(Error::Address);
+        }
+        if data.is_empty() {
+            return Err(Error::Length);
+        }
+        if offset + data.len() as u32 > self.size {
+            return Err(Error::Length);
+        }
+
+        flash_access::clear_error();
+        let efc = Self::regs();
+        let ecc_disable = efc.cr().read().ecc_disable().bit_is_set();
+        unlock(&efc);
+        unsafe {
+            efc.cr().write_with_zero(|w| {
+                w.prog_en().set_bit();
+                w.prefetch_en().set_bit();
+                if ecc_disable {
+                    w.ecc_disable().set_bit();
+                }
+                w
+            });
+        }
+        lock(&efc);
+
+        let mut i = 0;
+        while i < data.len() {
+            let mut chunk = [0xffu8; 8];
+            let remaining = data.len() - i;
+            let copy = remaining.min(8);
+            chunk[..copy].copy_from_slice(&data[i..i + copy]);
+            let d0 = u32::from_le_bytes(chunk[0..4].try_into().unwrap());
+            let d1 = u32::from_le_bytes(chunk[4..8].try_into().unwrap());
+            unsafe {
+                efc.program_data0().write_with_zero(|w| w.bits(d0));
+                efc.program_data1().write_with_zero(|w| w.bits(d1));
+                write_volatile((FLASH_BASE + offset + i as u32) as *mut u32, 0xffff_ffff);
+            }
+            if flash_access::take_error() {
+                return Err(Error::Security);
+            }
+            wait_done(&efc);
+            i += 8;
+        }
+        Ok(())
+    }
+
+    /// Read flash contents into `buf`.
+    pub fn read(&self, offset: u32, buf: &mut [u8]) -> Result<(), Error> {
+        if offset >= self.size {
+            return Err(Error::Address);
+        }
+        if offset + buf.len() as u32 > self.size {
+            return Err(Error::Length);
+        }
+        let src = (FLASH_BASE + offset) as *const u8;
+        for (i, byte) in buf.iter_mut().enumerate() {
+            *byte = unsafe { read_volatile(src.add(i)) };
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn regs() -> pac::Efc {
+        unsafe { pac::Efc::steal() }
+    }
+}
+
+fn unlock(efc: &pac::Efc) {
+    unsafe {
+        efc.protect_seq().write_with_zero(|w| w.bits(PROTECT_SEQ0));
+        efc.protect_seq().write_with_zero(|w| w.bits(PROTECT_SEQ1));
+    }
+}
+
+fn lock(efc: &pac::Efc) {
+    unsafe {
+        efc.protect_seq().write_with_zero(|w| w.bits(PROTECT_SEQ0));
+        efc.protect_seq().write_with_zero(|w| w.bits(0));
+    }
+}
+
+fn wait_done(efc: &pac::Efc) {
+    while efc.sr().read().operation_done().bit_is_clear() {}
+    let status = efc.sr().read().bits();
+    unsafe {
+        efc.sr().write_with_zero(|w| w.bits(status));
+    }
+}
+
+impl ErrorType for Flash<'_> {
+    type Error = Error;
+}
+
+impl ReadNorFlash for Flash<'_> {
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        Flash::read(self, offset, bytes)
+    }
+
+    fn capacity(&self) -> usize {
+        self.size as usize
+    }
+}
+
+impl NorFlash for Flash<'_> {
+    const WRITE_SIZE: usize = WRITE_SIZE as usize;
+    const ERASE_SIZE: usize = PAGE_SIZE as usize;
+
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        if from % PAGE_SIZE != 0 || to % PAGE_SIZE != 0 || from >= to || to > self.size {
+            return Err(Error::Address);
+        }
+        let mut offset = from;
+        while offset < to {
+            self.erase_page(offset)?;
+            offset += PAGE_SIZE;
+        }
+        Ok(())
+    }
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        if bytes.len() % WRITE_SIZE as usize != 0 {
+            return Err(Error::Length);
+        }
+        self.program(offset, bytes)
+    }
+}
+
+impl MultiwriteNorFlash for Flash<'_> {}

--- a/embassy-asr/src/gpio.rs
+++ b/embassy-asr/src/gpio.rs
@@ -1,0 +1,1445 @@
+//! General-purpose I/O for the ASR6601.
+//!
+//! The register programming in this driver follows the vendor
+//! `tremo_gpio.c` implementation. In particular, an `OER` bit disables the
+//! output driver when set, `IFR` is treated as write-one-to-clear, and
+//! open-drain operation on PD8..PD15 is emulated by switching `OER`.
+
+use core::convert::Infallible;
+use core::future::Future;
+use core::marker::PhantomData;
+use core::pin::Pin as FuturePin;
+use core::task::{Context, Poll};
+
+use embassy_hal_internal::interrupt::Priority;
+use embassy_hal_internal::{Peri, PeripheralType, impl_peripheral};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::{pac, peripherals};
+
+const PORT_COUNT: usize = 4;
+const PINS_PER_PORT: usize = 16;
+const PIN_COUNT: usize = PORT_COUNT * PINS_PER_PORT;
+const GPIO_BASE: usize = 0x4001_f000;
+const GPIO_PORT_STRIDE: usize = 0x400;
+
+const INTERRUPT_NONE: u32 = 0;
+const INTERRUPT_RISING: u32 = 1;
+const INTERRUPT_FALLING: u32 = 2;
+const INTERRUPT_ANY_EDGE: u32 = 3;
+
+static PIN_WAKERS: [AtomicWaker; PIN_COUNT] = [const { AtomicWaker::new() }; PIN_COUNT];
+
+/// A GPIO port.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum Port {
+    /// GPIO port A.
+    A = 0,
+    /// GPIO port B.
+    B = 1,
+    /// GPIO port C.
+    C = 2,
+    /// GPIO port D.
+    D = 3,
+}
+
+impl Port {
+    #[inline]
+    const fn from_index(index: u8) -> Self {
+        match index {
+            0 => Self::A,
+            1 => Self::B,
+            2 => Self::C,
+            3 => Self::D,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// A digital pin level.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Level {
+    /// Logical low.
+    Low,
+    /// Logical high.
+    High,
+}
+
+impl From<bool> for Level {
+    #[inline]
+    fn from(value: bool) -> Self {
+        if value { Self::High } else { Self::Low }
+    }
+}
+
+impl From<Level> for bool {
+    #[inline]
+    fn from(value: Level) -> Self {
+        value == Level::High
+    }
+}
+
+/// Internal pull resistor configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Pull {
+    /// Disable the internal pull resistor.
+    None,
+    /// Enable the internal pull-up resistor.
+    Up,
+    /// Enable the internal pull-down resistor.
+    Down,
+}
+
+/// Output drive capability.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Drive {
+    /// Maximum output current of 4 mA.
+    _4mA,
+    /// Maximum output current of 8 mA.
+    _8mA,
+}
+
+/// GPIO output slew-rate selection.
+///
+/// The vendor GPIO register block and `tremo_gpio` API expose no selectable
+/// slew-rate bit. This one-value type makes that hardware limitation explicit
+/// while allowing portable board code to state that the hardware default is
+/// required.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum SlewRate {
+    /// Leave the pad at its hardware-defined slew rate.
+    HardwareDefault,
+}
+
+/// GPIO output driver type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OutputType {
+    /// Drive both high and low levels.
+    PushPull,
+    /// Drive low and release the pin for a high level.
+    OpenDrain,
+}
+
+/// Explicit GPIO alternate-function selector.
+///
+/// Function 0 is the GPIO function. Functions 1 through 7 are deliberately
+/// not assigned peripheral signal names because the available vendor sources
+/// do not contain a complete pinmux matrix.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum AlternateFunction {
+    /// GPIO function.
+    Function0 = 0,
+    /// Alternate function 1.
+    Function1 = 1,
+    /// Alternate function 2.
+    Function2 = 2,
+    /// Alternate function 3.
+    Function3 = 3,
+    /// Alternate function 4.
+    Function4 = 4,
+    /// Alternate function 5.
+    Function5 = 5,
+    /// Alternate function 6.
+    Function6 = 6,
+    /// Alternate function 7.
+    Function7 = 7,
+}
+
+impl AlternateFunction {
+    #[inline]
+    const fn from_bits(bits: u32) -> Self {
+        match bits & 0x7 {
+            0 => Self::Function0,
+            1 => Self::Function1,
+            2 => Self::Function2,
+            3 => Self::Function3,
+            4 => Self::Function4,
+            5 => Self::Function5,
+            6 => Self::Function6,
+            7 => Self::Function7,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// Error returned when a pin cannot be a stop-3 wake source.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Stop3WakeError {
+    /// PD8..PD15 are not stop-3 wake sources.
+    UnsupportedPin,
+}
+
+mod sealed {
+    pub trait Pin {
+        fn id(&self) -> u8;
+    }
+}
+
+/// A GPIO pin singleton that can be used by this driver.
+#[allow(private_bounds)]
+pub trait Pin: PeripheralType + Into<AnyPin> + sealed::Pin + Sized + 'static {
+    /// Return the GPIO port.
+    #[inline]
+    fn port(&self) -> Port {
+        Port::from_index(self.id() / PINS_PER_PORT as u8)
+    }
+
+    /// Return the pin number within its port.
+    #[inline]
+    fn pin(&self) -> u8 {
+        self.id() % PINS_PER_PORT as u8
+    }
+}
+
+/// A type-erased GPIO pin.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct AnyPin {
+    id: u8,
+}
+
+impl AnyPin {
+    /// Unsafely construct a type-erased pin.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that no other token or driver accesses the same
+    /// port and pin for the lifetime of the returned value.
+    pub unsafe fn steal(port: Port, pin: u8) -> Peri<'static, Self> {
+        assert!(pin < PINS_PER_PORT as u8);
+        unsafe {
+            Peri::new_unchecked(Self {
+                id: port as u8 * PINS_PER_PORT as u8 + pin,
+            })
+        }
+    }
+}
+
+impl_peripheral!(AnyPin);
+
+impl sealed::Pin for AnyPin {
+    #[inline]
+    fn id(&self) -> u8 {
+        self.id
+    }
+}
+
+impl Pin for AnyPin {}
+
+macro_rules! impl_pin {
+    ($name:ident, $port:expr, $pin:expr) => {
+        impl sealed::Pin for peripherals::$name {
+            #[inline]
+            fn id(&self) -> u8 {
+                $port as u8 * PINS_PER_PORT as u8 + $pin
+            }
+        }
+
+        impl Pin for peripherals::$name {}
+
+        impl From<peripherals::$name> for AnyPin {
+            #[inline]
+            fn from(_pin: peripherals::$name) -> Self {
+                Self {
+                    id: $port as u8 * PINS_PER_PORT as u8 + $pin,
+                }
+            }
+        }
+    };
+}
+
+impl_pin!(PA0, Port::A, 0);
+impl_pin!(PA1, Port::A, 1);
+impl_pin!(PA2, Port::A, 2);
+impl_pin!(PA3, Port::A, 3);
+impl_pin!(PA4, Port::A, 4);
+impl_pin!(PA5, Port::A, 5);
+impl_pin!(PA6, Port::A, 6);
+impl_pin!(PA7, Port::A, 7);
+impl_pin!(PA8, Port::A, 8);
+impl_pin!(PA9, Port::A, 9);
+impl_pin!(PA10, Port::A, 10);
+impl_pin!(PA11, Port::A, 11);
+impl_pin!(PA12, Port::A, 12);
+impl_pin!(PA13, Port::A, 13);
+impl_pin!(PA14, Port::A, 14);
+impl_pin!(PA15, Port::A, 15);
+
+impl_pin!(PB0, Port::B, 0);
+impl_pin!(PB1, Port::B, 1);
+impl_pin!(PB2, Port::B, 2);
+impl_pin!(PB3, Port::B, 3);
+impl_pin!(PB4, Port::B, 4);
+impl_pin!(PB5, Port::B, 5);
+impl_pin!(PB6, Port::B, 6);
+impl_pin!(PB7, Port::B, 7);
+impl_pin!(PB8, Port::B, 8);
+impl_pin!(PB9, Port::B, 9);
+impl_pin!(PB10, Port::B, 10);
+impl_pin!(PB11, Port::B, 11);
+impl_pin!(PB12, Port::B, 12);
+impl_pin!(PB13, Port::B, 13);
+impl_pin!(PB14, Port::B, 14);
+impl_pin!(PB15, Port::B, 15);
+
+impl_pin!(PC0, Port::C, 0);
+impl_pin!(PC1, Port::C, 1);
+impl_pin!(PC2, Port::C, 2);
+impl_pin!(PC3, Port::C, 3);
+impl_pin!(PC4, Port::C, 4);
+impl_pin!(PC5, Port::C, 5);
+impl_pin!(PC6, Port::C, 6);
+impl_pin!(PC7, Port::C, 7);
+impl_pin!(PC8, Port::C, 8);
+impl_pin!(PC9, Port::C, 9);
+impl_pin!(PC10, Port::C, 10);
+impl_pin!(PC11, Port::C, 11);
+impl_pin!(PC12, Port::C, 12);
+impl_pin!(PC13, Port::C, 13);
+impl_pin!(PC14, Port::C, 14);
+impl_pin!(PC15, Port::C, 15);
+
+impl_pin!(PD0, Port::D, 0);
+impl_pin!(PD1, Port::D, 1);
+impl_pin!(PD2, Port::D, 2);
+impl_pin!(PD3, Port::D, 3);
+impl_pin!(PD4, Port::D, 4);
+impl_pin!(PD5, Port::D, 5);
+impl_pin!(PD6, Port::D, 6);
+impl_pin!(PD7, Port::D, 7);
+impl_pin!(PD8, Port::D, 8);
+impl_pin!(PD9, Port::D, 9);
+impl_pin!(PD10, Port::D, 10);
+impl_pin!(PD11, Port::D, 11);
+impl_pin!(PD12, Port::D, 12);
+impl_pin!(PD13, Port::D, 13);
+impl_pin!(PD14, Port::D, 14);
+impl_pin!(PD15, Port::D, 15);
+
+#[inline]
+fn regs(port: Port) -> &'static pac::gpioa::RegisterBlock {
+    let address = GPIO_BASE + port as usize * GPIO_PORT_STRIDE;
+    unsafe { &*(address as *const pac::gpioa::RegisterBlock) }
+}
+
+#[inline]
+fn enable_port(port: Port) {
+    critical_section::with(|_| {
+        let rcc = unsafe { pac::Rcc::steal() };
+        let bit = 1 << (25 - port as u32);
+        rcc.cgr0().modify(|r, w| unsafe { w.bits(r.bits() | bit) });
+    });
+}
+
+#[inline]
+fn pin_mask(pin: u8) -> u32 {
+    1 << pin
+}
+
+#[inline]
+fn interrupt_mask(pin: u8) -> u32 {
+    0x3 << (pin as u32 * 2)
+}
+
+#[inline]
+fn clear_interrupt(port: Port, pin: u8) {
+    let mask = interrupt_mask(pin);
+    unsafe {
+        regs(port).ifr().write_with_zero(|w| w.bits(mask));
+    }
+}
+
+#[inline]
+fn set_interrupt(port: Port, pin: u8, mode: u32) {
+    let mask = interrupt_mask(pin);
+    let value = mode << (pin as u32 * 2);
+
+    critical_section::with(|_| {
+        let gpio = regs(port);
+        gpio.icr().modify(|r, w| unsafe { w.bits((r.bits() & !mask) | value) });
+        unsafe {
+            gpio.ifr().write_with_zero(|w| w.bits(mask));
+        }
+    });
+}
+
+/// Handler for the single interrupt shared by all four GPIO ports.
+///
+/// Bind this to `GPIO` with [`crate::bind_interrupts!`] before constructing an
+/// asynchronous input or flex pin.
+pub struct InterruptHandler;
+
+impl Handler<crate::interrupt::typelevel::GPIO> for InterruptHandler {
+    unsafe fn on_interrupt() {
+        for port_index in 0..PORT_COUNT as u8 {
+            let port = Port::from_index(port_index);
+            let gpio = regs(port);
+            let flags = gpio.ifr().read().bits();
+
+            if flags == 0 {
+                continue;
+            }
+
+            let configured = gpio.icr().read().bits();
+            let mut disable_mask = 0;
+            let mut wake_mask = 0u16;
+
+            for pin in 0..PINS_PER_PORT as u8 {
+                let field = interrupt_mask(pin);
+                if flags & field != 0 && configured & field != 0 {
+                    disable_mask |= field;
+                    wake_mask |= 1 << pin;
+                }
+            }
+
+            if disable_mask != 0 {
+                gpio.icr().modify(|r, w| unsafe { w.bits(r.bits() & !disable_mask) });
+            }
+
+            // `tremo_gpio.c` establishes that IFR is W1C even though the PAC
+            // currently describes it only as an unstructured RW register.
+            unsafe {
+                gpio.ifr().write_with_zero(|w| w.bits(flags));
+            }
+
+            for pin in 0..PINS_PER_PORT {
+                if wake_mask & (1 << pin) != 0 {
+                    PIN_WAKERS[port_index as usize * PINS_PER_PORT + pin].wake();
+                }
+            }
+        }
+    }
+}
+
+#[inline]
+fn enable_gpio_interrupt() {
+    crate::interrupt::typelevel::GPIO::unpend();
+    crate::interrupt::typelevel::GPIO::set_priority(Priority::P3);
+    unsafe { crate::interrupt::typelevel::GPIO::enable() };
+}
+
+#[must_use = "futures do nothing unless polled or awaited"]
+struct InputFuture<'d> {
+    pin: Peri<'d, AnyPin>,
+}
+
+impl<'d> InputFuture<'d> {
+    #[inline]
+    fn new(pin: Peri<'d, AnyPin>, mode: u32) -> Self {
+        set_interrupt(pin.port(), pin.pin(), mode);
+        Self { pin }
+    }
+
+    #[inline]
+    fn is_high(&self) -> bool {
+        regs(self.pin.port()).idr().read().bits() & pin_mask(self.pin.pin()) != 0
+    }
+}
+
+impl Future for InputFuture<'_> {
+    type Output = ();
+
+    fn poll(self: FuturePin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let index = this.pin.id as usize;
+        PIN_WAKERS[index].register(cx.waker());
+
+        let mode = regs(this.pin.port()).icr().read().bits() & interrupt_mask(this.pin.pin());
+        if mode == INTERRUPT_NONE {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+impl Drop for InputFuture<'_> {
+    fn drop(&mut self) {
+        set_interrupt(self.pin.port(), self.pin.pin(), INTERRUPT_NONE);
+    }
+}
+
+/// A flexible GPIO pin.
+///
+/// The pin can be changed between input, output, analog, and alternate
+/// function configurations. GPIO port clocks remain enabled after a driver is
+/// dropped because each clock is shared by sixteen independently-owned pins.
+pub struct Flex<'d, M: Mode = Blocking> {
+    pin: Peri<'d, AnyPin>,
+    output_type: OutputType,
+    _mode: PhantomData<M>,
+}
+
+fn make_flex<'d, M: Mode>(pin: Peri<'d, impl Pin>) -> Flex<'d, M> {
+    enable_port(pin.port());
+    let mut result = Flex {
+        pin: pin.into(),
+        output_type: OutputType::PushPull,
+        _mode: PhantomData,
+    };
+    result.set_alternate_function(AlternateFunction::Function0);
+    result
+}
+
+impl<'d> Flex<'d> {
+    /// Wrap a pin for blocking GPIO use.
+    pub fn new(pin: Peri<'d, impl Pin>) -> Self {
+        make_flex(pin)
+    }
+}
+
+impl<'d> Flex<'d, Async> {
+    /// Wrap a pin for GPIO use with asynchronous edge waits.
+    pub fn new_async(
+        pin: Peri<'d, impl Pin>,
+        _irq: impl Binding<crate::interrupt::typelevel::GPIO, InterruptHandler>,
+    ) -> Self {
+        enable_gpio_interrupt();
+        make_flex(pin)
+    }
+
+    /// Wait until the sampled input is high.
+    ///
+    /// The hardware has edge interrupts but no level-interrupt mode, so this
+    /// arms a rising edge and rechecks the level to close the check/arm race.
+    pub async fn wait_for_high(&mut self) {
+        loop {
+            if self.is_high() {
+                return;
+            }
+            let future = InputFuture::new(self.pin.reborrow(), INTERRUPT_RISING);
+            if future.is_high() {
+                return;
+            }
+            future.await;
+        }
+    }
+
+    /// Wait until the sampled input is low.
+    ///
+    /// The hardware has edge interrupts but no level-interrupt mode, so this
+    /// arms a falling edge and rechecks the level to close the check/arm race.
+    pub async fn wait_for_low(&mut self) {
+        loop {
+            if self.is_low() {
+                return;
+            }
+            let future = InputFuture::new(self.pin.reborrow(), INTERRUPT_FALLING);
+            if !future.is_high() {
+                return;
+            }
+            future.await;
+        }
+    }
+
+    /// Wait for a low-to-high transition.
+    pub async fn wait_for_rising_edge(&mut self) {
+        InputFuture::new(self.pin.reborrow(), INTERRUPT_RISING).await;
+    }
+
+    /// Wait for a high-to-low transition.
+    pub async fn wait_for_falling_edge(&mut self) {
+        InputFuture::new(self.pin.reborrow(), INTERRUPT_FALLING).await;
+    }
+
+    /// Wait for either edge.
+    pub async fn wait_for_any_edge(&mut self) {
+        InputFuture::new(self.pin.reborrow(), INTERRUPT_ANY_EDGE).await;
+    }
+}
+
+impl<'d, M: Mode> Flex<'d, M> {
+    #[inline]
+    fn port(&self) -> Port {
+        self.pin.port()
+    }
+
+    #[inline]
+    fn pin_number(&self) -> u8 {
+        self.pin.pin()
+    }
+
+    #[inline]
+    fn mask(&self) -> u32 {
+        pin_mask(self.pin_number())
+    }
+
+    #[inline]
+    fn emulated_open_drain(&self) -> bool {
+        self.output_type == OutputType::OpenDrain && self.port() == Port::D && self.pin_number() > 7
+    }
+
+    /// Return the pin's port.
+    pub fn get_port(&self) -> Port {
+        self.port()
+    }
+
+    /// Return the pin number within its port.
+    pub fn get_pin(&self) -> u8 {
+        self.pin_number()
+    }
+
+    /// Configure the internal pull resistor.
+    pub fn set_pull(&mut self, pull: Pull) {
+        let mask = self.mask();
+        critical_section::with(|_| {
+            let gpio = regs(self.port());
+            match pull {
+                Pull::None => {
+                    gpio.per().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+                }
+                Pull::Up => {
+                    gpio.psr().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                    gpio.per().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                }
+                Pull::Down => {
+                    gpio.psr().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+                    gpio.per().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                }
+            }
+        });
+    }
+
+    /// Configure the documented output drive capability.
+    pub fn set_drive(&mut self, drive: Drive) {
+        let mask = self.mask();
+        regs(self.port()).dsr().modify(|r, w| unsafe {
+            w.bits(match drive {
+                Drive::_4mA => r.bits() & !mask,
+                Drive::_8mA => r.bits() | mask,
+            })
+        });
+    }
+
+    /// Select the GPIO slew rate.
+    ///
+    /// ASR's documented GPIO block has no slew-rate control; the only
+    /// representable value therefore leaves the hardware unchanged.
+    #[inline]
+    pub fn set_slew_rate(&mut self, _slew_rate: SlewRate) {}
+
+    /// Configure push-pull or open-drain output behavior.
+    ///
+    /// PD8..PD15 do not support `OTYPER` according to the vendor driver. For
+    /// those pins, open-drain high is emulated by disabling the output driver,
+    /// and open-drain low by enabling it with a low output latch.
+    pub fn set_output_type(&mut self, output_type: OutputType) {
+        self.output_type = output_type;
+        let mask = self.mask();
+        let emulated = self.emulated_open_drain();
+
+        critical_section::with(|_| {
+            let gpio = regs(self.port());
+            if output_type == OutputType::OpenDrain && !emulated {
+                gpio.otyper().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+            } else {
+                gpio.otyper().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+            }
+
+            if emulated {
+                gpio.oer().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+                gpio.ier().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+                gpio.psr().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+            }
+        });
+
+        if emulated {
+            unsafe {
+                regs(self.port()).brr().write_with_zero(|w| w.bits(mask));
+            }
+        }
+    }
+
+    /// Return the configured output type.
+    pub fn output_type(&self) -> OutputType {
+        self.output_type
+    }
+
+    /// Put the pin into input mode.
+    ///
+    /// The pull selection is left unchanged.
+    pub fn set_as_input(&mut self) {
+        let mask = self.mask();
+        critical_section::with(|_| {
+            let gpio = regs(self.port());
+            gpio.oer().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+            gpio.ier().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+        });
+    }
+
+    /// Put the pin into output mode.
+    ///
+    /// The output latch and pull selection are left unchanged. On an emulated
+    /// open-drain pin this enables the low driver.
+    pub fn set_as_output(&mut self) {
+        let mask = self.mask();
+        critical_section::with(|_| {
+            let gpio = regs(self.port());
+            gpio.oer().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+            gpio.ier().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+            if self.output_type == OutputType::PushPull {
+                gpio.otyper().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+            } else if !self.emulated_open_drain() {
+                gpio.otyper().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+            }
+        });
+    }
+
+    /// Put the pin into analog mode.
+    ///
+    /// This disables both digital drivers and the pull resistor, matching
+    /// `GPIO_MODE_ANALOG` in the vendor driver.
+    pub fn set_as_analog(&mut self) {
+        let mask = self.mask();
+        critical_section::with(|_| {
+            let gpio = regs(self.port());
+            gpio.oer().modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+            gpio.ier().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+            gpio.per().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+        });
+    }
+
+    /// Select an explicit alternate function from 0 through 7.
+    ///
+    /// This only changes the mux field. Configure input/output direction,
+    /// pulls, drive capability, and output type separately as required by the
+    /// selected peripheral.
+    pub fn set_alternate_function(&mut self, function: AlternateFunction) {
+        let port = self.port();
+        let pin = self.pin_number();
+        let value = function as u32;
+
+        critical_section::with(|_| {
+            let gpio = regs(port);
+            if pin < 8 {
+                let shift = pin as u32 * 4;
+                let mask = 0xf << shift;
+                gpio.afrl()
+                    .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value << shift)) });
+            } else {
+                let index = pin as u32 - 8;
+                let width = if port == Port::D { 3 } else { 4 };
+                let shift = index * width;
+                let mask = ((1u32 << width) - 1) << shift;
+                gpio.afrh()
+                    .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value << shift)) });
+            }
+        });
+    }
+
+    /// Read the currently selected alternate function.
+    pub fn alternate_function(&self) -> AlternateFunction {
+        let port = self.port();
+        let pin = self.pin_number();
+        let gpio = regs(port);
+        let bits = if pin < 8 {
+            gpio.afrl().read().bits() >> (pin as u32 * 4)
+        } else {
+            let width = if port == Port::D { 3 } else { 4 };
+            gpio.afrh().read().bits() >> ((pin as u32 - 8) * width)
+        };
+        AlternateFunction::from_bits(bits)
+    }
+
+    /// Return whether the sampled pin level is high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        regs(self.port()).idr().read().bits() & self.mask() != 0
+    }
+
+    /// Return whether the sampled pin level is low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        !self.is_high()
+    }
+
+    /// Return the sampled pin level.
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.is_high().into()
+    }
+
+    /// Set the output latch high, or release an emulated open-drain pin.
+    pub fn set_high(&mut self) {
+        let mask = self.mask();
+        if self.emulated_open_drain() {
+            regs(self.port())
+                .oer()
+                .modify(|r, w| unsafe { w.bits(r.bits() | mask) });
+        } else {
+            unsafe {
+                regs(self.port()).bsr().write_with_zero(|w| w.bits(mask));
+            }
+        }
+    }
+
+    /// Set the output latch low, or drive an emulated open-drain pin low.
+    pub fn set_low(&mut self) {
+        let mask = self.mask();
+        if self.emulated_open_drain() {
+            let gpio = regs(self.port());
+            unsafe {
+                gpio.brr().write_with_zero(|w| w.bits(mask));
+            }
+            gpio.oer().modify(|r, w| unsafe { w.bits(r.bits() & !mask) });
+        } else {
+            unsafe {
+                regs(self.port()).brr().write_with_zero(|w| w.bits(mask));
+            }
+        }
+    }
+
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        match level {
+            Level::Low => self.set_low(),
+            Level::High => self.set_high(),
+        }
+    }
+
+    /// Return whether the configured output level is high.
+    pub fn is_set_high(&self) -> bool {
+        if self.emulated_open_drain() {
+            regs(self.port()).oer().read().bits() & self.mask() != 0
+        } else {
+            regs(self.port()).odr().read().bits() & self.mask() != 0
+        }
+    }
+
+    /// Return whether the configured output level is low.
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        !self.is_set_high()
+    }
+
+    /// Return the configured output level.
+    #[inline]
+    pub fn get_output_level(&self) -> Level {
+        self.is_set_high().into()
+    }
+
+    /// Toggle the configured output level.
+    pub fn toggle(&mut self) {
+        if self.is_set_high() {
+            self.set_low();
+        } else {
+            self.set_high();
+        }
+    }
+
+    /// Enable or disable wakeup from stop modes 0, 1, and 2.
+    pub fn configure_wakeup(&mut self, enable: bool, level: Level) {
+        let mask = self.mask();
+        critical_section::with(|_| {
+            let gpio = regs(self.port());
+            gpio.wucr()
+                .modify(|r, w| unsafe { w.bits(if enable { r.bits() | mask } else { r.bits() & !mask }) });
+            gpio.wulvl().modify(|r, w| unsafe {
+                w.bits(if level == Level::High {
+                    r.bits() | mask
+                } else {
+                    r.bits() & !mask
+                })
+            });
+        });
+    }
+
+    /// Configure this pin as a stop-3 wake source.
+    ///
+    /// Stop-3 wake selection is shared by groups of four pins and selecting a
+    /// pin replaces the previous selection in that group. The unusual PA6/7
+    /// and PA12/13 remapping follows `gpio_config_stop3_wakeup`.
+    pub fn configure_stop3_wakeup(&mut self, enable: bool, level: Level) -> Result<(), Stop3WakeError> {
+        let port = self.port();
+        let mut pin = self.pin_number();
+        if port == Port::D && pin > 7 {
+            return Err(Stop3WakeError::UnsupportedPin);
+        }
+
+        if port == Port::A {
+            if pin == 6 || pin == 7 {
+                pin += 6;
+            } else if pin == 12 || pin == 13 {
+                pin -= 6;
+            }
+        }
+
+        let group = pin as u32 / 4;
+        let offset = pin as u32 % 4;
+        let shift = group * 4;
+        let mask = 0xf << shift;
+        let value = offset | if level == Level::High { 0x4 } else { 0 } | if enable { 0x8 } else { 0 };
+
+        regs(port)
+            .stop3_wucr()
+            .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value << shift)) });
+        Ok(())
+    }
+
+    /// Return the owned type-erased pin without resetting the pin state.
+    pub fn into_inner(self) -> Peri<'d, AnyPin> {
+        let this = core::mem::ManuallyDrop::new(self);
+        unsafe { core::ptr::read(&this.pin) }
+    }
+}
+
+impl<M: Mode> Drop for Flex<'_, M> {
+    fn drop(&mut self) {
+        set_interrupt(self.port(), self.pin_number(), INTERRUPT_NONE);
+        self.set_as_analog();
+        self.set_output_type(OutputType::PushPull);
+        self.set_alternate_function(AlternateFunction::Function0);
+    }
+}
+
+/// A GPIO input.
+pub struct Input<'d, M: Mode = Blocking> {
+    pin: Flex<'d, M>,
+}
+
+impl<'d> Input<'d> {
+    /// Create a blocking GPIO input.
+    pub fn new(pin: Peri<'d, impl Pin>, pull: Pull) -> Self {
+        let mut pin = Flex::new(pin);
+        pin.set_as_input();
+        pin.set_pull(pull);
+        Self { pin }
+    }
+}
+
+impl<'d> Input<'d, Async> {
+    /// Create a GPIO input with asynchronous edge waits.
+    pub fn new_async(
+        pin: Peri<'d, impl Pin>,
+        irq: impl Binding<crate::interrupt::typelevel::GPIO, InterruptHandler>,
+        pull: Pull,
+    ) -> Self {
+        let mut pin = Flex::new_async(pin, irq);
+        pin.set_as_input();
+        pin.set_pull(pull);
+        Self { pin }
+    }
+
+    /// Wait until the input is high.
+    #[inline]
+    pub async fn wait_for_high(&mut self) {
+        self.pin.wait_for_high().await;
+    }
+
+    /// Wait until the input is low.
+    #[inline]
+    pub async fn wait_for_low(&mut self) {
+        self.pin.wait_for_low().await;
+    }
+
+    /// Wait for a low-to-high transition.
+    #[inline]
+    pub async fn wait_for_rising_edge(&mut self) {
+        self.pin.wait_for_rising_edge().await;
+    }
+
+    /// Wait for a high-to-low transition.
+    #[inline]
+    pub async fn wait_for_falling_edge(&mut self) {
+        self.pin.wait_for_falling_edge().await;
+    }
+
+    /// Wait for either edge.
+    #[inline]
+    pub async fn wait_for_any_edge(&mut self) {
+        self.pin.wait_for_any_edge().await;
+    }
+}
+
+impl<'d, M: Mode> Input<'d, M> {
+    /// Return whether the input is high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        self.pin.is_high()
+    }
+
+    /// Return whether the input is low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        self.pin.is_low()
+    }
+
+    /// Return the sampled input level.
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.pin.get_level()
+    }
+
+    /// Configure wakeup from stop modes 0, 1, and 2.
+    #[inline]
+    pub fn configure_wakeup(&mut self, enable: bool, level: Level) {
+        self.pin.configure_wakeup(enable, level);
+    }
+
+    /// Configure wakeup from stop mode 3.
+    #[inline]
+    pub fn configure_stop3_wakeup(&mut self, enable: bool, level: Level) -> Result<(), Stop3WakeError> {
+        self.pin.configure_stop3_wakeup(enable, level)
+    }
+
+    /// Convert the input back into a flexible pin.
+    #[inline]
+    pub fn into_flex(self) -> Flex<'d, M> {
+        self.pin
+    }
+}
+
+/// A push-pull GPIO output.
+pub struct Output<'d> {
+    pin: Flex<'d>,
+}
+
+impl<'d> Output<'d> {
+    /// Create a push-pull output with a glitch-free initial level.
+    pub fn new(pin: Peri<'d, impl Pin>, initial: Level) -> Self {
+        let mut pin = Flex::new(pin);
+        pin.set_level(initial);
+        pin.set_output_type(OutputType::PushPull);
+        pin.set_as_output();
+        Self { pin }
+    }
+
+    /// Set the documented output drive capability.
+    #[inline]
+    pub fn set_drive(&mut self, drive: Drive) {
+        self.pin.set_drive(drive);
+    }
+
+    /// Select the hardware-defined slew rate.
+    #[inline]
+    pub fn set_slew_rate(&mut self, slew_rate: SlewRate) {
+        self.pin.set_slew_rate(slew_rate);
+    }
+
+    /// Drive the pin high.
+    #[inline]
+    pub fn set_high(&mut self) {
+        self.pin.set_high();
+    }
+
+    /// Drive the pin low.
+    #[inline]
+    pub fn set_low(&mut self) {
+        self.pin.set_low();
+    }
+
+    /// Set the output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        self.pin.set_level(level);
+    }
+
+    /// Return whether the output latch is high.
+    #[inline]
+    pub fn is_set_high(&self) -> bool {
+        self.pin.is_set_high()
+    }
+
+    /// Return whether the output latch is low.
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        self.pin.is_set_low()
+    }
+
+    /// Return the output latch level.
+    #[inline]
+    pub fn get_output_level(&self) -> Level {
+        self.pin.get_output_level()
+    }
+
+    /// Toggle the output latch.
+    #[inline]
+    pub fn toggle(&mut self) {
+        self.pin.toggle();
+    }
+
+    /// Convert the output back into a flexible pin.
+    #[inline]
+    pub fn into_flex(self) -> Flex<'d> {
+        self.pin
+    }
+}
+
+/// An open-drain GPIO output.
+pub struct OutputOpenDrain<'d, M: Mode = Blocking> {
+    pin: Flex<'d, M>,
+}
+
+fn configure_open_drain<M: Mode>(mut pin: Flex<'_, M>, initial: Level) -> Flex<'_, M> {
+    pin.set_output_type(OutputType::OpenDrain);
+    if pin.emulated_open_drain() {
+        pin.set_level(initial);
+    } else {
+        pin.set_level(initial);
+        pin.set_as_output();
+    }
+    pin
+}
+
+impl<'d> OutputOpenDrain<'d> {
+    /// Create a blocking open-drain output.
+    pub fn new(pin: Peri<'d, impl Pin>, initial: Level) -> Self {
+        Self {
+            pin: configure_open_drain(Flex::new(pin), initial),
+        }
+    }
+}
+
+impl<'d> OutputOpenDrain<'d, Async> {
+    /// Create an open-drain output with asynchronous input edge waits.
+    pub fn new_async(
+        pin: Peri<'d, impl Pin>,
+        irq: impl Binding<crate::interrupt::typelevel::GPIO, InterruptHandler>,
+        initial: Level,
+    ) -> Self {
+        Self {
+            pin: configure_open_drain(Flex::new_async(pin, irq), initial),
+        }
+    }
+
+    /// Wait until the sampled pin is high.
+    #[inline]
+    pub async fn wait_for_high(&mut self) {
+        self.pin.wait_for_high().await;
+    }
+
+    /// Wait until the sampled pin is low.
+    #[inline]
+    pub async fn wait_for_low(&mut self) {
+        self.pin.wait_for_low().await;
+    }
+
+    /// Wait for a low-to-high transition.
+    #[inline]
+    pub async fn wait_for_rising_edge(&mut self) {
+        self.pin.wait_for_rising_edge().await;
+    }
+
+    /// Wait for a high-to-low transition.
+    #[inline]
+    pub async fn wait_for_falling_edge(&mut self) {
+        self.pin.wait_for_falling_edge().await;
+    }
+
+    /// Wait for either edge.
+    #[inline]
+    pub async fn wait_for_any_edge(&mut self) {
+        self.pin.wait_for_any_edge().await;
+    }
+}
+
+impl<'d, M: Mode> OutputOpenDrain<'d, M> {
+    /// Configure the internal pull resistor.
+    #[inline]
+    pub fn set_pull(&mut self, pull: Pull) {
+        self.pin.set_pull(pull);
+    }
+
+    /// Set the documented output drive capability.
+    #[inline]
+    pub fn set_drive(&mut self, drive: Drive) {
+        self.pin.set_drive(drive);
+    }
+
+    /// Select the hardware-defined slew rate.
+    #[inline]
+    pub fn set_slew_rate(&mut self, slew_rate: SlewRate) {
+        self.pin.set_slew_rate(slew_rate);
+    }
+
+    /// Release the pin.
+    #[inline]
+    pub fn set_high(&mut self) {
+        self.pin.set_high();
+    }
+
+    /// Drive the pin low.
+    #[inline]
+    pub fn set_low(&mut self) {
+        self.pin.set_low();
+    }
+
+    /// Set the logical output level.
+    #[inline]
+    pub fn set_level(&mut self, level: Level) {
+        self.pin.set_level(level);
+    }
+
+    /// Return whether the output is released.
+    #[inline]
+    pub fn is_set_high(&self) -> bool {
+        self.pin.is_set_high()
+    }
+
+    /// Return whether the output is driving low.
+    #[inline]
+    pub fn is_set_low(&self) -> bool {
+        self.pin.is_set_low()
+    }
+
+    /// Return the configured logical output level.
+    #[inline]
+    pub fn get_output_level(&self) -> Level {
+        self.pin.get_output_level()
+    }
+
+    /// Toggle between released and low.
+    #[inline]
+    pub fn toggle(&mut self) {
+        self.pin.toggle();
+    }
+
+    /// Return whether the sampled pin is high.
+    #[inline]
+    pub fn is_high(&self) -> bool {
+        self.pin.is_high()
+    }
+
+    /// Return whether the sampled pin is low.
+    #[inline]
+    pub fn is_low(&self) -> bool {
+        self.pin.is_low()
+    }
+
+    /// Return the sampled pin level.
+    #[inline]
+    pub fn get_level(&self) -> Level {
+        self.pin.get_level()
+    }
+
+    /// Convert the output back into a flexible pin.
+    #[inline]
+    pub fn into_flex(self) -> Flex<'d, M> {
+        self.pin
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::ErrorType for Flex<'_, M> {
+    type Error = Infallible;
+}
+
+impl<M: Mode> embedded_hal::digital::InputPin for Flex<'_, M> {
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Flex::is_high(self))
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Flex::is_low(self))
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::OutputPin for Flex<'_, M> {
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Flex::set_high(self);
+        Ok(())
+    }
+
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Flex::set_low(self);
+        Ok(())
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::StatefulOutputPin for Flex<'_, M> {
+    #[inline]
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Flex::is_set_high(self))
+    }
+
+    #[inline]
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Flex::is_set_low(self))
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::ErrorType for Input<'_, M> {
+    type Error = Infallible;
+}
+
+impl<M: Mode> embedded_hal::digital::InputPin for Input<'_, M> {
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Input::is_high(self))
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Input::is_low(self))
+    }
+}
+
+impl embedded_hal::digital::ErrorType for Output<'_> {
+    type Error = Infallible;
+}
+
+impl embedded_hal::digital::OutputPin for Output<'_> {
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        Output::set_high(self);
+        Ok(())
+    }
+
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        Output::set_low(self);
+        Ok(())
+    }
+}
+
+impl embedded_hal::digital::StatefulOutputPin for Output<'_> {
+    #[inline]
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(Output::is_set_high(self))
+    }
+
+    #[inline]
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(Output::is_set_low(self))
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::ErrorType for OutputOpenDrain<'_, M> {
+    type Error = Infallible;
+}
+
+impl<M: Mode> embedded_hal::digital::InputPin for OutputOpenDrain<'_, M> {
+    #[inline]
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(OutputOpenDrain::is_high(self))
+    }
+
+    #[inline]
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(OutputOpenDrain::is_low(self))
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::OutputPin for OutputOpenDrain<'_, M> {
+    #[inline]
+    fn set_high(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::set_high(self);
+        Ok(())
+    }
+
+    #[inline]
+    fn set_low(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::set_low(self);
+        Ok(())
+    }
+}
+
+impl<M: Mode> embedded_hal::digital::StatefulOutputPin for OutputOpenDrain<'_, M> {
+    #[inline]
+    fn is_set_high(&mut self) -> Result<bool, Self::Error> {
+        Ok(OutputOpenDrain::is_set_high(self))
+    }
+
+    #[inline]
+    fn is_set_low(&mut self) -> Result<bool, Self::Error> {
+        Ok(OutputOpenDrain::is_set_low(self))
+    }
+}
+
+impl embedded_hal_async::digital::Wait for Flex<'_, Async> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        Flex::wait_for_high(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        Flex::wait_for_low(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        Flex::wait_for_rising_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        Flex::wait_for_falling_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        Flex::wait_for_any_edge(self).await;
+        Ok(())
+    }
+}
+
+impl embedded_hal_async::digital::Wait for Input<'_, Async> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        Input::wait_for_high(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        Input::wait_for_low(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        Input::wait_for_rising_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        Input::wait_for_falling_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        Input::wait_for_any_edge(self).await;
+        Ok(())
+    }
+}
+
+impl embedded_hal_async::digital::Wait for OutputOpenDrain<'_, Async> {
+    async fn wait_for_high(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::wait_for_high(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_low(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::wait_for_low(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_rising_edge(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::wait_for_rising_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_falling_edge(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::wait_for_falling_edge(self).await;
+        Ok(())
+    }
+
+    async fn wait_for_any_edge(&mut self) -> Result<(), Self::Error> {
+        OutputOpenDrain::wait_for_any_edge(self).await;
+        Ok(())
+    }
+}

--- a/embassy-asr/src/i2c.rs
+++ b/embassy-asr/src/i2c.rs
@@ -1,0 +1,1232 @@
+//! I2C0–I2C2 driver for the ASR6601 (Marvell-style TWSI).
+//!
+//! Register programming follows the vendor `tremo_i2c` driver and the I2C
+//! examples under `projects/*/examples/i2c`. Transfers use the non-FIFO
+//! byte path (`DBR` + `CR.TRANS_BYTE`), which is the SDK default.
+//!
+//! Alternate-function numbers come from datasheet Table 4-3 (Fun=3 for every
+//! documented I2C remap). Constructors either take typed pins that encode that
+//! AF, or accept an explicit [`AlternateFunction`] per pin.
+//!
+//! # Unsafe contracts
+//!
+//! - [`InterruptHandler::on_interrupt`] may be called only from the vector bound
+//!   through [`crate::bind_interrupts!`] for the matching I2C instance.
+//! - Constructing a driver steals the PAC register block for that I2C. The
+//!   owned [`Peri`] token is the exclusivity proof; do not also use
+//!   `pac::I2c*::steal()` from application code while the driver is alive.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::Priority;
+use embassy_sync::waitqueue::AtomicWaker;
+use embedded_hal::i2c::Operation as EhOperation;
+
+use crate::gpio::{AlternateFunction, Flex, Pin as GpioPin, Pull};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt as TypelevelInterrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::pac::i2c0::RegisterBlock;
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, PeripheralType, interrupt, peripherals};
+
+const SR_ARB_LOSS: u32 = 1 << 18;
+const SR_IDBR_EMPTY: u32 = 1 << 19;
+const SR_DBR_FULL: u32 = 1 << 20;
+const SR_BUS_ERROR: u32 = 1 << 22;
+const SR_SLAVE_ADDR_DET: u32 = 1 << 23;
+const SR_SLAVE_STOP_DET: u32 = 1 << 24;
+const SR_ERROR_MASK: u32 = SR_ARB_LOSS | SR_BUS_ERROR;
+
+const CR_INTR_MASK: u32 = (1 << 18) // arb loss
+    | (1 << 19) // idbr empty
+    | (1 << 20) // dbr full
+    | (1 << 22) // bus error
+    | (1 << 23) // slave addr
+    | (1 << 24) // slave stop
+    | (1 << 25) // master stop intr en
+    | (1 << 27); // trans done
+
+/// I2C transfer errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// ACK was not received for an address or data byte.
+    Nack,
+    /// Arbitration was lost.
+    Arbitration,
+    /// Protocol / bus error flag.
+    Bus,
+    /// Timed out waiting for the unit to leave reset / busy.
+    Timeout,
+    /// 10-bit addressing is not supported by the vendor programming model.
+    AddressMode,
+    /// RCC clocks have not been published by [`crate::init`].
+    ClocksNotInitialized,
+    /// Enabling or resetting the I2C clock failed.
+    Rcc(rcc::Error),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Nack => f.write_str("I2C NACK"),
+            Self::Arbitration => f.write_str("I2C arbitration lost"),
+            Self::Bus => f.write_str("I2C bus error"),
+            Self::Timeout => f.write_str("I2C timeout"),
+            Self::AddressMode => f.write_str("I2C 10-bit addressing unsupported"),
+            Self::ClocksNotInitialized => f.write_str("RCC clocks are not initialized"),
+            Self::Rcc(_) => f.write_str("I2C RCC error"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl embedded_hal::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal::i2c::ErrorKind {
+        match self {
+            Self::Nack => embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Unknown),
+            Self::Arbitration => embedded_hal::i2c::ErrorKind::ArbitrationLoss,
+            Self::Bus => embedded_hal::i2c::ErrorKind::Bus,
+            _ => embedded_hal::i2c::ErrorKind::Other,
+        }
+    }
+}
+
+/// Bus speed programmed through `CR.BUS_MODE` and the LCR/WCR dividers.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Frequency {
+    /// Standard mode, 100 kHz.
+    Standard,
+    /// Fast mode, 400 kHz.
+    Fast,
+}
+
+impl Frequency {
+    const fn hertz(self) -> u32 {
+        match self {
+            Self::Standard => 100_000,
+            Self::Fast => 400_000,
+        }
+    }
+}
+
+/// I2C master configuration.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Target bus frequency.
+    pub frequency: Frequency,
+    /// Optional internal pull on SCL.
+    ///
+    /// External pull-ups are recommended; leave this as [`Pull::None`] when
+    /// board pull-ups are present.
+    pub scl_pull: Pull,
+    /// Optional internal pull on SDA.
+    pub sda_pull: Pull,
+}
+
+impl Config {
+    /// Standard-mode master with no internal pulls.
+    pub const fn new() -> Self {
+        Self {
+            frequency: Frequency::Standard,
+            scl_pull: Pull::None,
+            sda_pull: Pull::None,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Direction observed after a slave address match.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum SlaveOp {
+    /// Master is writing; the slave should receive.
+    Read,
+    /// Master is reading; the slave should transmit.
+    Write,
+}
+
+#[derive(Clone, Copy)]
+enum PclkSel {
+    Pclk0,
+    Pclk1,
+}
+
+struct State {
+    waker: AtomicWaker,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            waker: AtomicWaker::new(),
+        }
+    }
+}
+
+static STATE_I2C0: State = State::new();
+static STATE_I2C1: State = State::new();
+static STATE_I2C2: State = State::new();
+
+struct Info {
+    regs: *const RegisterBlock,
+    peripheral: Peripheral,
+    pclk: PclkSel,
+    state: &'static State,
+}
+
+// Register blocks are Sync; the pointer is unique to the owned I2C instance.
+unsafe impl Sync for Info {}
+
+impl Info {
+    fn regs(&self) -> &'static RegisterBlock {
+        unsafe { &*self.regs }
+    }
+}
+
+/// Interrupt handler for one I2C instance.
+///
+/// Masks the sticky event enables that woke the vector and wakes any async
+/// waiter. Status bits are left for the waiter to observe and clear.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let info = T::info();
+        let regs = info.regs();
+        let sr = regs.sr().read().bits();
+
+        // Mask level/event enables; the waiter re-enables as needed.
+        let cr = regs.cr().read().bits() & !CR_INTR_MASK;
+        regs.cr().write_with_zero(|w| unsafe { w.bits(cr) });
+
+        // Clear only the error flags in the ISR so a cancelled waiter cannot
+        // leave sticky bus errors latched forever. Completion flags stay for
+        // the waiter.
+        let errors = sr & SR_ERROR_MASK;
+        if errors != 0 {
+            regs.sr().write_with_zero(|w| unsafe { w.bits(errors) });
+        }
+
+        info.state.waker.wake();
+    }
+}
+
+/// I2C master driver.
+pub struct I2c<'d, M: Mode> {
+    info: &'static Info,
+    _scl: Flex<'d>,
+    _sda: Flex<'d>,
+    _mode: PhantomData<&'d mut M>,
+}
+
+/// I2C slave driver.
+///
+/// Matches the vendor slave example: wait for address detect, then exchange
+/// bytes with ACK/NAK control until stop.
+pub struct I2cSlave<'d, M: Mode> {
+    info: &'static Info,
+    _scl: Flex<'d>,
+    _sda: Flex<'d>,
+    _mode: PhantomData<&'d mut M>,
+}
+
+fn configure_i2c_pin<'d>(pin: Peri<'d, impl GpioPin>, af: AlternateFunction, pull: Pull) -> Flex<'d> {
+    let mut flex = Flex::new(pin);
+    // The TWSI pad is open-drain when muxed; direction follows the vendor
+    // examples which only program the IOMUX.
+    flex.set_as_input();
+    flex.set_pull(pull);
+    flex.set_alternate_function(af);
+    flex
+}
+
+fn pclk_hz(sel: PclkSel) -> Result<u32, Error> {
+    let clocks = rcc::clocks().ok_or(Error::ClocksNotInitialized)?;
+    Ok(match sel {
+        PclkSel::Pclk0 => clocks.pclk0_hz,
+        PclkSel::Pclk1 => clocks.pclk1_hz,
+    })
+}
+
+fn unit_reset(regs: &RegisterBlock) -> Result<(), Error> {
+    let mut timeout = 1_000u32;
+    while regs.sr().read().unit_busy().bit_is_set() {
+        timeout = timeout.saturating_sub(1);
+        if timeout == 0 {
+            return Err(Error::Timeout);
+        }
+    }
+
+    // Vendor: CR = UNIT_RESET only, pulse reset, clear SR, clear reset bit.
+    unsafe {
+        regs.cr().write_with_zero(|w| w.unit_reset().set_bit());
+        let sr = regs.sr().read().bits();
+        regs.sr().write_with_zero(|w| w.bits(sr));
+        regs.cr().write_with_zero(|w| w.bits(0));
+    }
+    Ok(())
+}
+
+fn program_timing(regs: &RegisterBlock, pclk: u32, frequency: Frequency) {
+    let slv = (pclk / Frequency::Standard.hertz()).saturating_sub(8) / 2;
+    let flv = (pclk / Frequency::Fast.hertz()).saturating_sub(8) / 2;
+    let flv = flv.saturating_sub(1);
+    let lcr = (slv & 0x1ff) | ((flv & 0x1ff) << 9);
+    let wcr = flv / 3;
+
+    unsafe {
+        regs.lcr().write_with_zero(|w| w.bits(lcr));
+        regs.wcr().write_with_zero(|w| w.bits(wcr));
+    }
+
+    regs.cr().modify(|_, w| match frequency {
+        Frequency::Standard => w.bus_mode().standard(),
+        Frequency::Fast => w.bus_mode().fast(),
+    });
+}
+
+fn enable_unit(regs: &RegisterBlock, enable: bool) {
+    regs.cr().modify(|_, w| {
+        w.twsi_unit_en().bit(enable);
+        w.scl_en().bit(enable)
+    });
+}
+
+fn clear_sr(regs: &RegisterBlock, mask: u32) {
+    unsafe {
+        regs.sr().write_with_zero(|w| w.bits(mask));
+    }
+}
+
+fn check_errors(regs: &RegisterBlock) -> Result<(), Error> {
+    let sr = regs.sr().read();
+    if sr.arb_loss_det().bit_is_set() {
+        clear_sr(regs, SR_ARB_LOSS);
+        return Err(Error::Arbitration);
+    }
+    if sr.bus_error().bit_is_set() {
+        clear_sr(regs, SR_BUS_ERROR);
+        return Err(Error::Bus);
+    }
+    Ok(())
+}
+
+fn nack_seen(regs: &RegisterBlock) -> bool {
+    // ACK_STATUS = 1 means NAK was received for the previous byte.
+    regs.sr().read().ack_status().bit_is_set()
+}
+
+fn master_abort(regs: &RegisterBlock) {
+    regs.cr().modify(|_, w| {
+        w.start().clear_bit();
+        w.master_abort().set_bit()
+    });
+}
+
+fn master_send_start(regs: &RegisterBlock, addr7: u8, read: bool) {
+    let data = (addr7 << 1) | u8::from(read);
+    regs.cr().modify(|_, w| w.master_abort().clear_bit());
+    unsafe {
+        regs.dbr().write_with_zero(|w| w.bits(u32::from(data)));
+    }
+    regs.cr().modify(|_, w| {
+        w.stop().clear_bit();
+        w.start().set_bit();
+        w.trans_byte().set_bit()
+    });
+}
+
+fn master_send_byte(regs: &RegisterBlock, data: u8) {
+    unsafe {
+        regs.dbr().write_with_zero(|w| w.bits(u32::from(data)));
+    }
+    regs.cr().modify(|_, w| {
+        w.start().clear_bit();
+        w.trans_byte().set_bit()
+    });
+}
+
+fn set_receive_mode(regs: &RegisterBlock, ack: bool) {
+    // CR.ACKNAK = 1 requests NAK.
+    regs.cr().modify(|_, w| {
+        w.acknak().bit(!ack);
+        w.start().clear_bit();
+        w.trans_byte().set_bit()
+    });
+}
+
+fn read_dbr(regs: &RegisterBlock) -> u8 {
+    regs.dbr().read().bits() as u8
+}
+
+fn enable_clock(info: &'static Info) -> Result<(), Error> {
+    rcc::enable_peripheral(info.peripheral).map_err(Error::Rcc)?;
+    rcc::reset_peripheral(info.peripheral).map_err(Error::Rcc)?;
+    Ok(())
+}
+
+fn init_master(info: &'static Info, config: Config) -> Result<(), Error> {
+    let regs = info.regs();
+    let pclk = pclk_hz(info.pclk)?;
+    unit_reset(regs)?;
+    // FIFO stays disabled (SDK default).
+    regs.cr().modify(|_, w| w.fifo_en().clear_bit());
+    program_timing(regs, pclk, config.frequency);
+    enable_unit(regs, true);
+    Ok(())
+}
+
+fn init_slave(info: &'static Info, address: u8) -> Result<(), Error> {
+    if address > 0x7f {
+        return Err(Error::AddressMode);
+    }
+    let regs = info.regs();
+    let pclk = pclk_hz(info.pclk)?;
+    unit_reset(regs)?;
+    regs.cr().modify(|_, w| w.fifo_en().clear_bit());
+    // Dividers are still required by the hardware; use standard timing.
+    program_timing(regs, pclk, Frequency::Standard);
+    unsafe {
+        regs.sar().write_with_zero(|w| w.bits(u32::from(address)));
+    }
+    enable_unit(regs, true);
+    Ok(())
+}
+
+fn shutdown(info: &'static Info) {
+    let regs = info.regs();
+    enable_unit(regs, false);
+    let _ = rcc::disable_peripheral(info.peripheral);
+}
+
+fn set_irq_enables(regs: &RegisterBlock, mask: u32, enable: bool) {
+    regs.cr().modify(|r, w| {
+        let bits = if enable { r.bits() | mask } else { r.bits() & !mask };
+        unsafe { w.bits(bits) }
+    });
+}
+
+impl<'d> I2c<'d, Blocking> {
+    /// Create a blocking master using typed pins (datasheet Fun=3 remaps).
+    pub fn new_blocking<T: Instance, Scl: SclPin<T>, Sda: SdaPin<T>>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, Scl>,
+        sda: Peri<'d, Sda>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        Self::new_blocking_af(peri, scl, Scl::AF, sda, Sda::AF, config)
+    }
+
+    /// Create a blocking master with explicit alternate-function numbers.
+    pub fn new_blocking_af<T: Instance>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, impl GpioPin + 'd>,
+        scl_af: AlternateFunction,
+        sda: Peri<'d, impl GpioPin + 'd>,
+        sda_af: AlternateFunction,
+        config: Config,
+    ) -> Result<Self, Error> {
+        Self::new_inner(peri, scl, scl_af, sda, sda_af, config, false)
+    }
+}
+
+impl<'d> I2c<'d, Async> {
+    /// Create an async master using typed pins.
+    ///
+    /// `irq` proves the I2C vector is bound to [`InterruptHandler<T>`].
+    pub fn new<T: Instance, Scl: SclPin<T>, Sda: SdaPin<T>>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, Scl>,
+        sda: Peri<'d, Sda>,
+        irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        Self::new_af(peri, scl, Scl::AF, sda, Sda::AF, irq, config)
+    }
+
+    /// Create an async master with explicit alternate-function numbers.
+    pub fn new_af<T: Instance>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, impl GpioPin + 'd>,
+        scl_af: AlternateFunction,
+        sda: Peri<'d, impl GpioPin + 'd>,
+        sda_af: AlternateFunction,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        Self::new_inner(peri, scl, scl_af, sda, sda_af, config, true)
+    }
+}
+
+impl<'d, M: Mode> I2c<'d, M> {
+    fn new_inner<T: Instance>(
+        _peri: Peri<'d, T>,
+        scl: Peri<'d, impl GpioPin + 'd>,
+        scl_af: AlternateFunction,
+        sda: Peri<'d, impl GpioPin + 'd>,
+        sda_af: AlternateFunction,
+        config: Config,
+        enable_irq: bool,
+    ) -> Result<Self, Error> {
+        let info = T::info();
+        enable_clock(info)?;
+
+        let scl = configure_i2c_pin(scl, scl_af, config.scl_pull);
+        let sda = configure_i2c_pin(sda, sda_af, config.sda_pull);
+
+        init_master(info, config)?;
+
+        if enable_irq {
+            T::Interrupt::unpend();
+            T::Interrupt::set_priority(Priority::P3);
+            unsafe {
+                T::Interrupt::enable();
+            }
+        }
+
+        Ok(Self {
+            info,
+            _scl: scl,
+            _sda: sda,
+            _mode: PhantomData,
+        })
+    }
+
+    fn regs(&self) -> &'static RegisterBlock {
+        self.info.regs()
+    }
+
+    fn finish_error(&self, err: Error) -> Error {
+        master_abort(self.regs());
+        err
+    }
+
+    fn blocking_wait_tx_empty(&self) -> Result<(), Error> {
+        let regs = self.regs();
+        loop {
+            check_errors(regs)?;
+            if regs.sr().read().idbr_empty().bit_is_set() {
+                clear_sr(regs, SR_IDBR_EMPTY);
+                if nack_seen(regs) {
+                    return Err(self.finish_error(Error::Nack));
+                }
+                return Ok(());
+            }
+        }
+    }
+
+    fn blocking_wait_rx_full(&self) -> Result<(), Error> {
+        let regs = self.regs();
+        loop {
+            check_errors(regs)?;
+            if regs.sr().read().dbr_full().bit_is_set() {
+                clear_sr(regs, SR_DBR_FULL);
+                return Ok(());
+            }
+        }
+    }
+
+    fn blocking_write_ops(&mut self, addr: u8, bytes: &[u8], send_stop: bool) -> Result<(), Error> {
+        let regs = self.regs();
+        master_send_start(regs, addr, false);
+        clear_sr(regs, SR_IDBR_EMPTY);
+        self.blocking_wait_tx_empty()?;
+
+        for &byte in bytes {
+            master_send_byte(regs, byte);
+            clear_sr(regs, SR_IDBR_EMPTY);
+            self.blocking_wait_tx_empty()?;
+        }
+
+        if send_stop {
+            master_abort(regs);
+        }
+        Ok(())
+    }
+
+    fn blocking_read_ops(&mut self, addr: u8, buffer: &mut [u8], restart: bool, send_stop: bool) -> Result<(), Error> {
+        if buffer.is_empty() {
+            if send_stop {
+                master_abort(self.regs());
+            }
+            return Ok(());
+        }
+
+        let regs = self.regs();
+        if !restart {
+            // Fresh transaction: address phase.
+        }
+        master_send_start(regs, addr, true);
+        clear_sr(regs, SR_IDBR_EMPTY);
+        self.blocking_wait_tx_empty()?;
+
+        let last = buffer.len() - 1;
+        for (i, slot) in buffer.iter_mut().enumerate() {
+            let ack = i != last;
+            set_receive_mode(regs, ack);
+            self.blocking_wait_rx_full()?;
+            *slot = read_dbr(regs);
+        }
+
+        if send_stop {
+            master_abort(regs);
+        }
+        Ok(())
+    }
+
+    /// Blocking write of `bytes` to `address` (7-bit).
+    pub fn blocking_write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        self.blocking_write_ops(address, bytes, true)
+    }
+
+    /// Blocking read of `buffer.len()` bytes from `address` (7-bit).
+    pub fn blocking_read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        self.blocking_read_ops(address, buffer, false, true)
+    }
+
+    /// Blocking write then repeated-start read.
+    pub fn blocking_write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        self.blocking_write_ops(address, write, false)?;
+        self.blocking_read_ops(address, read, true, true)
+    }
+
+    /// Blocking embedded-hal transaction.
+    pub fn blocking_transaction(&mut self, address: u8, operations: &mut [EhOperation<'_>]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        if operations.is_empty() {
+            return Ok(());
+        }
+
+        let last = operations.len() - 1;
+        for (i, op) in operations.iter_mut().enumerate() {
+            let stop = i == last;
+            match op {
+                EhOperation::Write(bytes) => self.blocking_write_ops(address, bytes, stop)?,
+                EhOperation::Read(buffer) => {
+                    let restart = i != 0;
+                    self.blocking_read_ops(address, buffer, restart, stop)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'d> I2c<'d, Async> {
+    async fn wait_on<F>(&mut self, mut ready: F, irq_mask: u32) -> Result<(), Error>
+    where
+        F: FnMut(&RegisterBlock) -> Poll<Result<(), Error>>,
+    {
+        let regs = self.regs();
+        let state = self.info.state;
+
+        poll_fn(|cx| {
+            state.waker.register(cx.waker());
+            match ready(regs) {
+                Poll::Ready(result) => {
+                    set_irq_enables(regs, irq_mask, false);
+                    Poll::Ready(result)
+                }
+                Poll::Pending => {
+                    set_irq_enables(regs, irq_mask | SR_ERROR_MASK, true);
+                    // Re-check after arming to close the race.
+                    match ready(regs) {
+                        Poll::Ready(result) => {
+                            set_irq_enables(regs, irq_mask | SR_ERROR_MASK, false);
+                            Poll::Ready(result)
+                        }
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+            }
+        })
+        .await
+    }
+
+    async fn wait_tx_empty(&mut self) -> Result<(), Error> {
+        self.wait_on(
+            |regs| {
+                if let Err(e) = check_errors(regs) {
+                    return Poll::Ready(Err(e));
+                }
+                if regs.sr().read().idbr_empty().bit_is_set() {
+                    clear_sr(regs, SR_IDBR_EMPTY);
+                    if nack_seen(regs) {
+                        Poll::Ready(Err(Error::Nack))
+                    } else {
+                        Poll::Ready(Ok(()))
+                    }
+                } else {
+                    Poll::Pending
+                }
+            },
+            SR_IDBR_EMPTY,
+        )
+        .await
+        .map_err(|e| self.finish_error(e))
+    }
+
+    async fn wait_rx_full(&mut self) -> Result<(), Error> {
+        self.wait_on(
+            |regs| {
+                if let Err(e) = check_errors(regs) {
+                    return Poll::Ready(Err(e));
+                }
+                if regs.sr().read().dbr_full().bit_is_set() {
+                    clear_sr(regs, SR_DBR_FULL);
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            },
+            SR_DBR_FULL,
+        )
+        .await
+        .map_err(|e| self.finish_error(e))
+    }
+
+    async fn write_ops(&mut self, addr: u8, bytes: &[u8], send_stop: bool) -> Result<(), Error> {
+        let regs = self.regs();
+        master_send_start(regs, addr, false);
+        clear_sr(regs, SR_IDBR_EMPTY);
+        self.wait_tx_empty().await?;
+
+        for &byte in bytes {
+            master_send_byte(self.regs(), byte);
+            clear_sr(self.regs(), SR_IDBR_EMPTY);
+            self.wait_tx_empty().await?;
+        }
+
+        if send_stop {
+            master_abort(self.regs());
+        }
+        Ok(())
+    }
+
+    async fn read_ops(&mut self, addr: u8, buffer: &mut [u8], _restart: bool, send_stop: bool) -> Result<(), Error> {
+        if buffer.is_empty() {
+            if send_stop {
+                master_abort(self.regs());
+            }
+            return Ok(());
+        }
+
+        let regs = self.regs();
+        master_send_start(regs, addr, true);
+        clear_sr(regs, SR_IDBR_EMPTY);
+        self.wait_tx_empty().await?;
+
+        let last = buffer.len() - 1;
+        for (i, slot) in buffer.iter_mut().enumerate() {
+            let ack = i != last;
+            set_receive_mode(self.regs(), ack);
+            self.wait_rx_full().await?;
+            *slot = read_dbr(self.regs());
+        }
+
+        if send_stop {
+            master_abort(self.regs());
+        }
+        Ok(())
+    }
+
+    /// Async write of `bytes` to `address` (7-bit).
+    pub async fn write(&mut self, address: u8, bytes: &[u8]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        self.write_ops(address, bytes, true).await
+    }
+
+    /// Async read of `buffer.len()` bytes from `address` (7-bit).
+    pub async fn read(&mut self, address: u8, buffer: &mut [u8]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        self.read_ops(address, buffer, false, true).await
+    }
+
+    /// Async write then repeated-start read.
+    pub async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        self.write_ops(address, write, false).await?;
+        self.read_ops(address, read, true, true).await
+    }
+
+    /// Async embedded-hal transaction.
+    pub async fn transaction(&mut self, address: u8, operations: &mut [EhOperation<'_>]) -> Result<(), Error> {
+        if address > 0x7f {
+            return Err(Error::AddressMode);
+        }
+        if operations.is_empty() {
+            return Ok(());
+        }
+
+        let last = operations.len() - 1;
+        for (i, op) in operations.iter_mut().enumerate() {
+            let stop = i == last;
+            match op {
+                EhOperation::Write(bytes) => self.write_ops(address, bytes, stop).await?,
+                EhOperation::Read(buffer) => {
+                    let restart = i != 0;
+                    self.read_ops(address, buffer, restart, stop).await?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<'d, M: Mode> Drop for I2c<'d, M> {
+    fn drop(&mut self) {
+        shutdown(self.info);
+    }
+}
+
+impl<'d> I2cSlave<'d, Blocking> {
+    /// Create a blocking slave using typed pins.
+    pub fn new_blocking<T: Instance, Scl: SclPin<T>, Sda: SdaPin<T>>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, Scl>,
+        sda: Peri<'d, Sda>,
+        address: u8,
+        scl_pull: Pull,
+        sda_pull: Pull,
+    ) -> Result<Self, Error> {
+        Self::new_blocking_af(peri, scl, Scl::AF, sda, Sda::AF, address, scl_pull, sda_pull)
+    }
+
+    /// Create a blocking slave with explicit alternate-function numbers.
+    pub fn new_blocking_af<T: Instance>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, impl GpioPin + 'd>,
+        scl_af: AlternateFunction,
+        sda: Peri<'d, impl GpioPin + 'd>,
+        sda_af: AlternateFunction,
+        address: u8,
+        scl_pull: Pull,
+        sda_pull: Pull,
+    ) -> Result<Self, Error> {
+        Self::new_inner(peri, scl, scl_af, sda, sda_af, address, scl_pull, sda_pull, false)
+    }
+}
+
+impl<'d> I2cSlave<'d, Async> {
+    /// Create an async slave using typed pins.
+    pub fn new<T: Instance, Scl: SclPin<T>, Sda: SdaPin<T>>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, Scl>,
+        sda: Peri<'d, Sda>,
+        address: u8,
+        scl_pull: Pull,
+        sda_pull: Pull,
+        irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        Self::new_af(peri, scl, Scl::AF, sda, Sda::AF, address, scl_pull, sda_pull, irq)
+    }
+
+    /// Create an async slave with explicit alternate-function numbers.
+    pub fn new_af<T: Instance>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, impl GpioPin + 'd>,
+        scl_af: AlternateFunction,
+        sda: Peri<'d, impl GpioPin + 'd>,
+        sda_af: AlternateFunction,
+        address: u8,
+        scl_pull: Pull,
+        sda_pull: Pull,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+    ) -> Result<Self, Error> {
+        Self::new_inner(peri, scl, scl_af, sda, sda_af, address, scl_pull, sda_pull, true)
+    }
+}
+
+impl<'d, M: Mode> I2cSlave<'d, M> {
+    fn new_inner<T: Instance>(
+        _peri: Peri<'d, T>,
+        scl: Peri<'d, impl GpioPin + 'd>,
+        scl_af: AlternateFunction,
+        sda: Peri<'d, impl GpioPin + 'd>,
+        sda_af: AlternateFunction,
+        address: u8,
+        scl_pull: Pull,
+        sda_pull: Pull,
+        enable_irq: bool,
+    ) -> Result<Self, Error> {
+        let info = T::info();
+        enable_clock(info)?;
+
+        let scl = configure_i2c_pin(scl, scl_af, scl_pull);
+        let sda = configure_i2c_pin(sda, sda_af, sda_pull);
+
+        init_slave(info, address)?;
+
+        if enable_irq {
+            T::Interrupt::unpend();
+            T::Interrupt::set_priority(Priority::P3);
+            unsafe {
+                T::Interrupt::enable();
+            }
+        }
+
+        Ok(Self {
+            info,
+            _scl: scl,
+            _sda: sda,
+            _mode: PhantomData,
+        })
+    }
+
+    fn regs(&self) -> &'static RegisterBlock {
+        self.info.regs()
+    }
+
+    /// Block until the slave address is detected; return the transfer direction.
+    pub fn blocking_listen(&mut self) -> Result<SlaveOp, Error> {
+        let regs = self.regs();
+        loop {
+            check_errors(regs)?;
+            if regs.sr().read().slave_addr_det().bit_is_set() {
+                clear_sr(regs, SR_SLAVE_ADDR_DET);
+                // RW_MODE mirrors the R/W bit: 0 = master write / slave read.
+                let op = if regs.sr().read().rw_mode().bit_is_set() {
+                    SlaveOp::Write
+                } else {
+                    SlaveOp::Read
+                };
+                return Ok(op);
+            }
+        }
+    }
+
+    /// Receive `buffer.len()` bytes as slave (master write).
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        let regs = self.regs();
+        for slot in buffer.iter_mut() {
+            set_receive_mode(regs, true);
+            loop {
+                check_errors(regs)?;
+                if regs.sr().read().dbr_full().bit_is_set() {
+                    clear_sr(regs, SR_DBR_FULL);
+                    break;
+                }
+                if regs.sr().read().slave_stop_det().bit_is_set() {
+                    clear_sr(regs, SR_SLAVE_STOP_DET);
+                    return Ok(());
+                }
+            }
+            *slot = read_dbr(regs);
+        }
+        Ok(())
+    }
+
+    /// Transmit `bytes` as slave (master read).
+    pub fn blocking_write(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        let regs = self.regs();
+        for &byte in bytes {
+            master_send_byte(regs, byte);
+            clear_sr(regs, SR_IDBR_EMPTY);
+            loop {
+                check_errors(regs)?;
+                if regs.sr().read().idbr_empty().bit_is_set() {
+                    clear_sr(regs, SR_IDBR_EMPTY);
+                    break;
+                }
+                if regs.sr().read().slave_stop_det().bit_is_set() {
+                    clear_sr(regs, SR_SLAVE_STOP_DET);
+                    return Ok(());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Wait for a STOP condition after a slave transfer.
+    pub fn blocking_wait_stop(&mut self) -> Result<(), Error> {
+        let regs = self.regs();
+        set_receive_mode(regs, true);
+        loop {
+            check_errors(regs)?;
+            if regs.sr().read().slave_stop_det().bit_is_set() {
+                clear_sr(regs, SR_SLAVE_STOP_DET);
+                return Ok(());
+            }
+        }
+    }
+}
+
+impl<'d> I2cSlave<'d, Async> {
+    async fn wait_mask<F>(&mut self, mut ready: F, irq_mask: u32) -> Result<(), Error>
+    where
+        F: FnMut(&RegisterBlock) -> Poll<Result<(), Error>>,
+    {
+        let regs = self.regs();
+        let state = self.info.state;
+
+        poll_fn(|cx| {
+            state.waker.register(cx.waker());
+            match ready(regs) {
+                Poll::Ready(result) => {
+                    set_irq_enables(regs, irq_mask, false);
+                    Poll::Ready(result)
+                }
+                Poll::Pending => {
+                    set_irq_enables(regs, irq_mask | SR_ERROR_MASK, true);
+                    match ready(regs) {
+                        Poll::Ready(result) => {
+                            set_irq_enables(regs, irq_mask | SR_ERROR_MASK, false);
+                            Poll::Ready(result)
+                        }
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+            }
+        })
+        .await
+    }
+
+    /// Wait until the slave address is detected; return the transfer direction.
+    pub async fn listen(&mut self) -> Result<SlaveOp, Error> {
+        let mut op = SlaveOp::Read;
+        self.wait_mask(
+            |regs| {
+                if let Err(e) = check_errors(regs) {
+                    return Poll::Ready(Err(e));
+                }
+                if regs.sr().read().slave_addr_det().bit_is_set() {
+                    clear_sr(regs, SR_SLAVE_ADDR_DET);
+                    op = if regs.sr().read().rw_mode().bit_is_set() {
+                        SlaveOp::Write
+                    } else {
+                        SlaveOp::Read
+                    };
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            },
+            SR_SLAVE_ADDR_DET,
+        )
+        .await?;
+        Ok(op)
+    }
+
+    /// Receive `buffer.len()` bytes as slave.
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        for slot in buffer.iter_mut() {
+            set_receive_mode(self.regs(), true);
+            let mut done = false;
+            self.wait_mask(
+                |regs| {
+                    if let Err(e) = check_errors(regs) {
+                        return Poll::Ready(Err(e));
+                    }
+                    if regs.sr().read().dbr_full().bit_is_set() {
+                        clear_sr(regs, SR_DBR_FULL);
+                        done = true;
+                        Poll::Ready(Ok(()))
+                    } else if regs.sr().read().slave_stop_det().bit_is_set() {
+                        clear_sr(regs, SR_SLAVE_STOP_DET);
+                        done = false;
+                        Poll::Ready(Ok(()))
+                    } else {
+                        Poll::Pending
+                    }
+                },
+                SR_DBR_FULL | SR_SLAVE_STOP_DET,
+            )
+            .await?;
+            if !done {
+                return Ok(());
+            }
+            *slot = read_dbr(self.regs());
+        }
+        Ok(())
+    }
+
+    /// Transmit `bytes` as slave.
+    pub async fn write(&mut self, bytes: &[u8]) -> Result<(), Error> {
+        for &byte in bytes {
+            master_send_byte(self.regs(), byte);
+            clear_sr(self.regs(), SR_IDBR_EMPTY);
+            let mut early_stop = false;
+            self.wait_mask(
+                |regs| {
+                    if let Err(e) = check_errors(regs) {
+                        return Poll::Ready(Err(e));
+                    }
+                    if regs.sr().read().idbr_empty().bit_is_set() {
+                        clear_sr(regs, SR_IDBR_EMPTY);
+                        Poll::Ready(Ok(()))
+                    } else if regs.sr().read().slave_stop_det().bit_is_set() {
+                        clear_sr(regs, SR_SLAVE_STOP_DET);
+                        early_stop = true;
+                        Poll::Ready(Ok(()))
+                    } else {
+                        Poll::Pending
+                    }
+                },
+                SR_IDBR_EMPTY | SR_SLAVE_STOP_DET,
+            )
+            .await?;
+            if early_stop {
+                return Ok(());
+            }
+        }
+        Ok(())
+    }
+
+    /// Wait for a STOP condition after a slave transfer.
+    pub async fn wait_stop(&mut self) -> Result<(), Error> {
+        set_receive_mode(self.regs(), true);
+        self.wait_mask(
+            |regs| {
+                if let Err(e) = check_errors(regs) {
+                    return Poll::Ready(Err(e));
+                }
+                if regs.sr().read().slave_stop_det().bit_is_set() {
+                    clear_sr(regs, SR_SLAVE_STOP_DET);
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            },
+            SR_SLAVE_STOP_DET,
+        )
+        .await
+    }
+}
+
+impl<'d, M: Mode> Drop for I2cSlave<'d, M> {
+    fn drop(&mut self) {
+        shutdown(self.info);
+    }
+}
+
+// --- embedded-hal ----------------------------------------------------------
+
+impl<'d, M: Mode> embedded_hal::i2c::ErrorType for I2c<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_hal::i2c::I2c<embedded_hal::i2c::SevenBitAddress> for I2c<'d, M> {
+    fn transaction(&mut self, address: u8, operations: &mut [EhOperation<'_>]) -> Result<(), Self::Error> {
+        self.blocking_transaction(address, operations)
+    }
+}
+
+impl<'d> embedded_hal_async::i2c::I2c<embedded_hal::i2c::SevenBitAddress> for I2c<'d, Async> {
+    async fn transaction(&mut self, address: u8, operations: &mut [EhOperation<'_>]) -> Result<(), Self::Error> {
+        I2c::transaction(self, address, operations).await
+    }
+}
+
+// --- Instance / pins -------------------------------------------------------
+
+mod sealed {
+    use super::Info;
+
+    pub trait Instance {
+        fn info() -> &'static Info;
+    }
+}
+
+/// I2C instance (I2C0–I2C2).
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// NVIC vector for this I2C.
+    type Interrupt: TypelevelInterrupt;
+}
+
+macro_rules! impl_i2c {
+    ($peri:ident, $interrupt:ident, $base:expr, $rcc:ident, $pclk:ident, $state:ident) => {
+        impl sealed::Instance for peripherals::$peri {
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    regs: $base as *const RegisterBlock,
+                    peripheral: Peripheral::$rcc,
+                    pclk: PclkSel::$pclk,
+                    state: &$state,
+                };
+                &INFO
+            }
+        }
+
+        impl Instance for peripherals::$peri {
+            type Interrupt = interrupt::typelevel::$interrupt;
+        }
+    };
+}
+
+impl_i2c!(I2C0, I2C0, 0x4000_7000, I2c0, Pclk0, STATE_I2C0);
+impl_i2c!(I2C1, I2C1, 0x4001_4000, I2c1, Pclk1, STATE_I2C1);
+impl_i2c!(I2C2, I2C2, 0x4001_5000, I2c2, Pclk1, STATE_I2C2);
+
+/// SCL pin for an I2C instance.
+pub trait SclPin<T: Instance>: GpioPin {
+    /// Datasheet alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+/// SDA pin for an I2C instance.
+pub trait SdaPin<T: Instance>: GpioPin {
+    /// Datasheet alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+macro_rules! impl_pin {
+    ($pin:ident, $instance:ident, $trait:ident, $af:ident) => {
+        impl $trait<peripherals::$instance> for peripherals::$pin {
+            const AF: AlternateFunction = AlternateFunction::$af;
+        }
+    };
+}
+
+// Datasheet Table 4-3: every documented I2C remap uses Fun=3.
+impl_pin!(PA2, I2C0, SclPin, Function3);
+impl_pin!(PA3, I2C0, SdaPin, Function3);
+impl_pin!(PA14, I2C0, SclPin, Function3);
+impl_pin!(PA15, I2C0, SdaPin, Function3);
+impl_pin!(PB10, I2C0, SclPin, Function3);
+impl_pin!(PB11, I2C0, SdaPin, Function3);
+
+impl_pin!(PA6, I2C1, SclPin, Function3);
+impl_pin!(PA7, I2C1, SdaPin, Function3);
+impl_pin!(PB14, I2C1, SclPin, Function3);
+impl_pin!(PB15, I2C1, SdaPin, Function3);
+impl_pin!(PC10, I2C1, SclPin, Function3);
+
+impl_pin!(PA10, I2C2, SclPin, Function3);
+impl_pin!(PA11, I2C2, SdaPin, Function3);
+impl_pin!(PB7, I2C2, SdaPin, Function3);
+impl_pin!(PC2, I2C2, SclPin, Function3);
+impl_pin!(PC3, I2C2, SdaPin, Function3);
+impl_pin!(PC15, I2C2, SdaPin, Function3);

--- a/embassy-asr/src/i2c.rs
+++ b/embassy-asr/src/i2c.rs
@@ -208,19 +208,15 @@ impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let info = T::info();
         let regs = info.regs();
-        let sr = regs.sr().read().bits();
 
         // Mask level/event enables; the waiter re-enables as needed.
         let cr = regs.cr().read().bits() & !CR_INTR_MASK;
         regs.cr().write_with_zero(|w| unsafe { w.bits(cr) });
 
-        // Clear only the error flags in the ISR so a cancelled waiter cannot
-        // leave sticky bus errors latched forever. Completion flags stay for
-        // the waiter.
-        let errors = sr & SR_ERROR_MASK;
-        if errors != 0 {
-            regs.sr().write_with_zero(|w| unsafe { w.bits(errors) });
-        }
+        // Error flags are NOT cleared here: the waiter (async or blocking
+        // poll loop) has to observe them through `check_errors`. A latched
+        // flag left behind by a cancelled waiter is reported (and cleared)
+        // by the next transaction's first status check.
 
         info.state.waker.wake();
     }

--- a/embassy-asr/src/iwdg.rs
+++ b/embassy-asr/src/iwdg.rs
@@ -1,0 +1,194 @@
+//! Independent watchdog.
+//!
+//! Register programming follows the vendor `tremo_iwdg` driver.
+
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, pac, peripherals};
+
+const MAX_RELOAD: u32 = 0x0fff;
+
+const CR_RSTEN: u32 = 1 << 5;
+const CR_WKEN: u32 = 1 << 4;
+const CR_PREDIV_MASK: u32 = 0x0e;
+const CR_START: u32 = 1 << 0;
+
+const SR_WRITE_SR2_DONE: u32 = 1 << 3;
+const SR_WRITE_CR_DONE: u32 = 1 << 0;
+const SR_ALL_DONE: u32 = 0x0f;
+
+const CR1_RESET_REQ_INT_EN: u32 = 1 << 0;
+const SR2_RESET_REQ: u32 = 1 << 0;
+const RCC_RST_CR_IWDG_RESET_REQ_EN: u32 = 1 << 5;
+
+/// IWDG clock prescaler.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum Prescaler {
+    Div4 = 0x00,
+    Div8 = 0x02,
+    Div16 = 0x04,
+    Div32 = 0x06,
+    Div64 = 0x08,
+    Div128 = 0x0a,
+    Div256 = 0x0c,
+}
+
+/// Independent-watchdog configuration.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Clock prescaler.
+    pub prescaler: Prescaler,
+    /// Reload value in the range `0..=0x0FFF`.
+    pub reload: u32,
+    /// Optional window value in the range `0..=0x0FFF`.
+    pub window: Option<u32>,
+    /// When true, timeout asserts a system reset request.
+    ///
+    /// The vendor notes that auto-reset does not work in STOP3.
+    pub auto_reset: bool,
+}
+
+impl Config {
+    /// Create a default configuration with prescaler 4 and full reload.
+    pub const fn new() -> Self {
+        Self {
+            prescaler: Prescaler::Div4,
+            reload: MAX_RELOAD,
+            window: None,
+            auto_reset: true,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Owned independent watchdog.
+pub struct IndependentWatchdog<'d> {
+    _peri: Peri<'d, peripherals::IWDG>,
+}
+
+impl<'d> IndependentWatchdog<'d> {
+    /// Enable clocks, apply `config`, and leave the watchdog stopped.
+    pub fn new(peri: Peri<'d, peripherals::IWDG>, config: Config) -> Self {
+        let _ = rcc::enable_peripheral(Peripheral::Iwdg);
+        let this = Self { _peri: peri };
+        this.configure(config);
+        this
+    }
+
+    /// Apply configuration while the watchdog is stopped.
+    pub fn configure(&self, config: Config) {
+        let regs = Self::regs();
+        wait_sr_done();
+
+        regs.cr().modify(|r, w| unsafe { w.bits(r.bits() & !CR_START) });
+        wait_sr_done();
+
+        unsafe {
+            regs.sr2().write_with_zero(|w| w.bits(SR2_RESET_REQ));
+        }
+        wait_sr_done();
+
+        critical_section::with(|_| {
+            let rcc = unsafe { pac::Rcc::steal() };
+            rcc.rst_cr().modify(|r, w| unsafe {
+                let bits = if config.auto_reset {
+                    r.bits() | RCC_RST_CR_IWDG_RESET_REQ_EN
+                } else {
+                    r.bits() & !RCC_RST_CR_IWDG_RESET_REQ_EN
+                };
+                w.bits(bits)
+            });
+        });
+
+        regs.cr().modify(|r, w| unsafe {
+            let mut bits = (r.bits() & !CR_RSTEN) | (config.prescaler as u32 & CR_PREDIV_MASK);
+            if config.auto_reset {
+                bits |= CR_RSTEN;
+            }
+            w.bits(bits)
+        });
+        wait_sr_done();
+
+        let reload = config.reload.min(MAX_RELOAD);
+        unsafe {
+            regs.max().write_with_zero(|w| w.bits(reload));
+        }
+        wait_sr_done();
+
+        if let Some(window) = config.window {
+            unsafe {
+                regs.win().write_with_zero(|w| w.bits(window.min(MAX_RELOAD)));
+            }
+            wait_sr_done();
+        }
+    }
+
+    /// Start the watchdog.
+    pub fn start(&self) {
+        wait_sr_done();
+        Self::regs()
+            .cr()
+            .modify(|r, w| unsafe { w.bits(r.bits() | CR_START | CR_WKEN) });
+        while Self::regs().sr().read().bits() & SR_WRITE_CR_DONE == 0 {}
+    }
+
+    /// Stop the watchdog counter.
+    pub fn stop(&self) {
+        wait_sr_done();
+        Self::regs().cr().modify(|r, w| unsafe { w.bits(r.bits() & !CR_START) });
+        while Self::regs().sr().read().bits() & SR_WRITE_CR_DONE == 0 {}
+    }
+
+    /// Feed the watchdog.
+    pub fn pet(&self) {
+        let regs = Self::regs();
+        if regs.sr2().read().bits() & SR2_RESET_REQ != 0 {
+            wait_sr_done();
+            unsafe {
+                regs.sr2().write_with_zero(|w| w.bits(SR2_RESET_REQ));
+            }
+        }
+
+        wait_sr_done();
+        let reload = regs.max().read().bits();
+        unsafe {
+            regs.max().write_with_zero(|w| w.bits(reload));
+        }
+    }
+
+    /// Enable or disable the reset-request interrupt.
+    pub fn set_interrupt_enabled(&self, enabled: bool) {
+        Self::regs().cr1().modify(|r, w| unsafe {
+            let bits = if enabled {
+                r.bits() | CR1_RESET_REQ_INT_EN
+            } else {
+                r.bits() & !CR1_RESET_REQ_INT_EN
+            };
+            w.bits(bits)
+        });
+    }
+
+    /// Clear the reset-request interrupt status.
+    pub fn clear_interrupt(&self) {
+        unsafe {
+            Self::regs().sr2().write_with_zero(|w| w.bits(SR2_RESET_REQ));
+        }
+        while Self::regs().sr().read().bits() & SR_WRITE_SR2_DONE == 0 {}
+    }
+
+    #[inline]
+    fn regs() -> pac::Iwdg {
+        unsafe { pac::Iwdg::steal() }
+    }
+}
+
+fn wait_sr_done() {
+    while IndependentWatchdog::regs().sr().read().bits() & SR_ALL_DONE != SR_ALL_DONE {}
+}

--- a/embassy-asr/src/lib.rs
+++ b/embassy-asr/src/lib.rs
@@ -1,0 +1,46 @@
+#![no_std]
+
+//! Minimal Embassy support for ASR microcontrollers.
+//!
+//! This crate currently provides only initialization and an `embassy-time`
+//! driver. Peripheral HAL drivers are intentionally out of scope.
+
+#[cfg(feature = "asr6601")]
+pub mod pac {
+    pub use asr6601_pac::*;
+    pub use cortex_m_rt::interrupt;
+
+    pub mod interrupt {
+        pub use asr6601_pac::Interrupt;
+        pub use asr6601_pac::Interrupt::*;
+    }
+}
+
+#[cfg(feature = "time-driver-rtc")]
+mod time_driver;
+
+// There are no HAL peripheral singletons yet. Keeping the standard Embassy
+// `Peripherals` return value makes `init` forward-compatible with adding them.
+embassy_hal_internal::peripherals! {}
+
+/// Initialize minimal ASR chip support.
+///
+/// With `time-driver-rtc` enabled, this resets and uses RTC exclusively for
+/// Embassy time. Applications must not access RTC through the raw PAC.
+pub fn init() -> Peripherals {
+    let peripherals = Peripherals::take();
+
+    #[cfg(feature = "time-driver-rtc")]
+    crate::time_driver::init();
+
+    unsafe {
+        // The thread-mode Cortex-M executor uses WFE and must not inherit deep
+        // sleep state from a bootloader.
+        cortex_m::peripheral::Peripherals::steal()
+            .SCB
+            .clear_sleepdeep();
+        cortex_m::interrupt::enable();
+    }
+
+    peripherals
+}

--- a/embassy-asr/src/lib.rs
+++ b/embassy-asr/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
+#![allow(unsafe_op_in_unsafe_fn)]
 
-//! Minimal Embassy support for ASR microcontrollers.
+//! Embassy support for ASR microcontrollers.
 //!
-//! This crate currently provides only initialization and an `embassy-time`
-//! driver. Peripheral HAL drivers are intentionally out of scope.
+//! This crate provides the shared ownership, interrupt, and initialization
+//! infrastructure used by ASR peripheral drivers.
 
 #[cfg(feature = "asr6601")]
 pub mod pac {
@@ -19,16 +20,247 @@ pub mod pac {
 #[cfg(feature = "time-driver-rtc")]
 mod time_driver;
 
-// There are no HAL peripheral singletons yet. Keeping the standard Embassy
-// `Peripherals` return value makes `init` forward-compatible with adding them.
-embassy_hal_internal::peripherals! {}
+#[cfg(feature = "asr6601")]
+pub mod adc;
+#[cfg(feature = "asr6601")]
+pub mod afec;
+#[cfg(feature = "asr6601")]
+pub mod bstimer;
+#[cfg(feature = "asr6601")]
+pub mod crc;
+#[cfg(feature = "asr6601")]
+pub mod dac;
+#[cfg(feature = "asr6601")]
+pub mod dma;
+#[cfg(feature = "asr6601")]
+pub mod flash;
+#[cfg(feature = "asr6601")]
+pub mod gpio;
+#[cfg(feature = "asr6601")]
+pub mod i2c;
+#[cfg(feature = "asr6601")]
+pub mod iwdg;
+#[cfg(feature = "asr6601")]
+pub mod lptimer;
+#[cfg(feature = "asr6601")]
+pub mod lpuart;
+#[cfg(feature = "asr6601")]
+pub mod pwr;
+#[cfg(feature = "asr6601")]
+pub mod rcc;
+#[cfg(feature = "asr6601")]
+pub mod rng;
+#[cfg(feature = "asr6601")]
+pub mod sec;
+#[cfg(feature = "asr6601")]
+pub mod spi;
+#[cfg(feature = "asr6601")]
+pub mod syscfg;
+#[cfg(feature = "asr6601")]
+pub mod timer;
+#[cfg(feature = "asr6601")]
+pub mod uart;
+#[cfg(feature = "asr6601")]
+pub mod wdg;
 
-/// Initialize minimal ASR chip support.
+pub use embassy_hal_internal::{Peri, PeripheralType};
+
+/// Operating modes for peripherals.
+pub mod mode {
+    trait SealedMode {}
+
+    /// Operating mode for a peripheral.
+    #[allow(private_bounds)]
+    pub trait Mode: SealedMode {}
+
+    /// Blocking mode.
+    #[derive(Clone, Copy, Debug)]
+    pub struct Blocking;
+
+    /// Asynchronous mode.
+    #[derive(Clone, Copy, Debug)]
+    pub struct Async;
+
+    impl SealedMode for Blocking {}
+    impl Mode for Blocking {}
+    impl SealedMode for Async {}
+    impl Mode for Async {}
+}
+
+#[cfg(feature = "asr6601")]
+embassy_hal_internal::interrupt_mod!(
+    SEC, RTC, WDG, EFC, UART3, I2C2, UART0, UART1, UART2, LPUART, SSP0, SSP1, QSPI, I2C0, I2C1, SCC, ADC, AFEC, SSP2,
+    DMA1, DAC, LORA, GPIO, TIMER0, TIMER1, TIMER2, TIMER3, BSTIMER0, BSTIMER1, LPTIMER0, SAC, DMA0, I2S, LCD, PWR,
+    LPTIMER1, IWDG,
+);
+
+/// Bind interrupt vectors to HAL interrupt handlers.
+///
+/// The generated unit struct proves at compile time that each listed
+/// interrupt is bound to the requested handler or handlers.
+#[macro_export]
+macro_rules! bind_interrupts {
+    ($(#[$attr:meta])* $vis:vis struct $name:ident {
+        $(
+            $(#[cfg($cond_irq:meta)])?
+            $irq:ident => $(
+                $(#[cfg($cond_handler:meta)])?
+                $handler:ty
+            ),*;
+        )*
+    }) => {
+        #[derive(Copy, Clone)]
+        $(#[$attr])*
+        $vis struct $name;
+
+        $(
+            #[allow(non_snake_case)]
+            #[unsafe(no_mangle)]
+            $(#[cfg($cond_irq)])?
+            unsafe extern "C" fn $irq() {
+                unsafe {
+                    $(
+                        $(#[cfg($cond_handler)])?
+                        <$handler as $crate::interrupt::typelevel::Handler<
+                            $crate::interrupt::typelevel::$irq
+                        >>::on_interrupt();
+                    )*
+                }
+            }
+
+            $(#[cfg($cond_irq)])?
+            $crate::bind_interrupts!(@inner
+                $(
+                    $(#[cfg($cond_handler)])?
+                    unsafe impl $crate::interrupt::typelevel::Binding<
+                        $crate::interrupt::typelevel::$irq,
+                        $handler
+                    > for $name {}
+                )*
+            );
+        )*
+    };
+    (@inner $($t:tt)*) => {
+        $($t)*
+    }
+}
+
+embassy_hal_internal::peripherals! {
+    // GPIO port A
+    PA0, PA1, PA2, PA3, PA4, PA5, PA6, PA7,
+    PA8, PA9, PA10, PA11, PA12, PA13, PA14, PA15,
+
+    // GPIO port B
+    PB0, PB1, PB2, PB3, PB4, PB5, PB6, PB7,
+    PB8, PB9, PB10, PB11, PB12, PB13, PB14, PB15,
+
+    // GPIO port C
+    PC0, PC1, PC2, PC3, PC4, PC5, PC6, PC7,
+    PC8, PC9, PC10, PC11, PC12, PC13, PC14, PC15,
+
+    // GPIO port D
+    PD0, PD1, PD2, PD3, PD4, PD5, PD6, PD7,
+    PD8, PD9, PD10, PD11, PD12, PD13, PD14, PD15,
+
+    // GPIO hardware blocks
+    GPIOA, GPIOB, GPIOC, GPIOD,
+
+    // DMA hardware blocks and channels
+    DMA0, DMA1,
+    DMA0_CH0, DMA0_CH1, DMA0_CH2, DMA0_CH3,
+    DMA1_CH0, DMA1_CH1, DMA1_CH2, DMA1_CH3,
+
+    // Clock, system, and power control
+    RCC,
+    SYSCFG,
+    AFEC,
+    PWR,
+
+    // Communications
+    UART0,
+    UART1,
+    UART2,
+    UART3,
+    LPUART,
+    SSP0,
+    SSP1,
+    SSP2,
+    QSPI,
+    I2C0,
+    I2C1,
+    I2C2,
+    I2S,
+
+    // Timers
+    TIMER0,
+    TIMER1,
+    TIMER2,
+    TIMER3,
+    BSTIMER0,
+    BSTIMER1,
+    LPTIMER0,
+    LPTIMER1,
+    #[cfg(not(feature = "time-driver-rtc"))]
+    RTC,
+
+    // Analog and display
+    ADC,
+    DAC,
+    LCD,
+
+    // Storage and data processing
+    EFC,
+    CRC,
+    RNG,
+    SAE,
+    SEC,
+
+    // Radio and supervision
+    LORAC,
+    IWDG,
+    WDG,
+}
+
+/// Global HAL configuration.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug)]
+pub struct Config {
+    /// Oscillator and core/bus clock configuration.
+    pub rcc: rcc::Config,
+}
+
+impl Config {
+    /// Create the default HAL configuration.
+    pub const fn new() -> Self {
+        Self {
+            rcc: rcc::Config::new(),
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Initialize the ASR HAL.
 ///
 /// With `time-driver-rtc` enabled, this resets and uses RTC exclusively for
 /// Embassy time. Applications must not access RTC through the raw PAC.
-pub fn init() -> Peripherals {
+pub fn init(config: Config) -> Peripherals {
     let peripherals = Peripherals::take();
+
+    #[cfg(feature = "asr6601")]
+    {
+        // Consume RCC into the shared clock tree. Peripheral drivers continue
+        // to use crate-private RCC helpers for clock/reset gates.
+        rcc::init(unsafe { peripherals.RCC.clone_unchecked() }, config.rcc)
+            .expect("embassy-asr: RCC initialization failed");
+        unsafe {
+            dma::init();
+        }
+    }
 
     #[cfg(feature = "time-driver-rtc")]
     crate::time_driver::init();
@@ -36,9 +268,7 @@ pub fn init() -> Peripherals {
     unsafe {
         // The thread-mode Cortex-M executor uses WFE and must not inherit deep
         // sleep state from a bootloader.
-        cortex_m::peripheral::Peripherals::steal()
-            .SCB
-            .clear_sleepdeep();
+        cortex_m::peripheral::Peripherals::steal().SCB.clear_sleepdeep();
         cortex_m::interrupt::enable();
     }
 

--- a/embassy-asr/src/lptimer.rs
+++ b/embassy-asr/src/lptimer.rs
@@ -1,0 +1,935 @@
+//! Low-power timer (LPTIMER0 / LPTIMER1).
+//!
+//! Register programming follows the vendor `tremo_lptimer` driver and the
+//! ASR6601 SDK examples (`lptimer_wakeup_stop`, `external_trigger`,
+//! `external_clock`, `lptimer_encoder`).
+//!
+//! Many multi-bit CFGR/CR fields and the IER/ICR/CMP/ARR/CNT/SR1 field layouts
+//! are missing from the PAC/SVD. Those bits are programmed with the masks from
+//! `tremo_lptimer.h`.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicU32, Ordering};
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::InterruptExt;
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::gpio::{self, AlternateFunction, Flex};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt as TypelevelInterrupt};
+use crate::rcc::{self, Peripheral as RccPeripheral};
+use crate::{Peri, PeripheralType, interrupt, pac, peripherals};
+
+const POLL_LIMIT: u32 = 1_000_000;
+
+const ISR_CMPM: u32 = 1 << 0;
+const ISR_ARRM: u32 = 1 << 1;
+const ISR_EXTTRIG: u32 = 1 << 2;
+const ISR_CMPOK: u32 = 1 << 3;
+const ISR_ARROK: u32 = 1 << 4;
+const ISR_UP: u32 = 1 << 5;
+const ISR_DOWN: u32 = 1 << 6;
+const ISR_CFGROK: u32 = 1 << 7;
+const ISR_CROK: u32 = 1 << 8;
+
+const IT_MASK: u32 = ISR_CMPM | ISR_ARRM | ISR_EXTTRIG | ISR_CMPOK | ISR_ARROK | ISR_UP | ISR_DOWN;
+
+const CSR_CMPM: u32 = 1 << 0;
+const CSR_ARRM: u32 = 1 << 1;
+const CSR_EXTTRIG: u32 = 1 << 2;
+const CSR_UP: u32 = 1 << 3;
+const CSR_DOWN: u32 = 1 << 4;
+
+const CFGR_CKPOL_MASK: u32 = 0x6;
+const CFGR_CKFLT_MASK: u32 = 0x18;
+const CFGR_TRGFLT_MASK: u32 = 0xc0;
+const CFGR_PRESC_MASK: u32 = 0xe00;
+const CFGR_TRIGSEL_MASK: u32 = 0xe000;
+const CFGR_TRIGEN_MASK: u32 = 0x60000;
+
+const CR_SNGSTRT: u32 = 1 << 1;
+const CR_CNTSTRT: u32 = 1 << 2;
+
+const WKUP_MASK: u32 = (1 << 25) | (1 << 26) | (1 << 27) | (1 << 28) | (1 << 29) | (1 << 30);
+
+static WAKERS: [AtomicWaker; 2] = [const { AtomicWaker::new() }; 2];
+static PENDING: [AtomicU32; 2] = [const { AtomicU32::new(0) }; 2];
+
+/// LPTIMER driver error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// A bounded wait for a status bit expired.
+    Timeout(TimeoutTarget),
+    /// RCC rejected the clock or reset request.
+    Rcc(rcc::Error),
+}
+
+/// Status bit that failed to become ready within the poll budget.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum TimeoutTarget {
+    /// `ISR.CFGROK` after a CFGR write.
+    Cfgrok,
+    /// `ISR.CROK` after a CR write.
+    Crok,
+    /// `ISR.ARROK` after an ARR write.
+    Arrok,
+    /// `ISR.CMPOK` after a CMP write.
+    Cmpok,
+    /// `CSR` acknowledge after an interrupt clear.
+    ClearStatus,
+    /// RCC functional-clock sync clear while changing the LPTIMER source.
+    ClockSourceSync,
+}
+
+impl From<rcc::Error> for Error {
+    fn from(value: rcc::Error) -> Self {
+        Self::Rcc(value)
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Timeout(target) => write!(f, "LPTIMER timeout waiting for {target:?}"),
+            Self::Rcc(err) => write!(f, "LPTIMER RCC error: {err:?}"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+/// Kernel clock source selected in `RCC.CR1`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ClockSource {
+    /// PCLK0.
+    Pclk0,
+    /// Internal ~4 MHz RC oscillator.
+    Rco4m,
+    /// External 32.768 kHz crystal oscillator.
+    Xo32k,
+    /// Internal 32.768 kHz RC oscillator.
+    Rco32k,
+    /// External clock input (RCC `EXTCLK_SEL`).
+    ExtClk,
+}
+
+/// Counter clock prescaler (`CFGR.PRESC`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum Prescaler {
+    Div1 = 0x0,
+    Div2 = 0x200,
+    Div4 = 0x400,
+    Div8 = 0x600,
+    Div16 = 0x800,
+    Div32 = 0xa00,
+    Div64 = 0xc00,
+    Div128 = 0xe00,
+}
+
+/// External trigger polarity (`CFGR.TRIGEN`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum TriggerPolarity {
+    /// Software / no edge trigger.
+    Software = 0x0,
+    Rising = 0x20000,
+    Falling = 0x40000,
+    RisingFalling = 0x60000,
+}
+
+/// External trigger source (`CFGR.TRIGSEL`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum TriggerSource {
+    /// External trigger ETR pin.
+    Etr = 0x0,
+    Comp0 = 0x2000,
+    Comp1 = 0x4000,
+    RtcCyc = 0x6000,
+    RtcAlarm0 = 0x8000,
+    RtcAlarm1 = 0xa000,
+    Gpio0 = 0xc000,
+    Gpio1 = 0xe000,
+}
+
+/// Trigger digital filter length (`CFGR.TRGFLT`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum TriggerFilter {
+    None = 0x0,
+    Cycles2 = 0x40,
+    Cycles4 = 0x80,
+    Cycles8 = 0xc0,
+}
+
+/// External clock digital filter length (`CFGR.CKFLT`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum ClockFilter {
+    None = 0x0,
+    Cycles2 = 0x8,
+    Cycles4 = 0x10,
+    Cycles8 = 0x18,
+}
+
+/// External clock edge polarity (`CFGR.CKPOL`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum ClockPolarity {
+    Rising = 0x0,
+    Falling = 0x2,
+    Both = 0x4,
+}
+
+/// Count start mode programmed in `CR`.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CountMode {
+    /// Single-shot (`SNGSTRT`).
+    Single,
+    /// Continuous (`CNTSTRT`).
+    Continuous,
+}
+
+/// Interrupt / status flags that map to `IER` / `SR1` / `ICR` bits.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct InterruptFlags(u32);
+
+impl InterruptFlags {
+    pub const CMPM: Self = Self(ISR_CMPM);
+    pub const ARRM: Self = Self(ISR_ARRM);
+    pub const EXTTRIG: Self = Self(ISR_EXTTRIG);
+    pub const CMPOK: Self = Self(ISR_CMPOK);
+    pub const ARROK: Self = Self(ISR_ARROK);
+    pub const UP: Self = Self(ISR_UP);
+    pub const DOWN: Self = Self(ISR_DOWN);
+
+    /// Empty set.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Combine flag sets.
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Bits used by the vendor interrupt API (excludes CFGROK/CROK).
+    pub const fn bits(self) -> u32 {
+        self.0 & IT_MASK
+    }
+
+    /// Whether every bit in `other` is present.
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
+
+impl core::ops::BitOr for InterruptFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.union(rhs)
+    }
+}
+
+impl core::ops::BitOrAssign for InterruptFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// Wake-from-stop sources programmed in `CFGR` (vendor `lptimer_wkup_t`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct WakeupFlags(u32);
+
+impl WakeupFlags {
+    pub const CMPM: Self = Self(1 << 25);
+    pub const ARRM: Self = Self(1 << 26);
+    pub const EXTTRIG: Self = Self(1 << 27);
+    pub const UP: Self = Self(1 << 28);
+    pub const DOWN: Self = Self(1 << 29);
+    pub const OUT: Self = Self(1 << 30);
+
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0 & WKUP_MASK
+    }
+}
+
+impl core::ops::BitOr for WakeupFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.union(rhs)
+    }
+}
+
+impl core::ops::BitOrAssign for WakeupFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// LPTIMER initialization configuration (vendor `lptimer_init_t` plus RCC source).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Kernel clock selected in `RCC.CR1`.
+    pub clock_source: ClockSource,
+    /// Count external edges (`CFGR.COUNTMODE`).
+    pub count_by_external: bool,
+    /// Counter clock prescaler.
+    pub prescaler: Prescaler,
+    /// ARR/CMP preload (`CFGR.PRELOAD`).
+    pub autoreload_preload: bool,
+    /// Invert waveform polarity (`CFGR.WAVPOL`).
+    pub wavpol_inverted: bool,
+}
+
+impl Config {
+    /// Defaults matching the SDK wakeup example (XO32K, /1, no preload).
+    pub const fn new() -> Self {
+        Self {
+            clock_source: ClockSource::Xo32k,
+            count_by_external: false,
+            prescaler: Prescaler::Div1,
+            autoreload_preload: false,
+            wavpol_inverted: false,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+mod sealed {
+    use super::*;
+
+    pub trait Instance {
+        fn regs() -> &'static pac::lptimer0::RegisterBlock;
+        fn rcc_peripheral() -> RccPeripheral;
+        fn nv_interrupt() -> pac::Interrupt;
+        const INDEX: usize;
+        fn clock_source_sync() -> bool;
+        fn gate_functional_clock(enable: bool);
+        fn set_clock_source(source: ClockSource);
+    }
+
+    pub trait AfPin {
+        const AF: AlternateFunction;
+    }
+}
+
+/// LPTIMER peripheral instance.
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// NVIC vector for this instance.
+    type Interrupt: TypelevelInterrupt;
+}
+
+impl sealed::Instance for peripherals::LPTIMER0 {
+    #[inline]
+    fn regs() -> &'static pac::lptimer0::RegisterBlock {
+        unsafe { &*pac::Lptimer0::ptr() }
+    }
+
+    #[inline]
+    fn rcc_peripheral() -> RccPeripheral {
+        RccPeripheral::Lptimer0
+    }
+
+    #[inline]
+    fn nv_interrupt() -> pac::Interrupt {
+        pac::Interrupt::LPTIMER0
+    }
+
+    const INDEX: usize = 0;
+
+    fn clock_source_sync() -> bool {
+        unsafe { pac::Rcc::steal() }
+            .sr1()
+            .read()
+            .lptimer0_clk_en_sync()
+            .bit_is_set()
+    }
+
+    fn gate_functional_clock(enable: bool) {
+        critical_section::with(|_| {
+            unsafe { pac::Rcc::steal() }
+                .cgr1()
+                .modify(|_, w| w.lptimer0_clk_en().bit(enable));
+        });
+    }
+
+    fn set_clock_source(source: ClockSource) {
+        critical_section::with(|_| {
+            let rcc = unsafe { pac::Rcc::steal() };
+            rcc.cr1().modify(|_, w| match source {
+                ClockSource::ExtClk => w.lptimer0_extclk_sel().set_bit(),
+                ClockSource::Pclk0 => {
+                    w.lptimer0_extclk_sel().clear_bit();
+                    w.lptimer0_clk_sel().pclk0()
+                }
+                ClockSource::Rco4m => {
+                    w.lptimer0_extclk_sel().clear_bit();
+                    w.lptimer0_clk_sel().rco4m()
+                }
+                ClockSource::Xo32k => {
+                    w.lptimer0_extclk_sel().clear_bit();
+                    w.lptimer0_clk_sel().xo32k()
+                }
+                ClockSource::Rco32k => {
+                    w.lptimer0_extclk_sel().clear_bit();
+                    w.lptimer0_clk_sel().rco32k()
+                }
+            });
+        });
+    }
+}
+
+impl Instance for peripherals::LPTIMER0 {
+    type Interrupt = interrupt::typelevel::LPTIMER0;
+}
+
+impl sealed::Instance for peripherals::LPTIMER1 {
+    #[inline]
+    fn regs() -> &'static pac::lptimer0::RegisterBlock {
+        unsafe { &*pac::Lptimer1::ptr() }
+    }
+
+    #[inline]
+    fn rcc_peripheral() -> RccPeripheral {
+        RccPeripheral::Lptimer1
+    }
+
+    #[inline]
+    fn nv_interrupt() -> pac::Interrupt {
+        pac::Interrupt::LPTIMER1
+    }
+
+    const INDEX: usize = 1;
+
+    fn clock_source_sync() -> bool {
+        unsafe { pac::Rcc::steal() }
+            .sr1()
+            .read()
+            .lptimer1_clk_en_sync()
+            .bit_is_set()
+    }
+
+    fn gate_functional_clock(enable: bool) {
+        critical_section::with(|_| {
+            unsafe { pac::Rcc::steal() }
+                .cgr1()
+                .modify(|_, w| w.lptimer1_clk_en().bit(enable));
+        });
+    }
+
+    fn set_clock_source(source: ClockSource) {
+        critical_section::with(|_| {
+            let rcc = unsafe { pac::Rcc::steal() };
+            rcc.cr1().modify(|_, w| match source {
+                ClockSource::ExtClk => w.lptimer1_extclk_sel().set_bit(),
+                ClockSource::Pclk0 => {
+                    w.lptimer1_extclk_sel().clear_bit();
+                    w.lptimer1_clk_sel().pclk0()
+                }
+                ClockSource::Rco4m => {
+                    w.lptimer1_extclk_sel().clear_bit();
+                    w.lptimer1_clk_sel().rco4m()
+                }
+                ClockSource::Xo32k => {
+                    w.lptimer1_extclk_sel().clear_bit();
+                    w.lptimer1_clk_sel().xo32k()
+                }
+                ClockSource::Rco32k => {
+                    w.lptimer1_extclk_sel().clear_bit();
+                    w.lptimer1_clk_sel().rco32k()
+                }
+            });
+        });
+    }
+}
+
+impl Instance for peripherals::LPTIMER1 {
+    type Interrupt = interrupt::typelevel::LPTIMER1;
+}
+
+/// Interrupt handler for one LPTIMER instance.
+///
+/// Clears pending `SR1` flags acknowledged by the vendor clear sequence and
+/// wakes tasks waiting on [`LpTimer::wait_for`].
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        let pending = regs.sr1().read().bits() & regs.ier().read().bits() & IT_MASK;
+        if pending == 0 {
+            return;
+        }
+
+        unsafe {
+            regs.icr().write_with_zero(|w| w.bits(pending));
+        }
+
+        // Vendor wakeup example waits for CSR only for CMPM/ARRM; wait for any
+        // flag that has a CSR acknowledge bit.
+        let csr_mask = interrupt_to_csr(pending);
+        if csr_mask != 0 {
+            for _ in 0..POLL_LIMIT {
+                if regs.csr().read().bits() & csr_mask == csr_mask {
+                    break;
+                }
+                core::hint::spin_loop();
+            }
+        }
+
+        PENDING[T::INDEX].fetch_or(pending, Ordering::Release);
+        WAKERS[T::INDEX].wake();
+    }
+}
+
+/// Owned low-power timer.
+pub struct LpTimer<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> LpTimer<'d, T> {
+    /// Reset the block, select `config.clock_source`, enable clocks, and apply
+    /// the vendor `lptimer_init` fields. The counter remains disabled.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        // Match the wakeup example: gate functional clock, pulse reset, select
+        // source, then re-enable.
+        let _ = rcc::disable_peripheral(T::rcc_peripheral());
+        rcc::reset_peripheral(T::rcc_peripheral())?;
+        set_instance_clock_source::<T>(config.clock_source)?;
+        rcc::enable_peripheral(T::rcc_peripheral())?;
+
+        T::nv_interrupt().disable();
+        T::nv_interrupt().unpend();
+        PENDING[T::INDEX].store(0, Ordering::Release);
+
+        let this = Self { _peri: peri };
+        this.apply_init(config)?;
+        Ok(this)
+    }
+
+    /// Re-apply the vendor init fields while the counter is stopped.
+    pub fn configure(&self, config: Config) -> Result<(), Error> {
+        set_instance_clock_source::<T>(config.clock_source)?;
+        self.apply_init(config)
+    }
+
+    fn apply_init(&self, config: Config) -> Result<(), Error> {
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)?;
+
+        self.regs().cfgr().modify(|_, w| {
+            if config.count_by_external {
+                w.countmode().set_bit()
+            } else {
+                w.countmode().clear_bit()
+            }
+        });
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)?;
+
+        self.modify_cfgr_bits(CFGR_PRESC_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_PRESC_MASK, config.prescaler as u32)?;
+
+        self.regs().cfgr().modify(|_, w| {
+            if config.autoreload_preload {
+                w.preload().set_bit()
+            } else {
+                w.preload().clear_bit()
+            }
+        });
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)?;
+
+        self.regs().cfgr().modify(|_, w| {
+            if config.wavpol_inverted {
+                w.wavpol().set_bit()
+            } else {
+                w.wavpol().clear_bit()
+            }
+        });
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)?;
+
+        Ok(())
+    }
+
+    /// Enable or disable the peripheral (`CR.ENABLE`).
+    pub fn set_enabled(&self, enabled: bool) -> Result<(), Error> {
+        self.regs().cr().modify(|_, w| w.enable().bit(enabled));
+        wait_isr::<T>(ISR_CROK, TimeoutTarget::Crok)
+    }
+
+    /// Write ARR and wait for `ARROK`.
+    pub fn set_arr(&self, value: u16) -> Result<(), Error> {
+        unsafe {
+            self.regs().arr().write_with_zero(|w| w.bits(u32::from(value)));
+        }
+        wait_isr::<T>(ISR_ARROK, TimeoutTarget::Arrok)
+    }
+
+    /// Write CMP and wait for `CMPOK`.
+    pub fn set_cmp(&self, value: u16) -> Result<(), Error> {
+        unsafe {
+            self.regs().cmp().write_with_zero(|w| w.bits(u32::from(value)));
+        }
+        wait_isr::<T>(ISR_CMPOK, TimeoutTarget::Cmpok)
+    }
+
+    /// Current ARR value.
+    pub fn arr(&self) -> u16 {
+        self.regs().arr().read().bits() as u16
+    }
+
+    /// Current CMP value.
+    pub fn cmp(&self) -> u16 {
+        self.regs().cmp().read().bits() as u16
+    }
+
+    /// Current counter value.
+    pub fn counter(&self) -> u16 {
+        self.regs().cnt().read().bits() as u16
+    }
+
+    /// Start counting in single or continuous mode (vendor `lptimer_config_count_mode`).
+    pub fn start(&self, mode: CountMode) -> Result<(), Error> {
+        let bit = match mode {
+            CountMode::Single => CR_SNGSTRT,
+            CountMode::Continuous => CR_CNTSTRT,
+        };
+        self.regs().cr().modify(|r, w| unsafe { w.bits(r.bits() | bit) });
+        wait_isr::<T>(ISR_CROK, TimeoutTarget::Crok)
+    }
+
+    /// Clear a start-mode bit.
+    pub fn stop_mode(&self, mode: CountMode) -> Result<(), Error> {
+        let bit = match mode {
+            CountMode::Single => CR_SNGSTRT,
+            CountMode::Continuous => CR_CNTSTRT,
+        };
+        self.regs().cr().modify(|r, w| unsafe { w.bits(r.bits() & !bit) });
+        wait_isr::<T>(ISR_CROK, TimeoutTarget::Crok)
+    }
+
+    /// Enable or disable timeout mode (`CFGR.TIMEOUT`).
+    pub fn set_timeout_enabled(&self, enabled: bool) -> Result<(), Error> {
+        self.regs().cfgr().modify(|_, w| w.timeout().bit(enabled));
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    /// Enable or disable wake sources used with STOP modes.
+    pub fn set_wakeup(&self, flags: WakeupFlags, enabled: bool) -> Result<(), Error> {
+        let mask = flags.bits();
+        self.regs().cfgr().modify(|r, w| unsafe {
+            let bits = if enabled { r.bits() | mask } else { r.bits() & !mask };
+            w.bits(bits)
+        });
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    /// Enable or disable waveform generation (`CFGR.WAVE`).
+    pub fn set_wave_enabled(&self, enabled: bool) -> Result<(), Error> {
+        self.regs().cfgr().modify(|_, w| w.wave().bit(enabled));
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    /// Enable or disable encoder mode (`CFGR.ENC`).
+    pub fn set_encoder_enabled(&self, enabled: bool) -> Result<(), Error> {
+        self.regs().cfgr().modify(|_, w| w.enc().bit(enabled));
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    /// Configure external trigger polarity.
+    pub fn set_trigger_polarity(&self, polarity: TriggerPolarity) -> Result<(), Error> {
+        self.modify_cfgr_bits(CFGR_TRIGEN_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_TRIGEN_MASK, polarity as u32)
+    }
+
+    /// Configure external trigger source.
+    pub fn set_trigger_source(&self, source: TriggerSource) -> Result<(), Error> {
+        self.modify_cfgr_bits(CFGR_TRIGSEL_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_TRIGSEL_MASK, source as u32)
+    }
+
+    /// Configure the trigger digital filter value.
+    pub fn set_trigger_filter(&self, filter: TriggerFilter) -> Result<(), Error> {
+        self.modify_cfgr_bits(CFGR_TRGFLT_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_TRGFLT_MASK, filter as u32)
+    }
+
+    /// Enable or disable the trigger digital filter.
+    pub fn set_trigger_filter_enabled(&self, enabled: bool) -> Result<(), Error> {
+        self.regs().cfgr().modify(|_, w| w.trgflt_en().bit(enabled));
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    /// Configure the external clock digital filter value.
+    pub fn set_clock_filter(&self, filter: ClockFilter) -> Result<(), Error> {
+        self.modify_cfgr_bits(CFGR_CKFLT_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_CKFLT_MASK, filter as u32)
+    }
+
+    /// Enable or disable the external clock digital filter.
+    pub fn set_clock_filter_enabled(&self, enabled: bool) -> Result<(), Error> {
+        self.regs().cfgr().modify(|_, w| w.ckflt_en().bit(enabled));
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    /// Configure external clock edge polarity.
+    pub fn set_clock_polarity(&self, polarity: ClockPolarity) -> Result<(), Error> {
+        self.modify_cfgr_bits(CFGR_CKPOL_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_CKPOL_MASK, polarity as u32)
+    }
+
+    /// Configure the counter clock prescaler.
+    pub fn set_prescaler(&self, prescaler: Prescaler) -> Result<(), Error> {
+        self.modify_cfgr_bits(CFGR_PRESC_MASK, 0)?;
+        self.modify_cfgr_bits(CFGR_PRESC_MASK, prescaler as u32)
+    }
+
+    /// Enable or disable interrupt sources and unmask the NVIC vector when any
+    /// source is enabled.
+    pub fn set_interrupt_enabled(&self, flags: InterruptFlags, enabled: bool) {
+        let mask = flags.bits();
+        self.regs().ier().modify(|r, w| unsafe {
+            let bits = if enabled { r.bits() | mask } else { r.bits() & !mask };
+            w.bits(bits)
+        });
+
+        if self.regs().ier().read().bits() & IT_MASK != 0 {
+            T::nv_interrupt().unpend();
+            unsafe { T::nv_interrupt().enable() };
+        } else {
+            T::nv_interrupt().disable();
+        }
+    }
+
+    /// Clear interrupt status bits (vendor `lptimer_clear_interrupt` + CSR wait).
+    pub fn clear_interrupt(&self, flags: InterruptFlags) -> Result<(), Error> {
+        let mask = flags.bits();
+        unsafe {
+            self.regs().icr().write_with_zero(|w| w.bits(mask));
+        }
+
+        let csr_mask = interrupt_to_csr(mask);
+        if csr_mask == 0 {
+            return Ok(());
+        }
+
+        for _ in 0..POLL_LIMIT {
+            if self.regs().csr().read().bits() & csr_mask == csr_mask {
+                return Ok(());
+            }
+            core::hint::spin_loop();
+        }
+        Err(Error::Timeout(TimeoutTarget::ClearStatus))
+    }
+
+    /// Raw `SR1` interrupt status bits that are set.
+    pub fn interrupt_status(&self) -> InterruptFlags {
+        InterruptFlags(self.regs().sr1().read().bits() & IT_MASK)
+    }
+
+    /// Raw sticky `ISR` flags (includes CFGROK/CROK/CMPOK/ARROK).
+    pub fn status(&self) -> u32 {
+        self.regs().isr().read().bits()
+    }
+
+    /// Wait until any of `flags` is reported by [`InterruptHandler`].
+    ///
+    /// The handler clears the hardware status; this future consumes the latched
+    /// software pending bits for `flags`.
+    pub async fn wait_for(&self, flags: InterruptFlags) -> InterruptFlags {
+        let mask = flags.bits();
+        poll_fn(|cx| {
+            WAKERS[T::INDEX].register(cx.waker());
+
+            let latched = PENDING[T::INDEX].load(Ordering::Acquire) & mask;
+            if latched != 0 {
+                PENDING[T::INDEX].fetch_and(!latched, Ordering::AcqRel);
+                return Poll::Ready(InterruptFlags(latched));
+            }
+
+            let live = self.regs().sr1().read().bits() & mask;
+            if live != 0 {
+                // Handler has not run yet; clear in software path as the SDK does.
+                let _ = self.clear_interrupt(InterruptFlags(live));
+                PENDING[T::INDEX].fetch_and(!live, Ordering::AcqRel);
+                return Poll::Ready(InterruptFlags(live));
+            }
+
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Mux a documented `IN1` pin to this timer and return the owned GPIO wrap.
+    pub fn take_in1_pin(&self, pin: Peri<'d, impl In1Pin<T>>) -> Flex<'d> {
+        configure_af(pin)
+    }
+
+    /// Mux a documented `IN2` pin to this timer and return the owned GPIO wrap.
+    pub fn take_in2_pin(&self, pin: Peri<'d, impl In2Pin<T>>) -> Flex<'d> {
+        configure_af(pin)
+    }
+
+    /// Mux a documented `ETR` pin to this timer and return the owned GPIO wrap.
+    pub fn take_etr_pin(&self, pin: Peri<'d, impl EtrPin<T>>) -> Flex<'d> {
+        configure_af(pin)
+    }
+
+    fn modify_cfgr_bits(&self, mask: u32, value: u32) -> Result<(), Error> {
+        self.regs()
+            .cfgr()
+            .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value & mask)) });
+        wait_isr::<T>(ISR_CFGROK, TimeoutTarget::Cfgrok)
+    }
+
+    #[inline]
+    fn regs(&self) -> &'static pac::lptimer0::RegisterBlock {
+        T::regs()
+    }
+}
+
+impl<'d, T: Instance> Drop for LpTimer<'d, T> {
+    fn drop(&mut self) {
+        T::nv_interrupt().disable();
+        let _ = self.set_enabled(false);
+        let _ = rcc::disable_peripheral(T::rcc_peripheral());
+        let _ = rcc::reset_peripheral(T::rcc_peripheral());
+    }
+}
+
+fn configure_af<'d, P>(pin: Peri<'d, P>) -> Flex<'d>
+where
+    P: gpio::Pin + sealed::AfPin,
+{
+    let af = P::AF;
+    let mut flex = Flex::new(pin);
+    flex.set_alternate_function(af);
+    flex
+}
+
+fn interrupt_to_csr(flags: u32) -> u32 {
+    let mut csr = 0;
+    if flags & ISR_CMPM != 0 {
+        csr |= CSR_CMPM;
+    }
+    if flags & ISR_ARRM != 0 {
+        csr |= CSR_ARRM;
+    }
+    if flags & ISR_EXTTRIG != 0 {
+        csr |= CSR_EXTTRIG;
+    }
+    if flags & ISR_UP != 0 {
+        csr |= CSR_UP;
+    }
+    if flags & ISR_DOWN != 0 {
+        csr |= CSR_DOWN;
+    }
+    csr
+}
+
+fn wait_isr<T: Instance>(mask: u32, target: TimeoutTarget) -> Result<(), Error> {
+    for _ in 0..POLL_LIMIT {
+        if T::regs().isr().read().bits() & mask == mask {
+            return Ok(());
+        }
+        core::hint::spin_loop();
+    }
+    if T::regs().isr().read().bits() & mask == mask {
+        Ok(())
+    } else {
+        Err(Error::Timeout(target))
+    }
+}
+
+fn set_instance_clock_source<T: Instance>(source: ClockSource) -> Result<(), Error> {
+    if T::clock_source_sync() {
+        // Vendor disables the functional clock before changing CR1.
+        T::gate_functional_clock(false);
+
+        for _ in 0..POLL_LIMIT {
+            if !T::clock_source_sync() {
+                break;
+            }
+            core::hint::spin_loop();
+        }
+        if T::clock_source_sync() {
+            return Err(Error::Timeout(TimeoutTarget::ClockSourceSync));
+        }
+    }
+
+    T::set_clock_source(source);
+    Ok(())
+}
+
+/// Documented LPTIMER `IN1` pin for an instance.
+pub trait In1Pin<T: Instance>: gpio::Pin + sealed::AfPin {}
+/// Documented LPTIMER `IN2` pin for an instance.
+pub trait In2Pin<T: Instance>: gpio::Pin + sealed::AfPin {}
+/// Documented LPTIMER `ETR` pin for an instance.
+pub trait EtrPin<T: Instance>: gpio::Pin + sealed::AfPin {}
+
+macro_rules! impl_lptimer0_pin {
+    ($trait:ident, $pin:ident, $af:ident) => {
+        impl sealed::AfPin for peripherals::$pin {
+            const AF: AlternateFunction = AlternateFunction::$af;
+        }
+        impl $trait<peripherals::LPTIMER0> for peripherals::$pin {}
+    };
+}
+
+// SDK examples (ASR6601SE/CB EVAL):
+//   GPIOD PIN10 AF2 = IN1 (GP58)
+//   GPIOD PIN12 AF5 = IN2 (GP60)
+//   GPIOD PIN14 AF3 = ETR (GP62)
+// No LPTIMER1 or OUT routes are documented by the vendor examples.
+impl_lptimer0_pin!(In1Pin, PD10, Function2);
+impl_lptimer0_pin!(In2Pin, PD12, Function5);
+impl_lptimer0_pin!(EtrPin, PD14, Function3);
+
+/// Alternate-function numbers documented by the LPTIMER0 SDK examples.
+pub mod af {
+    use crate::gpio::AlternateFunction;
+
+    /// `PD10` / GP58 as LPTIMER0 IN1.
+    pub const LPTIMER0_IN1: AlternateFunction = AlternateFunction::Function2;
+    /// `PD12` / GP60 as LPTIMER0 IN2.
+    pub const LPTIMER0_IN2: AlternateFunction = AlternateFunction::Function5;
+    /// `PD14` / GP62 as LPTIMER0 ETR.
+    pub const LPTIMER0_ETR: AlternateFunction = AlternateFunction::Function3;
+}

--- a/embassy-asr/src/lpuart.rs
+++ b/embassy-asr/src/lpuart.rs
@@ -1,0 +1,1262 @@
+//! Low-power UART (LPUART) driver for the ASR6601.
+//!
+//! Register programming follows the vendor `tremo_lpuart` driver. Pin mux
+//! numbers are supplied explicitly by the caller as `(pin, AlternateFunction)`
+//! pairs; see [`pins`] for the datasheet mappings used by the SDK examples.
+//!
+//! # Clocking
+//!
+//! LPUART is clocked from the always-on domain (`XO32K`, `RCO32K`, or
+//! `RCO4M`). Select the source with [`Config::clock_source`]. The selected
+//! oscillator must already be running; this driver does not power oscillators.
+//! With `time-driver-rtc`, `XO32K` is typically already enabled by
+//! [`crate::init`].
+//!
+//! # Wakeup (STOP)
+//!
+//! The SDK exposes three mutually exclusive CR0 wakeup enables (see
+//! [`Wakeup`]). The `lpuart_wakeup_stop` example enables
+//! [`Wakeup::LowLevel`] and then enters STOP3; the LoRaWAN AT path uses
+//! [`Wakeup::RxDone`] with the RX-done interrupt. Wakeup only affects the
+//! CR0 enable bits — entering STOP is done through the power driver.
+//!
+//! # Unsafe contracts
+//!
+//! - [`InterruptHandler::on_interrupt`] may be called only from the vector
+//!   bound through [`crate::bind_interrupts!`] for [`InterruptHandler`].
+//! - DMA helpers require exclusive channel ownership and a buffer that stays
+//!   valid and DMA-accessible until the call returns.
+//! - Constructing a driver steals the PAC LPUART block. The owned [`Peri`]
+//!   token is the exclusivity proof; do not also use `pac::Lpuart::steal()`
+//!   from application code while the driver is alive.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicU8, Ordering, compiler_fence};
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::Priority;
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::dma::{self, Channel as DmaChannel, Request, TransferOptions};
+use crate::gpio::{AlternateFunction, AnyPin, Flex, Pin};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::pac::lpuart::RegisterBlock;
+use crate::rcc::{self, Peripheral};
+use crate::{interrupt, pac, peripherals};
+
+const BAUD_INT_POS: u32 = 10;
+const BAUD_FRA_POS: u32 = 6;
+const BAUD_INT_MAX: u32 = 0x0fff;
+
+const SR0_START_INVALID: u32 = 1 << 2;
+const SR0_PARITY_ERR: u32 = 1 << 3;
+const SR0_STOP_ERR: u32 = 1 << 4;
+const SR0_RX_OVERFLOW: u32 = 1 << 5;
+const SR0_RX_ERRORS: u32 = SR0_START_INVALID | SR0_PARITY_ERR | SR0_STOP_ERR | SR0_RX_OVERFLOW;
+
+const SR1_WRITE_SR0: u32 = 1 << 1;
+const SR1_WRITE_CR0: u32 = 1 << 2;
+const SR1_RX_NOT_EMPTY: u32 = 1 << 3;
+const SR1_TX_EMPTY: u32 = 1 << 4;
+const SR1_TX_DONE: u32 = 1 << 5;
+
+const CR1_RX_DONE_INT: u32 = 1 << 1;
+const CR1_START_INVALID_INT: u32 = 1 << 2;
+const CR1_PARITY_ERR_INT: u32 = 1 << 3;
+const CR1_STOP_ERR_INT: u32 = 1 << 4;
+const CR1_RX_OVERFLOW_INT: u32 = 1 << 5;
+const CR1_RX_NOT_EMPTY_INT: u32 = 1 << 6;
+const CR1_TX_EMPTY_INT: u32 = 1 << 7;
+const CR1_TX_DONE_INT: u32 = 1 << 8;
+const CR1_RX_INTS: u32 = CR1_RX_DONE_INT
+    | CR1_START_INVALID_INT
+    | CR1_PARITY_ERR_INT
+    | CR1_STOP_ERR_INT
+    | CR1_RX_OVERFLOW_INT
+    | CR1_RX_NOT_EMPTY_INT;
+const CR1_TX_INTS: u32 = CR1_TX_EMPTY_INT | CR1_TX_DONE_INT;
+
+const RCO4M_HZ: u32 = 3_600_000;
+const LOW_SPEED_HZ: u32 = 32_768;
+
+static STATE: State = State::new();
+
+struct State {
+    tx_waker: AtomicWaker,
+    rx_waker: AtomicWaker,
+    /// Number of live [`LpuartTx`] / [`LpuartRx`] halves.
+    refcount: AtomicU8,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            tx_waker: AtomicWaker::new(),
+            rx_waker: AtomicWaker::new(),
+            refcount: AtomicU8::new(0),
+        }
+    }
+}
+
+struct Info {
+    base: usize,
+    rcc: Peripheral,
+    dma_tx: Request,
+    dma_rx: Request,
+    state: &'static State,
+}
+
+impl Info {
+    fn regs(&self) -> &'static RegisterBlock {
+        unsafe { &*(self.base as *const RegisterBlock) }
+    }
+}
+
+/// LPUART interrupt handler.
+pub struct InterruptHandler {
+    _private: (),
+}
+
+impl Handler<interrupt::typelevel::LPUART> for InterruptHandler {
+    unsafe fn on_interrupt() {
+        let info = info();
+        let regs = info.regs();
+        let cr1 = regs.cr1().read().bits();
+        let sr0 = read_sr0(regs);
+        let sr1 = regs.sr1().read().bits();
+
+        let tx_pending = (cr1 & CR1_TX_EMPTY_INT != 0 && sr1 & SR1_TX_EMPTY != 0)
+            || (cr1 & CR1_TX_DONE_INT != 0 && sr1 & SR1_TX_DONE != 0);
+        if tx_pending {
+            set_cr1_bits(regs, CR1_TX_INTS, false);
+            info.state.tx_waker.wake();
+        }
+
+        let rx_pending = (cr1 & CR1_RX_NOT_EMPTY_INT != 0 && sr1 & SR1_RX_NOT_EMPTY != 0)
+            || (cr1 & CR1_RX_DONE_INT != 0 && sr0 & (1 << 1) != 0)
+            || (cr1 & CR1_START_INVALID_INT != 0 && sr0 & SR0_START_INVALID != 0)
+            || (cr1 & CR1_PARITY_ERR_INT != 0 && sr0 & SR0_PARITY_ERR != 0)
+            || (cr1 & CR1_STOP_ERR_INT != 0 && sr0 & SR0_STOP_ERR != 0)
+            || (cr1 & CR1_RX_OVERFLOW_INT != 0 && sr0 & SR0_RX_OVERFLOW != 0);
+        if rx_pending {
+            set_cr1_bits(regs, CR1_RX_INTS, false);
+            info.state.rx_waker.wake();
+        }
+    }
+}
+
+/// Documented datasheet / SDK LPUART pin mux values.
+///
+/// Pass these with the matching pad to constructors, for example
+/// `(p.PC15, pins::TX_PC15)`.
+pub mod pins {
+    use crate::gpio::AlternateFunction;
+
+    /// `GPIO47` / `PC15` AF2 — `LPUART_TX` (SDK `lpuart_txrx` example).
+    pub const TX_PC15: AlternateFunction = AlternateFunction::Function2;
+
+    /// `GPIO60` / `PD12` AF2 — `LPUART_RX` (SDK examples).
+    pub const RX_PD12: AlternateFunction = AlternateFunction::Function2;
+
+    /// `GPIO62` / `PD14` AF2 — `LPUART_RX`.
+    pub const RX_PD14: AlternateFunction = AlternateFunction::Function2;
+
+    /// `GPIO58` / `PD10` AF5 — `LPUART_RX`.
+    pub const RX_PD10: AlternateFunction = AlternateFunction::Function5;
+
+    /// `GPIO59` / `PD11` AF5 — `LPUART_RTS`.
+    ///
+    /// The datasheet does not list an `LPUART_CTS` mux entry.
+    pub const RTS_PD11: AlternateFunction = AlternateFunction::Function5;
+}
+
+/// Number of data bits (`lpuart_data_width_t`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DataBits {
+    /// 5 data bits.
+    DataBits5,
+    /// 6 data bits.
+    DataBits6,
+    /// 7 data bits.
+    DataBits7,
+    /// 8 data bits.
+    DataBits8,
+}
+
+impl DataBits {
+    const fn cr0_bits(self) -> u32 {
+        match self {
+            Self::DataBits5 => 0,
+            Self::DataBits6 => 1,
+            Self::DataBits7 => 2,
+            Self::DataBits8 => 3,
+        }
+    }
+}
+
+/// Parity selection (`lpuart_parity_t`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Parity {
+    /// Even parity (`LPUART_PARITY_EVEN`).
+    Even,
+    /// Odd parity (`LPUART_PARITY_ODD`).
+    Odd,
+    /// Sticky 0 parity (`LPUART_PARITY_STICK_0`).
+    Stick0,
+    /// Sticky 1 parity (`LPUART_PARITY_STICK_1`).
+    Stick1,
+    /// No parity (`LPUART_PARITY_NONE`).
+    None,
+}
+
+impl Parity {
+    const fn cr0_bits(self) -> u32 {
+        match self {
+            Self::Even => 0x0,
+            Self::Odd => 0x4,
+            Self::Stick0 => 0x8,
+            Self::Stick1 => 0xc,
+            Self::None => 0x1c,
+        }
+    }
+}
+
+/// Number of stop bits (`lpuart_stop_bits_t`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum StopBits {
+    /// One stop bit.
+    STOP1,
+    /// Two stop bits.
+    STOP2,
+}
+
+impl StopBits {
+    const fn cr0_bits(self) -> u32 {
+        match self {
+            Self::STOP1 => 0x0,
+            Self::STOP2 => 0x20,
+        }
+    }
+}
+
+/// Hardware flow control.
+///
+/// RTS has a documented pin mux ([`pins::RTS_PD11`]). The datasheet does not
+/// list an `LPUART_CTS` pad; CTS can still be enabled in CR1 if the board
+/// wires a CTS input through an undocumented mux.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FlowControl {
+    /// No RTS/CTS.
+    None,
+    /// RTS only (`LPUART_CR0_RTS_ENABLE`).
+    Rts,
+    /// CTS only (`LPUART_CR1_CTS_ENABLE`).
+    Cts,
+    /// RTS and CTS.
+    RtsCts,
+}
+
+/// CR0 wakeup source (`lpuart_init_t` wakeup flags).
+///
+/// The vendor `lpuart_init` treats these as mutually exclusive (`if` /
+/// `else if`). At most one bit is programmed into CR0.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Wakeup {
+    /// No wakeup enable bit.
+    #[default]
+    None,
+    /// `LPUART_CR0_LOW_LEVEL_WAKEUP` — wake on RX low level.
+    ///
+    /// Used by `projects/*/examples/lpuart/lpuart_wakeup_stop` before
+    /// `pwr_deepsleep_wfi(PWR_LP_MODE_STOP3)`.
+    LowLevel,
+    /// `LPUART_CR0_START_WAKEUP` — wake on a start bit.
+    StartBit,
+    /// `LPUART_CR0_RX_DONE_WAKEUP` — wake when a character reception completes.
+    ///
+    /// Used by `projects/*/examples/lorawan/lorawan_at` together with the
+    /// RX-done interrupt (`LPUART_CR1_RX_DONE_INT`).
+    RxDone,
+}
+
+impl Wakeup {
+    const fn cr0_bits(self) -> u32 {
+        match self {
+            Self::None => 0,
+            Self::LowLevel => 1 << 22,
+            Self::StartBit => 1 << 23,
+            Self::RxDone => 1 << 24,
+        }
+    }
+}
+
+/// LPUART functional clock source (`rcc_lpuart_clk_source_t`).
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Default)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ClockSource {
+    /// External 32.768 kHz crystal (`RCC_LPUART_CLK_SOURCE_XO32K`).
+    #[default]
+    Xo32k,
+    /// Internal 32.768 kHz RC (`RCC_LPUART_CLK_SOURCE_RCO32K`).
+    Rco32k,
+    /// Internal RC reported as 3.6 MHz by the vendor (`RCC_LPUART_CLK_SOURCE_RCO4M`).
+    Rco4m,
+}
+
+impl ClockSource {
+    const fn frequency_hz(self) -> u32 {
+        match self {
+            Self::Xo32k | Self::Rco32k => LOW_SPEED_HZ,
+            Self::Rco4m => RCO4M_HZ,
+        }
+    }
+
+    const fn sel_bits(self) -> u8 {
+        match self {
+            Self::Xo32k => 0,
+            Self::Rco32k => 1,
+            Self::Rco4m => 2,
+        }
+    }
+}
+
+/// Baud rates listed as macros in `tremo_lpuart.h`.
+///
+/// Other rates are accepted when they fit the baud divider; these constants
+/// match the SDK naming.
+pub mod baudrate {
+    /// 110 baud.
+    pub const B110: u32 = 110;
+    /// 300 baud.
+    pub const B300: u32 = 300;
+    /// 600 baud.
+    pub const B600: u32 = 600;
+    /// 1200 baud.
+    pub const B1200: u32 = 1200;
+    /// 2400 baud.
+    pub const B2400: u32 = 2400;
+    /// 4800 baud.
+    pub const B4800: u32 = 4800;
+    /// 9600 baud (default in SDK examples).
+    pub const B9600: u32 = 9600;
+}
+
+/// LPUART configuration.
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Baud rate in bits per second.
+    pub baudrate: u32,
+    /// Number of data bits.
+    pub data_bits: DataBits,
+    /// Parity.
+    pub parity: Parity,
+    /// Number of stop bits.
+    pub stop_bits: StopBits,
+    /// Hardware flow control.
+    pub flow_control: FlowControl,
+    /// STOP / deep-sleep wakeup source programmed into CR0.
+    pub wakeup: Wakeup,
+    /// Functional clock source used for baud generation.
+    pub clock_source: ClockSource,
+}
+
+impl Config {
+    /// Create a 9600 8N1 configuration matching the SDK examples.
+    pub const fn new() -> Self {
+        Self {
+            baudrate: baudrate::B9600,
+            data_bits: DataBits::DataBits8,
+            parity: Parity::None,
+            stop_bits: StopBits::STOP1,
+            flow_control: FlowControl::None,
+            wakeup: Wakeup::None,
+            clock_source: ClockSource::Xo32k,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Configuration error.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ConfigError {
+    /// Baud rate cannot be represented for the selected LPUART clock.
+    Baudrate,
+    /// Neither an RX nor a TX pin was supplied.
+    NoRxOrTx,
+    /// Flow-control pins required by [`Config::flow_control`] were missing.
+    MissingFlowControlPin,
+    /// Enabling, resetting, or selecting the LPUART clock failed.
+    Rcc(rcc::Error),
+}
+
+/// LPUART transfer / framing error.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// RX overflow (`LPUART_SR0_RX_OVERFLOW_STATE`).
+    Overrun,
+    /// Stop-bit error (`LPUART_SR0_STOP_ERR_STATE`).
+    Framing,
+    /// Parity error (`LPUART_SR0_PARITY_ERR_STATE`).
+    Parity,
+    /// Invalid start condition (`LPUART_SR0_START_INVALID_STATE`).
+    StartInvalid,
+    /// DMA helper failed.
+    Dma(dma::Error),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Overrun => write!(f, "LPUART overrun"),
+            Self::Framing => write!(f, "LPUART framing error"),
+            Self::Parity => write!(f, "LPUART parity error"),
+            Self::StartInvalid => write!(f, "LPUART start invalid"),
+            Self::Dma(_) => write!(f, "LPUART DMA error"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        match self {
+            Self::Overrun => embedded_io::ErrorKind::OutOfMemory,
+            Self::Framing | Self::Parity | Self::StartInvalid => embedded_io::ErrorKind::InvalidData,
+            Self::Dma(_) => embedded_io::ErrorKind::Other,
+        }
+    }
+}
+
+fn info() -> &'static Info {
+    static INFO: Info = Info {
+        base: 0x4000_5000,
+        rcc: Peripheral::Lpuart,
+        dma_tx: Request::LpuartTx,
+        dma_rx: Request::LpuartRx,
+        state: &STATE,
+    };
+    &INFO
+}
+
+fn erase_pin<'d>(
+    pin: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+) -> Option<(Peri<'d, AnyPin>, AlternateFunction)> {
+    pin.map(|(p, af)| (p.into(), af))
+}
+
+fn configure_pin(pin: Peri<'_, impl Pin>, af: AlternateFunction, output: bool) -> Peri<'_, AnyPin> {
+    let mut flex = Flex::new(pin);
+    if output {
+        flex.set_as_output();
+    } else {
+        flex.set_as_input();
+    }
+    flex.set_alternate_function(af);
+    flex.into_inner()
+}
+
+fn wait_cr0_writable(regs: &RegisterBlock) {
+    while regs.sr1().read().bits() & (SR1_WRITE_SR0 | SR1_WRITE_CR0) != (SR1_WRITE_SR0 | SR1_WRITE_CR0) {}
+}
+
+fn wait_sr0_readable(regs: &RegisterBlock) {
+    while regs.sr1().read().bits() & SR1_WRITE_SR0 == 0 {}
+}
+
+fn read_sr0(regs: &RegisterBlock) -> u32 {
+    wait_sr0_readable(regs);
+    regs.sr0().read().bits()
+}
+
+fn clear_sr0(regs: &RegisterBlock, mask: u32) {
+    wait_cr0_writable(regs);
+    unsafe {
+        regs.sr0().write_with_zero(|w| w.bits(mask));
+    }
+    wait_cr0_writable(regs);
+}
+
+fn write_cr0(regs: &RegisterBlock, value: u32) {
+    wait_cr0_writable(regs);
+    unsafe {
+        regs.cr0().write_with_zero(|w| w.bits(value));
+    }
+    wait_cr0_writable(regs);
+}
+
+fn modify_cr0(regs: &RegisterBlock, clear: u32, set: u32) {
+    wait_cr0_writable(regs);
+    let value = (regs.cr0().read().bits() & !clear) | set;
+    unsafe {
+        regs.cr0().write_with_zero(|w| w.bits(value));
+    }
+    wait_cr0_writable(regs);
+}
+
+fn set_cr1_bits(regs: &RegisterBlock, mask: u32, enable: bool) {
+    let value = regs.cr1().read().bits();
+    let value = if enable { value | mask } else { value & !mask };
+    unsafe {
+        regs.cr1().write_with_zero(|w| w.bits(value));
+    }
+}
+
+fn calc_baud(freq: u32, baud: u32) -> Option<(u32, u32)> {
+    if baud == 0 || freq < baud {
+        return None;
+    }
+    let ibaud = freq / baud;
+    if ibaud > BAUD_INT_MAX {
+        return None;
+    }
+    // Vendor: fbaud = ((freq % baud) * 16 + baud / 2) / baud
+    let fbaud = ((freq % baud) * 16 + baud / 2) / baud;
+    Some((ibaud, fbaud & 0xf))
+}
+
+fn set_clock_source(source: ClockSource) {
+    // Mirror `rcc_set_lpuart_clk_source`: only the functional CGR0 gate must be
+    // off while the selector is written (AON stays untouched).
+    critical_section::with(|_| {
+        let rcc_regs = unsafe { pac::Rcc::steal() };
+        if rcc_regs.sr1().read().lpuart_clk_en_sync().bit_is_set() {
+            rcc_regs.cgr0().modify(|_, w| w.lpuart_clk_en().clear_bit());
+        }
+    });
+    while unsafe { pac::Rcc::steal() }
+        .sr1()
+        .read()
+        .lpuart_clk_en_sync()
+        .bit_is_set()
+    {}
+
+    critical_section::with(|_| {
+        let rcc_regs = unsafe { pac::Rcc::steal() };
+        rcc_regs.cr1().modify(|r, w| {
+            let bits = (r.bits() & !0xc) | (u32::from(source.sel_bits()) << 2);
+            unsafe { w.bits(bits) }
+        });
+    });
+}
+
+fn enable_clock(source: ClockSource) -> Result<(), ConfigError> {
+    set_clock_source(source);
+    rcc::enable_peripheral(Peripheral::Lpuart).map_err(ConfigError::Rcc)?;
+    rcc::reset_peripheral(Peripheral::Lpuart).map_err(ConfigError::Rcc)?;
+    Ok(())
+}
+
+fn apply_config(regs: &RegisterBlock, config: Config) -> Result<(), ConfigError> {
+    let (ibaud, fbaud) = calc_baud(config.clock_source.frequency_hz(), config.baudrate).ok_or(ConfigError::Baudrate)?;
+
+    let cr0 = (ibaud << BAUD_INT_POS)
+        | (fbaud << BAUD_FRA_POS)
+        | config.stop_bits.cr0_bits()
+        | config.parity.cr0_bits()
+        | config.data_bits.cr0_bits()
+        | config.wakeup.cr0_bits();
+
+    // Baud / frame / wakeup live in CR0; PAC field accessors cover only the
+    // wakeup and RX/RTS enables, so the frame fields are written as raw bits.
+    write_cr0(regs, cr0);
+
+    let rts = matches!(config.flow_control, FlowControl::Rts | FlowControl::RtsCts);
+    let cts = matches!(config.flow_control, FlowControl::Cts | FlowControl::RtsCts);
+    if rts {
+        modify_cr0(regs, 0, 1 << 26);
+    }
+    set_cr1_bits(regs, 1 << 12, cts);
+
+    Ok(())
+}
+
+fn set_rx_enable(regs: &RegisterBlock, enable: bool) {
+    if enable {
+        modify_cr0(regs, 0, 1 << 25);
+    } else {
+        modify_cr0(regs, 1 << 25, 0);
+    }
+}
+
+fn set_tx_enable(regs: &RegisterBlock, enable: bool) {
+    set_cr1_bits(regs, 1 << 9, enable);
+}
+
+fn set_dma_req(regs: &RegisterBlock, tx: bool, enable: bool) {
+    set_cr1_bits(regs, if tx { 1 << 10 } else { 1 << 11 }, enable);
+}
+
+fn shutdown(info: &'static Info) {
+    let regs = info.regs();
+    set_tx_enable(regs, false);
+    set_rx_enable(regs, false);
+    set_cr1_bits(regs, CR1_TX_INTS | CR1_RX_INTS | (1 << 10) | (1 << 11), false);
+    let _ = rcc::disable_peripheral(info.rcc);
+}
+
+fn take_rx_errors(regs: &RegisterBlock) -> Result<(), Error> {
+    let sr0 = read_sr0(regs);
+    let errors = sr0 & SR0_RX_ERRORS;
+    if errors == 0 {
+        return Ok(());
+    }
+    clear_sr0(regs, errors);
+    if errors & SR0_RX_OVERFLOW != 0 {
+        return Err(Error::Overrun);
+    }
+    if errors & SR0_PARITY_ERR != 0 {
+        return Err(Error::Parity);
+    }
+    if errors & SR0_STOP_ERR != 0 {
+        return Err(Error::Framing);
+    }
+    Err(Error::StartInvalid)
+}
+
+fn rx_not_empty(regs: &RegisterBlock) -> bool {
+    regs.sr1().read().bits() & SR1_RX_NOT_EMPTY != 0
+}
+
+fn tx_empty(regs: &RegisterBlock) -> bool {
+    regs.sr1().read().bits() & SR1_TX_EMPTY != 0
+}
+
+fn tx_done(regs: &RegisterBlock) -> bool {
+    regs.sr1().read().bits() & SR1_TX_DONE != 0
+}
+
+fn clear_tx_done(regs: &RegisterBlock) {
+    // Vendor `lpuart_clear_tx_done_status` sets the TX_DONE bit in SR1.
+    regs.sr1().modify(|r, w| unsafe { w.bits(r.bits() | SR1_TX_DONE) });
+}
+
+fn read_data(regs: &RegisterBlock) -> u8 {
+    regs.data().read().bits() as u8
+}
+
+fn write_data(regs: &RegisterBlock, byte: u8) {
+    unsafe {
+        regs.data().write_with_zero(|w| w.bits(u32::from(byte)));
+    }
+}
+
+/// Bidirectional LPUART driver.
+pub struct Lpuart<'d, M: Mode> {
+    tx: LpuartTx<'d, M>,
+    rx: LpuartRx<'d, M>,
+}
+
+/// Transmit half of an LPUART.
+pub struct LpuartTx<'d, M: Mode> {
+    info: &'static Info,
+    _pin: Option<Peri<'d, AnyPin>>,
+    _rts: Option<Peri<'d, AnyPin>>,
+    _mode: PhantomData<&'d mut M>,
+}
+
+/// Receive half of an LPUART.
+pub struct LpuartRx<'d, M: Mode> {
+    info: &'static Info,
+    _pin: Option<Peri<'d, AnyPin>>,
+    _cts: Option<Peri<'d, AnyPin>>,
+    _mode: PhantomData<&'d mut M>,
+}
+
+impl<'d> Lpuart<'d, Blocking> {
+    /// Create a blocking LPUART.
+    ///
+    /// `rx` / `tx` are `(pin, alternate_function)` pairs. See [`pins`] for the
+    /// datasheet AF numbers. Supply `None` for unused directions.
+    pub fn new_blocking(
+        peri: Peri<'d, peripherals::LPUART>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(peri, erase_pin(rx), erase_pin(tx), None, None, config, false)
+    }
+
+    /// Create a blocking LPUART with explicit RTS/CTS pins and AF selectors.
+    pub fn new_blocking_with_flow_control(
+        peri: Peri<'d, peripherals::LPUART>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        rts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        cts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            erase_pin(rx),
+            erase_pin(tx),
+            erase_pin(rts),
+            erase_pin(cts),
+            config,
+            false,
+        )
+    }
+}
+
+impl<'d> Lpuart<'d, Async> {
+    /// Create an interrupt-driven asynchronous LPUART.
+    ///
+    /// `irq` proves the LPUART vector is bound to [`InterruptHandler`].
+    pub fn new(
+        peri: Peri<'d, peripherals::LPUART>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        _irq: impl Binding<interrupt::typelevel::LPUART, InterruptHandler> + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(peri, erase_pin(rx), erase_pin(tx), None, None, config, true)
+    }
+
+    /// Create an asynchronous LPUART with explicit RTS/CTS pins and AF selectors.
+    pub fn new_with_flow_control(
+        peri: Peri<'d, peripherals::LPUART>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        rts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        cts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        _irq: impl Binding<interrupt::typelevel::LPUART, InterruptHandler> + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            erase_pin(rx),
+            erase_pin(tx),
+            erase_pin(rts),
+            erase_pin(cts),
+            config,
+            true,
+        )
+    }
+
+    /// Write `buffer` using interrupt-driven TX.
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.write(buffer).await
+    }
+
+    /// Read into `buffer` until it is full using interrupt-driven RX.
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.read(buffer).await
+    }
+
+    /// Wait until the last byte has left the transmitter (`TX_DONE`).
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.tx.flush().await
+    }
+
+    /// Write `buffer` with a DMA channel (memory-to-peripheral).
+    pub async fn write_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.write_dma(channel, buffer).await
+    }
+
+    /// Read `buffer.len()` bytes with a DMA channel (peripheral-to-memory).
+    pub async fn read_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.read_dma(channel, buffer).await
+    }
+}
+
+impl<'d, M: Mode> Lpuart<'d, M> {
+    fn new_inner(
+        _peri: Peri<'d, peripherals::LPUART>,
+        rx: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        rts: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        cts: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        config: Config,
+        enable_irq: bool,
+    ) -> Result<Self, ConfigError> {
+        match config.flow_control {
+            FlowControl::Rts if rts.is_none() => return Err(ConfigError::MissingFlowControlPin),
+            FlowControl::Cts if cts.is_none() => return Err(ConfigError::MissingFlowControlPin),
+            FlowControl::RtsCts if rts.is_none() || cts.is_none() => {
+                return Err(ConfigError::MissingFlowControlPin);
+            }
+            _ => {}
+        }
+
+        let has_rx = rx.is_some();
+        let has_tx = tx.is_some();
+        if !has_rx && !has_tx {
+            return Err(ConfigError::NoRxOrTx);
+        }
+
+        let info = info();
+        enable_clock(config.clock_source)?;
+
+        let rx_pin = rx.map(|(p, af)| configure_pin(p, af, false));
+        let tx_pin = tx.map(|(p, af)| configure_pin(p, af, true));
+        let rts_pin = rts.map(|(p, af)| configure_pin(p, af, true));
+        let cts_pin = cts.map(|(p, af)| configure_pin(p, af, false));
+
+        let regs = info.regs();
+        apply_config(regs, config)?;
+        set_tx_enable(regs, has_tx);
+        set_rx_enable(regs, has_rx);
+
+        info.state.refcount.store(2, Ordering::Release);
+
+        if enable_irq {
+            interrupt::typelevel::LPUART::unpend();
+            interrupt::typelevel::LPUART::set_priority(Priority::P3);
+            unsafe {
+                interrupt::typelevel::LPUART::enable();
+            }
+        }
+
+        Ok(Self {
+            tx: LpuartTx {
+                info,
+                _pin: tx_pin,
+                _rts: rts_pin,
+                _mode: PhantomData,
+            },
+            rx: LpuartRx {
+                info,
+                _pin: rx_pin,
+                _cts: cts_pin,
+                _mode: PhantomData,
+            },
+        })
+    }
+
+    /// Split into independent TX and RX drivers.
+    pub fn split(self) -> (LpuartTx<'d, M>, LpuartRx<'d, M>) {
+        (self.tx, self.rx)
+    }
+
+    /// Reborrow as independent TX and RX drivers.
+    pub fn split_ref(&mut self) -> (&mut LpuartTx<'d, M>, &mut LpuartRx<'d, M>) {
+        (&mut self.tx, &mut self.rx)
+    }
+
+    /// Blocking write of the entire buffer.
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.blocking_write(buffer)
+    }
+
+    /// Blocking read that fills the entire buffer.
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.blocking_read(buffer)
+    }
+
+    /// Blocking flush of the transmitter.
+    pub fn blocking_flush(&mut self) -> Result<(), Error> {
+        self.tx.blocking_flush()
+    }
+
+    /// Blocking DMA write.
+    pub fn blocking_write_dma(&mut self, channel: &mut DmaChannel<'_, Blocking>, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.blocking_write_dma(channel, buffer)
+    }
+
+    /// Blocking DMA read of `buffer.len()` bytes.
+    pub fn blocking_read_dma(
+        &mut self,
+        channel: &mut DmaChannel<'_, Blocking>,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        self.rx.blocking_read_dma(channel, buffer)
+    }
+}
+
+impl<'d, M: Mode> LpuartTx<'d, M> {
+    fn regs(&self) -> &'static RegisterBlock {
+        self.info.regs()
+    }
+
+    /// Blocking write of the entire buffer.
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        let regs = self.regs();
+        for &byte in buffer {
+            while !tx_empty(regs) {}
+            write_data(regs, byte);
+        }
+        Ok(())
+    }
+
+    /// Blocking flush: wait for `TX_DONE`, then clear it (SDK pattern).
+    pub fn blocking_flush(&mut self) -> Result<(), Error> {
+        let regs = self.regs();
+        // Idle with a cleared TX_DONE means nothing is in flight.
+        if tx_empty(regs) && !tx_done(regs) {
+            return Ok(());
+        }
+        while !tx_done(regs) {}
+        clear_tx_done(regs);
+        Ok(())
+    }
+
+    /// Blocking DMA write.
+    pub fn blocking_write_dma(&mut self, channel: &mut DmaChannel<'_, Blocking>, buffer: &[u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let dest = regs.data().as_ptr();
+        set_dma_req(regs, true, true);
+        let result = unsafe {
+            channel
+                .start_write(buffer, dest.cast::<u8>(), self.info.dma_tx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .blocking_wait()
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, true, false);
+        result
+    }
+}
+
+impl<'d> LpuartTx<'d, Async> {
+    /// Interrupt-driven write of the entire buffer.
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        let info = self.info;
+        let regs = info.regs();
+        for &byte in buffer {
+            poll_fn(|cx| {
+                if tx_empty(regs) {
+                    return Poll::Ready(());
+                }
+                info.state.tx_waker.register(cx.waker());
+                set_cr1_bits(regs, CR1_TX_EMPTY_INT, true);
+                if tx_empty(regs) {
+                    set_cr1_bits(regs, CR1_TX_EMPTY_INT, false);
+                    return Poll::Ready(());
+                }
+                Poll::Pending
+            })
+            .await;
+            write_data(regs, byte);
+        }
+        set_cr1_bits(regs, CR1_TX_EMPTY_INT, false);
+        Ok(())
+    }
+
+    /// Wait until `TX_DONE` is set, then clear it.
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        let info = self.info;
+        let regs = info.regs();
+        if tx_empty(regs) && !tx_done(regs) {
+            return Ok(());
+        }
+        poll_fn(|cx| {
+            if tx_done(regs) {
+                return Poll::Ready(());
+            }
+            info.state.tx_waker.register(cx.waker());
+            set_cr1_bits(regs, CR1_TX_DONE_INT, true);
+            if tx_done(regs) {
+                set_cr1_bits(regs, CR1_TX_DONE_INT, false);
+                return Poll::Ready(());
+            }
+            Poll::Pending
+        })
+        .await;
+        set_cr1_bits(regs, CR1_TX_DONE_INT, false);
+        clear_tx_done(regs);
+        Ok(())
+    }
+
+    /// DMA write using an async DMA channel.
+    pub async fn write_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &[u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let dest = regs.data().as_ptr();
+        set_dma_req(regs, true, true);
+        compiler_fence(Ordering::SeqCst);
+        let result = unsafe {
+            channel
+                .write(buffer, dest.cast::<u8>(), self.info.dma_tx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .await
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, true, false);
+        result
+    }
+}
+
+impl<'d, M: Mode> LpuartRx<'d, M> {
+    fn regs(&self) -> &'static RegisterBlock {
+        self.info.regs()
+    }
+
+    /// Blocking read that fills the entire buffer.
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        let regs = self.regs();
+        for slot in buffer.iter_mut() {
+            while !rx_not_empty(regs) {
+                take_rx_errors(regs)?;
+            }
+            take_rx_errors(regs)?;
+            *slot = read_data(regs);
+        }
+        Ok(())
+    }
+
+    /// Blocking DMA read of `buffer.len()` bytes.
+    pub fn blocking_read_dma(
+        &mut self,
+        channel: &mut DmaChannel<'_, Blocking>,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let src = regs.data().as_ptr();
+        set_dma_req(regs, false, true);
+        let result = unsafe {
+            channel
+                .start_read(src.cast::<u8>(), buffer, self.info.dma_rx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .blocking_wait()
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, false, false);
+        result
+    }
+
+    fn nb_read_byte(&mut self) -> Result<Option<u8>, Error> {
+        let regs = self.regs();
+        take_rx_errors(regs)?;
+        if !rx_not_empty(regs) {
+            Ok(None)
+        } else {
+            Ok(Some(read_data(regs)))
+        }
+    }
+}
+
+impl<'d> LpuartRx<'d, Async> {
+    async fn wait_rx_ready(&mut self) -> Result<(), Error> {
+        let info = self.info;
+        let regs = info.regs();
+        poll_fn(|cx| {
+            if let Err(e) = take_rx_errors(regs) {
+                return Poll::Ready(Err(e));
+            }
+            if rx_not_empty(regs) {
+                return Poll::Ready(Ok(()));
+            }
+            info.state.rx_waker.register(cx.waker());
+            set_cr1_bits(regs, CR1_RX_INTS, true);
+            if let Err(e) = take_rx_errors(regs) {
+                set_cr1_bits(regs, CR1_RX_INTS, false);
+                return Poll::Ready(Err(e));
+            }
+            if rx_not_empty(regs) {
+                set_cr1_bits(regs, CR1_RX_INTS, false);
+                return Poll::Ready(Ok(()));
+            }
+            Poll::Pending
+        })
+        .await?;
+        set_cr1_bits(regs, CR1_RX_INTS, false);
+        Ok(())
+    }
+
+    /// Interrupt-driven read that fills the entire buffer.
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        for slot in buffer.iter_mut() {
+            self.wait_rx_ready().await?;
+            take_rx_errors(self.regs())?;
+            *slot = read_data(self.regs());
+        }
+        Ok(())
+    }
+
+    /// DMA read of `buffer.len()` bytes.
+    pub async fn read_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &mut [u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let src = regs.data().as_ptr();
+        set_dma_req(regs, false, true);
+        compiler_fence(Ordering::SeqCst);
+        let result = unsafe {
+            channel
+                .read(src.cast::<u8>(), buffer, self.info.dma_rx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .await
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, false, false);
+        result
+    }
+}
+
+impl<'d, M: Mode> Drop for LpuartTx<'d, M> {
+    fn drop(&mut self) {
+        if self.info.state.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
+            shutdown(self.info);
+        }
+    }
+}
+
+impl<'d, M: Mode> Drop for LpuartRx<'d, M> {
+    fn drop(&mut self) {
+        if self.info.state.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
+            shutdown(self.info);
+        }
+    }
+}
+
+// --- embedded-io -----------------------------------------------------------
+
+impl<'d, M: Mode> embedded_io::ErrorType for Lpuart<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_io::ErrorType for LpuartTx<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_io::ErrorType for LpuartRx<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_io::Write for LpuartTx<'d, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.blocking_write(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush()
+    }
+}
+
+impl<'d, M: Mode> embedded_io::Write for Lpuart<'d, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.tx.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.tx.flush()
+    }
+}
+
+impl<'d, M: Mode> embedded_io::Read for LpuartRx<'d, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        while !rx_not_empty(self.regs()) {
+            take_rx_errors(self.regs())?;
+        }
+        let mut n = 0;
+        while n < buf.len() {
+            match self.nb_read_byte()? {
+                Some(b) => {
+                    buf[n] = b;
+                    n += 1;
+                }
+                None => break,
+            }
+        }
+        Ok(n)
+    }
+}
+
+impl<'d, M: Mode> embedded_io::Read for Lpuart<'d, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.rx.read(buf)
+    }
+}
+
+impl<'d> embedded_io_async::Write for LpuartTx<'d, Async> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        LpuartTx::write(self, buf).await?;
+        Ok(buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        LpuartTx::flush(self).await
+    }
+}
+
+impl<'d> embedded_io_async::Write for Lpuart<'d, Async> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        Lpuart::write(self, buf).await?;
+        Ok(buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Lpuart::flush(self).await
+    }
+}
+
+impl<'d> embedded_io_async::Read for LpuartRx<'d, Async> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        self.wait_rx_ready().await?;
+        let mut n = 0;
+        while n < buf.len() {
+            match self.nb_read_byte()? {
+                Some(b) => {
+                    buf[n] = b;
+                    n += 1;
+                }
+                None => break,
+            }
+        }
+        Ok(n)
+    }
+}
+
+impl<'d> embedded_io_async::Read for Lpuart<'d, Async> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        embedded_io_async::Read::read(&mut self.rx, buf).await
+    }
+}
+
+// --- Instance --------------------------------------------------------------
+
+mod sealed {
+    pub trait Instance {
+        fn info() -> &'static super::Info;
+    }
+}
+
+/// LPUART instance.
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// NVIC vector for LPUART.
+    type Interrupt: Interrupt;
+}
+
+impl sealed::Instance for peripherals::LPUART {
+    fn info() -> &'static Info {
+        info()
+    }
+}
+
+impl Instance for peripherals::LPUART {
+    type Interrupt = interrupt::typelevel::LPUART;
+}

--- a/embassy-asr/src/pwr.rs
+++ b/embassy-asr/src/pwr.rs
@@ -1,0 +1,528 @@
+//! ASR6601 power-control driver.
+//!
+//! The implementation follows the ASR SDK `tremo_pwr.c` sequences. The
+//! crate-level [`crate::Config`] does not currently contain power settings, so
+//! runtime power transitions are made through an owned [`Pwr`] constructed from
+//! [`peripherals::PWR`].
+//!
+//! The vendor SVD does not describe the fields in the PWR status registers.
+//! Consequently this module exposes those registers only as [`RawStatus`].
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use embassy_hal_internal::interrupt::InterruptExt;
+
+use crate::pac::{self, Interrupt};
+use crate::{Peri, interrupt, peripherals};
+
+const CR0_LOW_POWER_MODE_MASK: u32 = 0x03;
+const CR0_WAIT_FOR_EVENT: u32 = 1 << 5;
+
+const CR1_DEEP_SLEEP_ENABLE: u32 = 1 << 4;
+const CR1_TRIM_MASK: u32 = 0x0f << 20;
+const CR1_TRIM_DEFAULT: u32 = 1 << 20;
+const CR1_STOP3_NOT_STANDBY: u32 = 1 << 24;
+
+const FLASH_INFO_TRIM: *const u32 = 0x1000_2010 as *const u32;
+const FLASH_PROTECT_SEQUENCE_0: u32 = 0x8c9d_aebf;
+const FLASH_PROTECT_SEQUENCE_1: u32 = 0x1314_1516;
+
+const AFEC_BASE: usize = 0x4000_8000;
+const AFEC_XO32K_CONTROL: usize = 0x03;
+const AFEC_LOW_POWER_CONTROL_0: usize = 0x05;
+const AFEC_LOW_POWER_CONTROL_1: usize = 0x06;
+const AFEC_STOP3_CONTROL: usize = 0x0c;
+
+const XO32K_LOW_POWER_ENABLE: u32 = 1 << 7;
+const LOW_POWER_RUN_ENABLE_0: u32 = 1 << 3;
+const LOW_POWER_RUN_ENABLE_1: u32 = 0x03 << 20;
+const STOP3_ANALOG_ENABLE: u32 = 1 << 14;
+
+static PWR_INTERRUPT_OBSERVED: AtomicBool = AtomicBool::new(false);
+
+/// Deep-sleep mode selected in the PWR controller.
+///
+/// The SDK names the encodings but does not document which clocks, memories, or
+/// peripheral domains remain available in `Stop0` through `Stop2`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum DeepSleepMode {
+    /// SDK `PWR_LP_MODE_STOP0`.
+    Stop0 = 0,
+    /// SDK `PWR_LP_MODE_STOP1`.
+    Stop1 = 1,
+    /// SDK `PWR_LP_MODE_STOP2`.
+    Stop2 = 2,
+    /// Retention stop mode used by the SDK GPIO, RTC, LPUART, and LPTIMER examples.
+    Stop3 = 3,
+    /// Standby mode. A successful wake from standby resets the processor.
+    Standby = 4,
+}
+
+impl DeepSleepMode {
+    fn needs_stop3_sequence(self) -> bool {
+        matches!(self, Self::Stop3 | Self::Standby)
+    }
+}
+
+/// Uninterpreted contents of the PWR status registers.
+///
+/// Neither the vendor SVD nor `tremo_pwr.h` defines fields or clear semantics
+/// for these registers. In particular, do not assume that writing a captured
+/// value back is a valid way to clear status.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct RawStatus {
+    sr0: u32,
+    sr1: u32,
+}
+
+impl RawStatus {
+    /// Raw PWR `SR0` value.
+    pub const fn sr0(self) -> u32 {
+        self.sr0
+    }
+
+    /// Raw PWR `SR1` value.
+    pub const fn sr1(self) -> u32 {
+        self.sr1
+    }
+}
+
+/// Status captured after a WFI or WFE returns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct WakeStatus {
+    raw: RawStatus,
+    pwr_interrupt_observed: bool,
+    pwr_interrupt_pending: bool,
+    standby_reset: bool,
+}
+
+impl WakeStatus {
+    /// Raw PWR status-register snapshot.
+    pub const fn raw(self) -> RawStatus {
+        self.raw
+    }
+
+    /// Whether the bound PWR interrupt handler ran during the latest wait.
+    ///
+    /// This is a software latch, not a decoded PWR hardware status bit.
+    pub const fn pwr_interrupt_observed(self) -> bool {
+        self.pwr_interrupt_observed
+    }
+
+    /// Whether the PWR interrupt is pending in the NVIC.
+    ///
+    /// This does not identify the underlying wake source.
+    pub const fn pwr_interrupt_pending(self) -> bool {
+        self.pwr_interrupt_pending
+    }
+
+    /// Whether RCC reports that this boot followed a standby wake/reset.
+    pub const fn standby_reset(self) -> bool {
+        self.standby_reset
+    }
+}
+
+/// Interrupt handler for the PWR interrupt.
+///
+/// The SDK handler is empty and the SVD contains no interrupt-status fields.
+/// This handler therefore records only that the vector ran.
+pub struct InterruptHandler;
+
+impl interrupt::typelevel::Handler<interrupt::typelevel::PWR> for InterruptHandler {
+    unsafe fn on_interrupt() {
+        PWR_INTERRUPT_OBSERVED.store(true, Ordering::Release);
+    }
+}
+
+/// Owned ASR6601 power controller.
+pub struct Pwr<'d> {
+    _peri: Peri<'d, peripherals::PWR>,
+}
+
+impl<'d> Pwr<'d> {
+    /// Create the power driver and enable the PWR register clock.
+    ///
+    /// `irq` proves that the PWR vector is bound before the WFI APIs temporarily
+    /// enable it, matching `pwr_sleep_wfi()` and `pwr_deepsleep_wfi()`.
+    pub fn new(
+        peri: Peri<'d, peripherals::PWR>,
+        _irq: impl interrupt::typelevel::Binding<interrupt::typelevel::PWR, InterruptHandler> + 'd,
+    ) -> Self {
+        critical_section::with(|_| {
+            let rcc = unsafe { pac::Rcc::steal() };
+            rcc.cgr0().modify(|_, w| w.pwr_clk_en().set_bit());
+        });
+
+        Interrupt::PWR.disable();
+        Interrupt::PWR.unpend();
+        PWR_INTERRUPT_OBSERVED.store(false, Ordering::Release);
+
+        Self { _peri: peri }
+    }
+
+    /// Enter ordinary sleep and wait for an interrupt.
+    ///
+    /// The PWR interrupt is enabled only for the duration of the wait, as in the
+    /// SDK. Other enabled interrupts can also wake the processor.
+    pub fn sleep_wfi(&mut self) -> WakeStatus {
+        clear_sleepdeep();
+        self.wait_wfi();
+        self.wake_status()
+    }
+
+    /// Enter ordinary sleep and wait for an event.
+    ///
+    /// This performs one WFE, matching `pwr_sleep_wfe()`. A previously latched
+    /// event can therefore make it return immediately.
+    pub fn sleep_wfe(&mut self) -> WakeStatus {
+        clear_sleepdeep();
+        PWR_INTERRUPT_OBSERVED.store(false, Ordering::Release);
+        cortex_m::asm::dsb();
+        cortex_m::asm::wfe();
+        self.wake_status()
+    }
+
+    /// Enter a deep-sleep mode and wait for an interrupt.
+    ///
+    /// `SLEEPDEEP` is cleared before this function returns so a later Embassy
+    /// executor WFE does not unexpectedly re-enter deep sleep.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that:
+    ///
+    /// - every active clock and peripheral can tolerate the selected mode, and
+    ///   all transfers or flash operations that cannot tolerate it have ended;
+    /// - a valid wake source and its interrupt are configured;
+    /// - the clock tree and affected peripherals are restored as required after
+    ///   wake;
+    /// - for `Stop3`/`Standby`, disabling flash prefetch and setting AFEC analog
+    ///   register 0x0c bit 14 is valid for this silicon and application;
+    /// - code after a `Standby` request does not rely on the request returning.
+    pub unsafe fn deep_sleep_wfi(&mut self, mode: DeepSleepMode) -> WakeStatus {
+        unsafe { self.prepare_deep_sleep(mode, WaitKind::Interrupt) };
+        let _sleepdeep = SleepDeepGuard::enter();
+        self.wait_wfi();
+        self.wake_status()
+    }
+
+    /// Enter a deep-sleep mode and wait for an event.
+    ///
+    /// This uses the SDK's `SEV; WFE; WFE` sequence to discard a stale event
+    /// before sleeping. `SLEEPDEEP` is cleared before this function returns.
+    ///
+    /// # Safety
+    ///
+    /// The caller must satisfy the clock, peripheral, flash, AFEC, wake-source,
+    /// and standby requirements of [`Self::deep_sleep_wfi`]. The configured
+    /// wake source must also generate an event that can wake WFE.
+    pub unsafe fn deep_sleep_wfe(&mut self, mode: DeepSleepMode) -> WakeStatus {
+        unsafe { self.prepare_deep_sleep(mode, WaitKind::Event) };
+        let _sleepdeep = SleepDeepGuard::enter();
+
+        PWR_INTERRUPT_OBSERVED.store(false, Ordering::Release);
+        cortex_m::asm::dsb();
+        cortex_m::asm::sev();
+        cortex_m::asm::wfe();
+        cortex_m::asm::wfe();
+
+        self.wake_status()
+    }
+
+    /// Enter low-power run mode until the returned guard is dropped.
+    ///
+    /// # Safety
+    ///
+    /// The caller must first put the CPU and bus clocks within the undocumented
+    /// low-power-run limits for this silicon and ensure all active peripherals
+    /// can operate with the reduced regulator settings. The SDK provides no
+    /// frequency or peripheral-domain limits, so this cannot be checked here.
+    pub unsafe fn enter_low_power_run(&mut self) -> LowPowerRun<'_, 'd> {
+        set_low_power_run(true);
+        LowPowerRun {
+            pwr: self,
+            active: true,
+        }
+    }
+
+    /// Sleep with WFI while low-power run mode is active.
+    ///
+    /// Low-power run mode is exited before this function returns.
+    ///
+    /// # Safety
+    ///
+    /// The caller must satisfy [`Self::enter_low_power_run`]'s clock and
+    /// peripheral requirements.
+    pub unsafe fn low_power_sleep_wfi(&mut self) -> WakeStatus {
+        let mut low_power = unsafe { self.enter_low_power_run() };
+        let status = low_power.sleep_wfi();
+        drop(low_power);
+        status
+    }
+
+    /// Sleep with WFE while low-power run mode is active.
+    ///
+    /// Low-power run mode is exited before this function returns.
+    ///
+    /// # Safety
+    ///
+    /// The caller must satisfy [`Self::enter_low_power_run`]'s clock and
+    /// peripheral requirements.
+    pub unsafe fn low_power_sleep_wfe(&mut self) -> WakeStatus {
+        let mut low_power = unsafe { self.enter_low_power_run() };
+        let status = low_power.sleep_wfe();
+        drop(low_power);
+        status
+    }
+
+    /// Whether both SDK low-power-run control fields are set.
+    pub fn low_power_run_enabled(&self) -> bool {
+        read_analog(AFEC_LOW_POWER_CONTROL_0) & LOW_POWER_RUN_ENABLE_0 != 0
+            && read_analog(AFEC_LOW_POWER_CONTROL_1) & LOW_POWER_RUN_ENABLE_1 == LOW_POWER_RUN_ENABLE_1
+    }
+
+    /// Enable XO32K low-power mode.
+    ///
+    /// # Safety
+    ///
+    /// XO32K must already be running and stable. The board's crystal and PCB
+    /// routing must be qualified for ASR6601 XO32K low-power mode, and no code
+    /// may concurrently reconfigure XO32K. The datasheet warns that unsuitable
+    /// routing requires normal mode.
+    pub unsafe fn enable_xo32k_low_power_mode(&mut self) {
+        modify_analog(AFEC_XO32K_CONTROL, |value| value | XO32K_LOW_POWER_ENABLE);
+    }
+
+    /// Disable XO32K low-power mode, selecting its normal operating mode.
+    pub fn disable_xo32k_low_power_mode(&mut self) {
+        modify_analog(AFEC_XO32K_CONTROL, |value| value & !XO32K_LOW_POWER_ENABLE);
+    }
+
+    /// Whether the XO32K low-power-mode control bit is set.
+    ///
+    /// This reports the requested mode, not oscillator stability.
+    pub fn xo32k_low_power_mode_enabled(&self) -> bool {
+        read_analog(AFEC_XO32K_CONTROL) & XO32K_LOW_POWER_ENABLE != 0
+    }
+
+    /// Capture the two raw PWR status registers.
+    pub fn raw_status(&self) -> RawStatus {
+        let pwr = regs();
+        RawStatus {
+            sr0: pwr.sr0().read().bits(),
+            sr1: pwr.sr1().read().bits(),
+        }
+    }
+
+    /// Whether the PWR vector has run since the latest wait began or latch clear.
+    pub fn pwr_interrupt_observed(&self) -> bool {
+        PWR_INTERRUPT_OBSERVED.load(Ordering::Acquire)
+    }
+
+    /// Return and clear the software PWR-interrupt latch.
+    pub fn take_pwr_interrupt_observed(&mut self) -> bool {
+        PWR_INTERRUPT_OBSERVED.swap(false, Ordering::AcqRel)
+    }
+
+    /// Whether the PWR interrupt is pending in the NVIC.
+    pub fn pwr_interrupt_pending(&self) -> bool {
+        Interrupt::PWR.is_pending()
+    }
+
+    /// Clear the NVIC pending bit for PWR.
+    ///
+    /// This does not clear an undocumented peripheral status source. A
+    /// level-sensitive source can pend the interrupt again immediately.
+    pub fn clear_pwr_interrupt_pending(&mut self) {
+        Interrupt::PWR.unpend();
+    }
+
+    /// Whether RCC reports that the current boot followed a standby wake/reset.
+    pub fn was_standby_reset(&self) -> bool {
+        let rcc = unsafe { pac::Rcc::steal() };
+        rcc.rst_sr().read().standby_reset_sr().bit_is_set()
+    }
+
+    fn wait_wfi(&mut self) {
+        PWR_INTERRUPT_OBSERVED.store(false, Ordering::Release);
+        Interrupt::PWR.unpend();
+        unsafe { Interrupt::PWR.enable() };
+
+        cortex_m::asm::dsb();
+        cortex_m::asm::wfi();
+
+        Interrupt::PWR.disable();
+    }
+
+    fn wake_status(&self) -> WakeStatus {
+        WakeStatus {
+            raw: self.raw_status(),
+            pwr_interrupt_observed: self.pwr_interrupt_observed(),
+            pwr_interrupt_pending: self.pwr_interrupt_pending(),
+            standby_reset: self.was_standby_reset(),
+        }
+    }
+
+    unsafe fn prepare_deep_sleep(&mut self, mode: DeepSleepMode, wait: WaitKind) {
+        let pwr = regs();
+
+        pwr.cr1().modify(|r, w| unsafe {
+            let mut bits = r.bits() | CR1_DEEP_SLEEP_ENABLE;
+            if unsafe { core::ptr::read_volatile(FLASH_INFO_TRIM) } & 0x03 == 0 {
+                bits = (bits & !CR1_TRIM_MASK) | CR1_TRIM_DEFAULT;
+            }
+            w.bits(bits)
+        });
+
+        pwr.cr0().modify(|r, w| unsafe {
+            let bits = match wait {
+                WaitKind::Interrupt => r.bits() & !CR0_WAIT_FOR_EVENT,
+                WaitKind::Event => r.bits() | CR0_WAIT_FOR_EVENT,
+            };
+            w.bits(bits)
+        });
+
+        if mode.needs_stop3_sequence() {
+            disable_flash_prefetch();
+            modify_analog(AFEC_STOP3_CONTROL, |value| value | STOP3_ANALOG_ENABLE);
+
+            pwr.cr0()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !CR0_LOW_POWER_MODE_MASK) | DeepSleepMode::Stop3 as u32) });
+            pwr.cr1().modify(|r, w| unsafe {
+                let bits = match mode {
+                    DeepSleepMode::Stop3 => r.bits() | CR1_STOP3_NOT_STANDBY,
+                    DeepSleepMode::Standby => r.bits() & !CR1_STOP3_NOT_STANDBY,
+                    _ => r.bits(),
+                };
+                w.bits(bits)
+            });
+        } else {
+            pwr.cr0()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !CR0_LOW_POWER_MODE_MASK) | mode as u32) });
+        }
+    }
+}
+
+impl Drop for Pwr<'_> {
+    fn drop(&mut self) {
+        Interrupt::PWR.disable();
+    }
+}
+
+/// Guard proving that low-power run mode is active.
+///
+/// Dropping the guard restores normal run mode in the reverse order used by the
+/// SDK.
+pub struct LowPowerRun<'a, 'd> {
+    pwr: &'a mut Pwr<'d>,
+    active: bool,
+}
+
+impl LowPowerRun<'_, '_> {
+    /// Enter ordinary sleep and wait for an interrupt.
+    pub fn sleep_wfi(&mut self) -> WakeStatus {
+        self.pwr.sleep_wfi()
+    }
+
+    /// Enter ordinary sleep and wait for an event.
+    pub fn sleep_wfe(&mut self) -> WakeStatus {
+        self.pwr.sleep_wfe()
+    }
+
+    /// Capture status without leaving low-power run mode.
+    pub fn status(&self) -> WakeStatus {
+        self.pwr.wake_status()
+    }
+
+    /// Exit low-power run mode.
+    pub fn exit(self) {}
+}
+
+impl Drop for LowPowerRun<'_, '_> {
+    fn drop(&mut self) {
+        if self.active {
+            set_low_power_run(false);
+            self.active = false;
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum WaitKind {
+    Interrupt,
+    Event,
+}
+
+struct SleepDeepGuard;
+
+impl SleepDeepGuard {
+    fn enter() -> Self {
+        let mut cp = unsafe { cortex_m::Peripherals::steal() };
+        cp.SCB.set_sleepdeep();
+        cortex_m::asm::dsb();
+        cortex_m::asm::isb();
+        Self
+    }
+}
+
+impl Drop for SleepDeepGuard {
+    fn drop(&mut self) {
+        clear_sleepdeep();
+    }
+}
+
+fn clear_sleepdeep() {
+    let mut cp = unsafe { cortex_m::Peripherals::steal() };
+    cp.SCB.clear_sleepdeep();
+    cortex_m::asm::dsb();
+    cortex_m::asm::isb();
+}
+
+fn regs() -> pac::Pwr {
+    unsafe { pac::Pwr::steal() }
+}
+
+fn read_analog(index: usize) -> u32 {
+    unsafe { core::ptr::read_volatile((AFEC_BASE + index * 4) as *const u32) }
+}
+
+fn modify_analog(index: usize, f: impl FnOnce(u32) -> u32) {
+    critical_section::with(|_| unsafe {
+        let register = (AFEC_BASE + index * 4) as *mut u32;
+        let value = core::ptr::read_volatile(register);
+        core::ptr::write_volatile(register, f(value));
+    });
+}
+
+fn set_low_power_run(enabled: bool) {
+    if enabled {
+        modify_analog(AFEC_LOW_POWER_CONTROL_0, |value| value | LOW_POWER_RUN_ENABLE_0);
+        modify_analog(AFEC_LOW_POWER_CONTROL_1, |value| value | LOW_POWER_RUN_ENABLE_1);
+    } else {
+        modify_analog(AFEC_LOW_POWER_CONTROL_1, |value| value & !LOW_POWER_RUN_ENABLE_1);
+        modify_analog(AFEC_LOW_POWER_CONTROL_0, |value| value & !LOW_POWER_RUN_ENABLE_0);
+    }
+}
+
+fn disable_flash_prefetch() {
+    critical_section::with(|_| {
+        let efc = unsafe { pac::Efc::steal() };
+        if efc.cr().read().prefetch_en().bit_is_clear() {
+            return;
+        }
+
+        unsafe {
+            efc.protect_seq().write_with_zero(|w| w.bits(FLASH_PROTECT_SEQUENCE_0));
+            efc.protect_seq().write_with_zero(|w| w.bits(FLASH_PROTECT_SEQUENCE_1));
+        }
+        efc.cr().modify(|_, w| w.prefetch_en().clear_bit());
+        unsafe {
+            efc.protect_seq().write_with_zero(|w| w.bits(FLASH_PROTECT_SEQUENCE_0));
+            efc.protect_seq().write_with_zero(|w| w.bits(0));
+        }
+    });
+}

--- a/embassy-asr/src/rcc.rs
+++ b/embassy-asr/src/rcc.rs
@@ -15,12 +15,6 @@ const XO24M_HZ: u32 = 24_000_000;
 const XO32M_HZ: u32 = 32_000_000;
 const LOW_SPEED_HZ: u32 = 32_768;
 
-// The analog oscillator control registers occupy the otherwise-unmodelled
-// first 0x200 bytes of the AFEC address range.
-const AFEC_ANALOG_BASE: usize = 0x4000_8000;
-const AFEC_ANALOG_OSC32K: usize = 0x02;
-const AFEC_ANALOG_OSC_HIGH_SPEED: usize = 0x06;
-
 const ANALOG_RCO32K_POWER_DOWN: u32 = 1 << 15;
 const ANALOG_XO32K_POWER_DOWN: u32 = (1 << 13) | (1 << 14);
 const ANALOG_XO24M_ENABLE: u32 = 1 << 3;
@@ -288,8 +282,15 @@ pub fn clocks() -> Option<Clocks> {
 /// selected oscillator is enabled before it is selected. PCLKs are temporarily
 /// divided by 16, and HCLK/source ordering is chosen to avoid a transient clock
 /// faster than either the existing or requested clock.
+///
+/// Matches vendor `system_init()` by enabling the AFEC clock before any
+/// analog-window or `RAW_SR` access. Without that gate, oscillator readiness
+/// bits read as clear and [`Error::Timeout`] is reported.
 pub fn init(_rcc: Peri<'_, peripherals::RCC>, config: Config) -> Result<Clocks, Error> {
     CLOCKS_INITIALIZED.store(false, Ordering::Release);
+
+    // Vendor `system_cm4.c` enables AFEC before oscillator or clock work.
+    crate::afec::analog::enable_clock();
 
     enable_oscillator(
         config.system_clock.oscillator(),
@@ -388,14 +389,6 @@ fn configure_clock_tree(config: Config) {
     set_pclk_dividers(config.pclk0_divider, config.pclk1_divider);
 }
 
-fn modify_analog(register: usize, f: impl FnOnce(u32) -> u32) {
-    critical_section::with(|_| unsafe {
-        let address = (AFEC_ANALOG_BASE + register * size_of::<u32>()) as *mut u32;
-        let value = core::ptr::read_volatile(address);
-        core::ptr::write_volatile(address, f(value));
-    });
-}
-
 fn wait_until(poll_limit: u32, target: WaitTarget, mut ready: impl FnMut() -> bool) -> Result<(), Error> {
     for _ in 0..poll_limit {
         if ready() {
@@ -408,25 +401,31 @@ fn wait_until(poll_limit: u32, target: WaitTarget, mut ready: impl FnMut() -> bo
 }
 
 fn enable_oscillator(oscillator: Oscillator, xo32m_uses_tcxo: bool, poll_limit: u32) -> Result<(), Error> {
+    use crate::afec::analog::{REG_02, REG_06};
+
+    // Analog-window helpers gate AFEC; keep the digital block live for RAW_SR.
+    crate::afec::analog::enable_clock();
+
     match oscillator {
         Oscillator::Rco48m => {
-            modify_analog(AFEC_ANALOG_OSC_HIGH_SPEED, |value| value & !ANALOG_RCO48M_POWER_DOWN);
+            REG_06.clear_bits(ANALOG_RCO48M_POWER_DOWN);
             wait_until(poll_limit, WaitTarget::Rco48m, || {
                 afec().raw_sr().read().rco24m_ready().bit_is_set()
             })
         }
         Oscillator::Rco32k => {
-            modify_analog(AFEC_ANALOG_OSC32K, |value| value & !ANALOG_RCO32K_POWER_DOWN);
+            REG_02.clear_bits(ANALOG_RCO32K_POWER_DOWN);
             Ok(())
         }
         Oscillator::Xo32k => {
-            modify_analog(AFEC_ANALOG_OSC32K, |value| value & !ANALOG_XO32K_POWER_DOWN);
+            REG_02.clear_bits(ANALOG_XO32K_POWER_DOWN);
             Ok(())
         }
         Oscillator::Xo24m => {
-            modify_analog(AFEC_ANALOG_OSC_HIGH_SPEED, |value| {
-                (value | ANALOG_XO24M_ENABLE) & !ANALOG_XO24M_POWER_DOWN
-            });
+            REG_06.modify(
+                ANALOG_XO24M_ENABLE | ANALOG_XO24M_POWER_DOWN,
+                ANALOG_XO24M_ENABLE,
+            );
             Ok(())
         }
         Oscillator::Xo32m => {
@@ -452,7 +451,7 @@ fn enable_oscillator(oscillator: Oscillator, xo32m_uses_tcxo: bool, poll_limit: 
             })
         }
         Oscillator::Rco4m => {
-            modify_analog(AFEC_ANALOG_OSC_HIGH_SPEED, |value| value & !ANALOG_RCO4M_POWER_DOWN);
+            REG_06.clear_bits(ANALOG_RCO4M_POWER_DOWN);
             wait_until(poll_limit, WaitTarget::Rco4m, || {
                 afec().raw_sr().read().rco4m_ready().bit_is_set()
             })

--- a/embassy-asr/src/rcc.rs
+++ b/embassy-asr/src/rcc.rs
@@ -1,0 +1,761 @@
+//! Reset and clock control for the ASR6601.
+//!
+//! The clock tree is deliberately configured before it is published through
+//! [`clocks`]. Peripheral drivers may share RCC through the crate-private
+//! helpers at the end of this module; their register updates are serialized by
+//! a critical section.
+
+use core::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+use crate::{Peri, pac, peripherals};
+
+const RCO48M_HZ: u32 = 48_000_000;
+const RCO4M_HZ: u32 = 3_600_000;
+const XO24M_HZ: u32 = 24_000_000;
+const XO32M_HZ: u32 = 32_000_000;
+const LOW_SPEED_HZ: u32 = 32_768;
+
+// The analog oscillator control registers occupy the otherwise-unmodelled
+// first 0x200 bytes of the AFEC address range.
+const AFEC_ANALOG_BASE: usize = 0x4000_8000;
+const AFEC_ANALOG_OSC32K: usize = 0x02;
+const AFEC_ANALOG_OSC_HIGH_SPEED: usize = 0x06;
+
+const ANALOG_RCO32K_POWER_DOWN: u32 = 1 << 15;
+const ANALOG_XO32K_POWER_DOWN: u32 = (1 << 13) | (1 << 14);
+const ANALOG_XO24M_ENABLE: u32 = 1 << 3;
+const ANALOG_XO24M_POWER_DOWN: u32 = 1 << 4;
+const ANALOG_RCO48M_POWER_DOWN: u32 = 1 << 5;
+const ANALOG_RCO4M_POWER_DOWN: u32 = 1 << 6;
+
+const CR0_PCLK0_DIV_MASK: u32 = 0x0000_00e0;
+const CR0_HCLK_DIV_MASK: u32 = 0x0000_0f00;
+const CR0_SYSCLK_SEL_MASK: u32 = 0x0000_7000;
+const CR0_PCLK1_DIV_MASK: u32 = 0x0003_8000;
+
+const RCC_SR_ALL_DONE: u32 = 0x3f;
+
+const LORAC_CR1_TCXO_ENABLE: u32 = 0x03;
+const LORAC_CR1_XO32M_ENABLE: u32 = 1 << 2;
+const LORAC_CR1_NRESET: u32 = 1 << 5;
+const LORAC_CR1_POWER_ON_RESET: u32 = 1 << 7;
+const LORAC_SR_XO32M_READY: u32 = 1 << 1;
+
+const ASYNC_RESET_DELAY_US: u64 = 92;
+
+static CLOCKS_INITIALIZED: AtomicBool = AtomicBool::new(false);
+static SYSCLK_HZ: AtomicU32 = AtomicU32::new(0);
+static HCLK_HZ: AtomicU32 = AtomicU32::new(0);
+static PCLK0_HZ: AtomicU32 = AtomicU32::new(0);
+static PCLK1_HZ: AtomicU32 = AtomicU32::new(0);
+
+/// Oscillators controlled by RCC initialization.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Oscillator {
+    /// Internal 48 MHz RC oscillator.
+    Rco48m,
+    /// Internal 32.768 kHz RC oscillator.
+    Rco32k,
+    /// External 32.768 kHz crystal oscillator.
+    Xo32k,
+    /// External 24 MHz crystal oscillator.
+    Xo24m,
+    /// 32 MHz LoRa-radio crystal oscillator.
+    Xo32m,
+    /// Internal RC oscillator. Despite its name, the vendor reports 3.6 MHz.
+    Rco4m,
+}
+
+/// System clock source.
+///
+/// The PAC also describes a PLL selector value. It is intentionally absent:
+/// the vendor RCC API neither exposes PLL as a system-clock source nor
+/// specifies its frequency or setup sequence.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SystemClockSource {
+    /// Internal 48 MHz RC oscillator divided by two.
+    #[default]
+    Rco48mDiv2 = 0,
+    /// Internal 32.768 kHz RC oscillator.
+    Rco32k = 1,
+    /// External 32.768 kHz crystal oscillator.
+    Xo32k = 2,
+    /// External 24 MHz crystal oscillator.
+    Xo24m = 4,
+    /// 32 MHz LoRa-radio crystal oscillator.
+    Xo32m = 5,
+    /// Internal RC oscillator (3.6 MHz according to the vendor clock API).
+    Rco4m = 6,
+    /// Internal 48 MHz RC oscillator.
+    Rco48m = 7,
+}
+
+impl SystemClockSource {
+    /// Nominal source frequency in hertz.
+    pub const fn frequency_hz(self) -> u32 {
+        match self {
+            Self::Rco48mDiv2 => RCO48M_HZ / 2,
+            Self::Rco32k | Self::Xo32k => LOW_SPEED_HZ,
+            Self::Xo24m => XO24M_HZ,
+            Self::Xo32m => XO32M_HZ,
+            Self::Rco4m => RCO4M_HZ,
+            Self::Rco48m => RCO48M_HZ,
+        }
+    }
+
+    const fn oscillator(self) -> Oscillator {
+        match self {
+            Self::Rco48mDiv2 | Self::Rco48m => Oscillator::Rco48m,
+            Self::Rco32k => Oscillator::Rco32k,
+            Self::Xo32k => Oscillator::Xo32k,
+            Self::Xo24m => Oscillator::Xo24m,
+            Self::Xo32m => Oscillator::Xo32m,
+            Self::Rco4m => Oscillator::Rco4m,
+        }
+    }
+}
+
+/// HCLK divider.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HclkDivider {
+    /// Divide by 1.
+    #[default]
+    Div1 = 0,
+    /// Divide by 2.
+    Div2 = 1,
+    /// Divide by 4.
+    Div4 = 2,
+    /// Divide by 8.
+    Div8 = 3,
+    /// Divide by 16.
+    Div16 = 4,
+    /// Divide by 32.
+    Div32 = 5,
+    /// Divide by 64.
+    Div64 = 6,
+    /// Divide by 128.
+    Div128 = 7,
+    /// Divide by 256.
+    Div256 = 8,
+    /// Divide by 512.
+    Div512 = 9,
+}
+
+impl HclkDivider {
+    /// Numeric divider.
+    pub const fn divisor(self) -> u32 {
+        1 << self as u8
+    }
+}
+
+/// PCLK0 or PCLK1 divider.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum PclkDivider {
+    /// Divide by 1.
+    #[default]
+    Div1 = 0,
+    /// Divide by 2.
+    Div2 = 1,
+    /// Divide by 4.
+    Div4 = 2,
+    /// Divide by 8.
+    Div8 = 3,
+    /// Divide by 16.
+    Div16 = 4,
+}
+
+impl PclkDivider {
+    /// Numeric divider.
+    pub const fn divisor(self) -> u32 {
+        1 << self as u8
+    }
+}
+
+/// RCC initialization configuration.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Config {
+    /// System clock source.
+    pub system_clock: SystemClockSource,
+    /// HCLK divider.
+    pub hclk_divider: HclkDivider,
+    /// PCLK0 divider relative to HCLK.
+    pub pclk0_divider: PclkDivider,
+    /// PCLK1 divider relative to HCLK.
+    pub pclk1_divider: PclkDivider,
+    /// Set the vendor TCXO-enable bits when starting the LoRa 32 MHz source.
+    pub xo32m_uses_tcxo: bool,
+    /// Maximum number of status-register polls for each readiness transition.
+    ///
+    /// This is a polling budget, not a duration: the CPU frequency can change
+    /// while RCC is being initialized.
+    pub readiness_poll_limit: u32,
+}
+
+impl Config {
+    /// Configuration matching the documented reset clock tree.
+    pub const fn new() -> Self {
+        Self {
+            system_clock: SystemClockSource::Rco48mDiv2,
+            hclk_divider: HclkDivider::Div1,
+            pclk0_divider: PclkDivider::Div1,
+            pclk1_divider: PclkDivider::Div1,
+            xo32m_uses_tcxo: false,
+            readiness_poll_limit: 1_000_000,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Initialized core and bus clock frequencies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Clocks {
+    /// System clock frequency in hertz.
+    pub sysclk_hz: u32,
+    /// CPU/AHB clock frequency in hertz.
+    pub hclk_hz: u32,
+    /// Peripheral bus 0 frequency in hertz.
+    pub pclk0_hz: u32,
+    /// Peripheral bus 1 frequency in hertz.
+    pub pclk1_hz: u32,
+}
+
+impl Clocks {
+    const fn from_config(config: Config) -> Self {
+        let sysclk_hz = config.system_clock.frequency_hz();
+        let hclk_hz = sysclk_hz / config.hclk_divider.divisor();
+        Self {
+            sysclk_hz,
+            hclk_hz,
+            pclk0_hz: hclk_hz / config.pclk0_divider.divisor(),
+            pclk1_hz: hclk_hz / config.pclk1_divider.divisor(),
+        }
+    }
+}
+
+/// Hardware transition whose status did not become ready.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WaitTarget {
+    /// Internal 48 MHz RC oscillator.
+    Rco48m,
+    /// Internal 3.6 MHz RC oscillator.
+    Rco4m,
+    /// LoRa 32 MHz crystal oscillator.
+    Xo32m,
+    /// RCC clock-domain synchronization.
+    ClockDomain,
+}
+
+/// RCC configuration or peripheral-control error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// A bounded readiness wait expired.
+    Timeout(WaitTarget),
+    /// A reset requiring a timed release was requested before clock setup.
+    ClocksNotInitialized,
+    /// The vendor RCC does not provide a reset bit for this peripheral.
+    ResetUnsupported(Peripheral),
+}
+
+/// Return the frequencies published by successful RCC initialization.
+///
+/// `None` is returned until [`init`] has completed all oscillator and clock
+/// transitions.
+pub fn clocks() -> Option<Clocks> {
+    if !CLOCKS_INITIALIZED.load(Ordering::Acquire) {
+        return None;
+    }
+
+    Some(Clocks {
+        sysclk_hz: SYSCLK_HZ.load(Ordering::Relaxed),
+        hclk_hz: HCLK_HZ.load(Ordering::Relaxed),
+        pclk0_hz: PCLK0_HZ.load(Ordering::Relaxed),
+        pclk1_hz: PCLK1_HZ.load(Ordering::Relaxed),
+    })
+}
+
+/// Initialize the ASR6601 oscillator and core/bus clock tree.
+///
+/// The RCC singleton makes normal callers perform this operation once. The
+/// selected oscillator is enabled before it is selected. PCLKs are temporarily
+/// divided by 16, and HCLK/source ordering is chosen to avoid a transient clock
+/// faster than either the existing or requested clock.
+pub fn init(_rcc: Peri<'_, peripherals::RCC>, config: Config) -> Result<Clocks, Error> {
+    CLOCKS_INITIALIZED.store(false, Ordering::Release);
+
+    enable_oscillator(
+        config.system_clock.oscillator(),
+        config.xo32m_uses_tcxo,
+        config.readiness_poll_limit,
+    )?;
+    configure_clock_tree(config);
+
+    let clocks = Clocks::from_config(config);
+    SYSCLK_HZ.store(clocks.sysclk_hz, Ordering::Relaxed);
+    HCLK_HZ.store(clocks.hclk_hz, Ordering::Relaxed);
+    PCLK0_HZ.store(clocks.pclk0_hz, Ordering::Relaxed);
+    PCLK1_HZ.store(clocks.pclk1_hz, Ordering::Relaxed);
+    CLOCKS_INITIALIZED.store(true, Ordering::Release);
+    Ok(clocks)
+}
+
+fn rcc() -> pac::Rcc {
+    // RCC is a shared hardware service. Every read-modify-write performed by
+    // this module is protected by a critical section.
+    unsafe { pac::Rcc::steal() }
+}
+
+fn afec() -> pac::Afec {
+    unsafe { pac::Afec::steal() }
+}
+
+fn lorac() -> pac::Lorac {
+    unsafe { pac::Lorac::steal() }
+}
+
+fn update_bits(value: u32, mask: u32, set: bool) -> u32 {
+    if set { value | mask } else { value & !mask }
+}
+
+fn modify_cr0(mask: u32, value: u32) {
+    critical_section::with(|_| {
+        rcc()
+            .cr0()
+            .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value & mask)) });
+    });
+}
+
+fn current_system_frequency() -> Option<u32> {
+    match (rcc().cr0().read().bits() & CR0_SYSCLK_SEL_MASK) >> 12 {
+        0 => Some(RCO48M_HZ / 2),
+        1 | 2 => Some(LOW_SPEED_HZ),
+        3 => None,
+        4 => Some(XO24M_HZ),
+        5 => Some(XO32M_HZ),
+        6 => Some(RCO4M_HZ),
+        7 => Some(RCO48M_HZ),
+        _ => unreachable!(),
+    }
+}
+
+fn set_hclk_divider(divider: HclkDivider) {
+    modify_cr0(CR0_HCLK_DIV_MASK, (divider as u32) << 8);
+}
+
+fn set_pclk_dividers(pclk0: PclkDivider, pclk1: PclkDivider) {
+    modify_cr0(
+        CR0_PCLK0_DIV_MASK | CR0_PCLK1_DIV_MASK,
+        ((pclk0 as u32) << 5) | ((pclk1 as u32) << 15),
+    );
+}
+
+fn set_system_clock(source: SystemClockSource) {
+    modify_cr0(CR0_SYSCLK_SEL_MASK, (source as u32) << 12);
+}
+
+fn configure_clock_tree(config: Config) {
+    let old_frequency = current_system_frequency();
+    let new_frequency = config.system_clock.frequency_hz();
+
+    // Protect both peripheral buses while HCLK and SYSCLK are in transition.
+    set_pclk_dividers(PclkDivider::Div16, PclkDivider::Div16);
+
+    match old_frequency {
+        Some(old_frequency) if new_frequency >= old_frequency => {
+            set_hclk_divider(config.hclk_divider);
+            set_system_clock(config.system_clock);
+        }
+        Some(_) => {
+            set_system_clock(config.system_clock);
+            set_hclk_divider(config.hclk_divider);
+        }
+        None => {
+            // PLL setup/frequency is not specified by the vendor RCC API.
+            set_hclk_divider(HclkDivider::Div512);
+            set_system_clock(config.system_clock);
+            set_hclk_divider(config.hclk_divider);
+        }
+    }
+
+    set_pclk_dividers(config.pclk0_divider, config.pclk1_divider);
+}
+
+fn modify_analog(register: usize, f: impl FnOnce(u32) -> u32) {
+    critical_section::with(|_| unsafe {
+        let address = (AFEC_ANALOG_BASE + register * size_of::<u32>()) as *mut u32;
+        let value = core::ptr::read_volatile(address);
+        core::ptr::write_volatile(address, f(value));
+    });
+}
+
+fn wait_until(poll_limit: u32, target: WaitTarget, mut ready: impl FnMut() -> bool) -> Result<(), Error> {
+    for _ in 0..poll_limit {
+        if ready() {
+            return Ok(());
+        }
+        core::hint::spin_loop();
+    }
+
+    if ready() { Ok(()) } else { Err(Error::Timeout(target)) }
+}
+
+fn enable_oscillator(oscillator: Oscillator, xo32m_uses_tcxo: bool, poll_limit: u32) -> Result<(), Error> {
+    match oscillator {
+        Oscillator::Rco48m => {
+            modify_analog(AFEC_ANALOG_OSC_HIGH_SPEED, |value| value & !ANALOG_RCO48M_POWER_DOWN);
+            wait_until(poll_limit, WaitTarget::Rco48m, || {
+                afec().raw_sr().read().rco24m_ready().bit_is_set()
+            })
+        }
+        Oscillator::Rco32k => {
+            modify_analog(AFEC_ANALOG_OSC32K, |value| value & !ANALOG_RCO32K_POWER_DOWN);
+            Ok(())
+        }
+        Oscillator::Xo32k => {
+            modify_analog(AFEC_ANALOG_OSC32K, |value| value & !ANALOG_XO32K_POWER_DOWN);
+            Ok(())
+        }
+        Oscillator::Xo24m => {
+            modify_analog(AFEC_ANALOG_OSC_HIGH_SPEED, |value| {
+                (value | ANALOG_XO24M_ENABLE) & !ANALOG_XO24M_POWER_DOWN
+            });
+            Ok(())
+        }
+        Oscillator::Xo32m => {
+            set_peripheral_clock_raw(Peripheral::Lora, true, poll_limit)?;
+
+            critical_section::with(|_| {
+                lorac().cr1().modify(|r, w| {
+                    let mut value = r.bits();
+                    if value & LORAC_CR1_NRESET == 0 {
+                        value |= LORAC_CR1_NRESET;
+                        value &= !LORAC_CR1_POWER_ON_RESET;
+                    }
+                    if xo32m_uses_tcxo {
+                        value |= LORAC_CR1_TCXO_ENABLE;
+                    }
+                    value |= LORAC_CR1_XO32M_ENABLE;
+                    unsafe { w.bits(value) }
+                });
+            });
+
+            wait_until(poll_limit, WaitTarget::Xo32m, || {
+                lorac().sr().read().bits() & LORAC_SR_XO32M_READY != 0
+            })
+        }
+        Oscillator::Rco4m => {
+            modify_analog(AFEC_ANALOG_OSC_HIGH_SPEED, |value| value & !ANALOG_RCO4M_POWER_DOWN);
+            wait_until(poll_limit, WaitTarget::Rco4m, || {
+                afec().raw_sr().read().rco4m_ready().bit_is_set()
+            })
+        }
+    }
+}
+
+/// RCC-controlled peripheral clock/reset identifier.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Peripheral {
+    Sac,
+    Sec,
+    Crc,
+    Rtc,
+    Wdg,
+    Iwdg,
+    Lptimer0,
+    Bstimer1,
+    Bstimer0,
+    Timer3,
+    Timer2,
+    Timer1,
+    Timer0,
+    GpioA,
+    GpioB,
+    GpioC,
+    GpioD,
+    Lora,
+    Dac,
+    Lcd,
+    Afec,
+    Adc,
+    I2c2,
+    I2c1,
+    I2c0,
+    Qspi,
+    Ssp2,
+    Ssp1,
+    Ssp0,
+    Lpuart,
+    Uart3,
+    Uart2,
+    Uart1,
+    Uart0,
+    Dma1,
+    Dma0,
+    I2s,
+    Rng,
+    Lptimer1,
+    Syscfg,
+    Pwr,
+}
+
+#[derive(Clone, Copy)]
+enum ClockRegister {
+    Cgr0,
+    Cgr1,
+    Cgr2,
+}
+
+fn modify_clock_register(register: ClockRegister, mask: u32, enable: bool) {
+    critical_section::with(|_| {
+        let rcc = rcc();
+        match register {
+            ClockRegister::Cgr0 => rcc
+                .cgr0()
+                .modify(|r, w| unsafe { w.bits(update_bits(r.bits(), mask, enable)) }),
+            ClockRegister::Cgr1 => rcc
+                .cgr1()
+                .modify(|r, w| unsafe { w.bits(update_bits(r.bits(), mask, enable)) }),
+            ClockRegister::Cgr2 => rcc
+                .cgr2()
+                .modify(|r, w| unsafe { w.bits(update_bits(r.bits(), mask, enable)) }),
+        };
+    });
+}
+
+fn basic_clock(peripheral: Peripheral) -> Option<(ClockRegister, u32)> {
+    let value = match peripheral {
+        Peripheral::Timer3 => (ClockRegister::Cgr0, 1 << 0),
+        Peripheral::Timer2 => (ClockRegister::Cgr0, 1 << 1),
+        Peripheral::Timer1 => (ClockRegister::Cgr0, 1 << 2),
+        Peripheral::Timer0 => (ClockRegister::Cgr0, 1 << 3),
+        Peripheral::Lora => (ClockRegister::Cgr0, 1 << 4),
+        Peripheral::Dac => (ClockRegister::Cgr0, 1 << 5),
+        Peripheral::Afec => (ClockRegister::Cgr0, 1 << 7),
+        Peripheral::Adc => (ClockRegister::Cgr0, 1 << 8),
+        Peripheral::I2c2 => (ClockRegister::Cgr0, 1 << 10),
+        Peripheral::I2c1 => (ClockRegister::Cgr0, 1 << 11),
+        Peripheral::I2c0 => (ClockRegister::Cgr0, 1 << 12),
+        Peripheral::Ssp2 => (ClockRegister::Cgr0, 1 << 13),
+        Peripheral::Ssp1 => (ClockRegister::Cgr0, 1 << 14),
+        Peripheral::Ssp0 => (ClockRegister::Cgr0, 1 << 15),
+        Peripheral::Uart3 => (ClockRegister::Cgr0, 1 << 17),
+        Peripheral::Uart2 => (ClockRegister::Cgr0, 1 << 18),
+        Peripheral::Uart1 => (ClockRegister::Cgr0, 1 << 19),
+        Peripheral::Uart0 => (ClockRegister::Cgr0, 1 << 20),
+        Peripheral::Syscfg => (ClockRegister::Cgr0, 1 << 21),
+        Peripheral::GpioD => (ClockRegister::Cgr0, 1 << 22),
+        Peripheral::GpioC => (ClockRegister::Cgr0, 1 << 23),
+        Peripheral::GpioB => (ClockRegister::Cgr0, 1 << 24),
+        Peripheral::GpioA => (ClockRegister::Cgr0, 1 << 25),
+        Peripheral::Bstimer1 => (ClockRegister::Cgr0, 1 << 26),
+        Peripheral::Bstimer0 => (ClockRegister::Cgr0, 1 << 27),
+        Peripheral::Crc => (ClockRegister::Cgr0, 1 << 28),
+        Peripheral::Dma1 => (ClockRegister::Cgr0, 1 << 29),
+        Peripheral::Dma0 => (ClockRegister::Cgr0, 1 << 30),
+        Peripheral::Pwr => (ClockRegister::Cgr0, 1 << 31),
+        Peripheral::Sec => (ClockRegister::Cgr1, 1 << 0),
+        Peripheral::Qspi => (ClockRegister::Cgr1, 1 << 5),
+        Peripheral::Sac => (ClockRegister::Cgr1, 1 << 7),
+        Peripheral::I2s => (ClockRegister::Cgr1, 1 << 8),
+        Peripheral::Rng => (ClockRegister::Cgr1, 1 << 10),
+        Peripheral::Wdg => (ClockRegister::Cgr1, (1 << 2) | (1 << 6)),
+        Peripheral::Rtc
+        | Peripheral::Iwdg
+        | Peripheral::Lptimer0
+        | Peripheral::Lptimer1
+        | Peripheral::Lcd
+        | Peripheral::Lpuart => return None,
+    };
+    Some(value)
+}
+
+fn wait_rcc_status(mask: u32, poll_limit: u32) -> Result<(), Error> {
+    wait_until(poll_limit, WaitTarget::ClockDomain, || {
+        rcc().sr().read().bits() & mask == mask
+    })
+}
+
+fn set_dual_domain_clock(
+    functional_register: ClockRegister,
+    functional_mask: u32,
+    aon_mask: u32,
+    enable: bool,
+    poll_limit: u32,
+) -> Result<(), Error> {
+    modify_clock_register(functional_register, functional_mask, enable);
+    wait_rcc_status(RCC_SR_ALL_DONE, poll_limit)?;
+    modify_clock_register(ClockRegister::Cgr2, aon_mask, enable);
+    wait_rcc_status(aon_mask, poll_limit)
+}
+
+fn set_lptimer_clock(
+    functional_mask: u32,
+    pclk_mask: u32,
+    aon_mask: u32,
+    enable: bool,
+    poll_limit: u32,
+) -> Result<(), Error> {
+    if enable {
+        modify_clock_register(ClockRegister::Cgr1, pclk_mask, true);
+        wait_rcc_status(RCC_SR_ALL_DONE, poll_limit)?;
+        modify_clock_register(ClockRegister::Cgr2, aon_mask, true);
+        wait_rcc_status(aon_mask, poll_limit)?;
+        modify_clock_register(ClockRegister::Cgr1, functional_mask, true);
+    } else {
+        modify_clock_register(ClockRegister::Cgr1, functional_mask, false);
+        wait_rcc_status(RCC_SR_ALL_DONE, poll_limit)?;
+        modify_clock_register(ClockRegister::Cgr2, aon_mask, false);
+        wait_rcc_status(aon_mask, poll_limit)?;
+        // The vendor intentionally leaves the PCLK gate enabled on disable.
+    }
+    Ok(())
+}
+
+fn set_peripheral_clock_raw(peripheral: Peripheral, enable: bool, poll_limit: u32) -> Result<(), Error> {
+    match peripheral {
+        Peripheral::Lpuart => set_dual_domain_clock(ClockRegister::Cgr0, 1 << 16, 1 << 2, enable, poll_limit),
+        Peripheral::Lcd => set_dual_domain_clock(ClockRegister::Cgr0, 1 << 6, 1 << 3, enable, poll_limit),
+        Peripheral::Rtc => set_dual_domain_clock(ClockRegister::Cgr1, 1 << 1, 1 << 1, enable, poll_limit),
+        Peripheral::Iwdg => set_dual_domain_clock(ClockRegister::Cgr1, 1 << 3, 1 << 0, enable, poll_limit),
+        Peripheral::Lptimer0 => set_lptimer_clock(1 << 4, 1 << 9, 1 << 4, enable, poll_limit),
+        Peripheral::Lptimer1 => set_lptimer_clock(1 << 11, 1 << 12, 1 << 5, enable, poll_limit),
+        _ => {
+            let (register, mask) = basic_clock(peripheral).unwrap();
+            modify_clock_register(register, mask, enable);
+            Ok(())
+        }
+    }
+}
+
+/// Enable a peripheral clock using the default bounded synchronization budget.
+pub(crate) fn enable_peripheral(peripheral: Peripheral) -> Result<(), Error> {
+    set_peripheral_clock_raw(peripheral, true, Config::new().readiness_poll_limit)
+}
+
+/// Disable a peripheral clock using the default bounded synchronization budget.
+pub(crate) fn disable_peripheral(peripheral: Peripheral) -> Result<(), Error> {
+    set_peripheral_clock_raw(peripheral, false, Config::new().readiness_poll_limit)
+}
+
+#[derive(Clone, Copy)]
+enum ResetRegister {
+    Rst0,
+    Rst1,
+}
+
+fn reset_bit(peripheral: Peripheral) -> Result<(ResetRegister, u32), Error> {
+    let bit = match peripheral {
+        Peripheral::Sac => (ResetRegister::Rst0, 0),
+        Peripheral::Sec => (ResetRegister::Rst0, 1),
+        Peripheral::Crc => (ResetRegister::Rst0, 2),
+        Peripheral::Rtc => (ResetRegister::Rst0, 3),
+        Peripheral::Wdg => (ResetRegister::Rst0, 4),
+        Peripheral::Iwdg => (ResetRegister::Rst0, 5),
+        Peripheral::Lptimer0 => (ResetRegister::Rst0, 6),
+        Peripheral::Bstimer1 => (ResetRegister::Rst0, 7),
+        Peripheral::Bstimer0 => (ResetRegister::Rst0, 8),
+        Peripheral::Timer3 => (ResetRegister::Rst0, 9),
+        Peripheral::Timer2 => (ResetRegister::Rst0, 10),
+        Peripheral::Timer1 => (ResetRegister::Rst0, 11),
+        Peripheral::Timer0 => (ResetRegister::Rst0, 12),
+        Peripheral::GpioA | Peripheral::GpioB | Peripheral::GpioC | Peripheral::GpioD => (ResetRegister::Rst0, 13),
+        Peripheral::Lora => (ResetRegister::Rst0, 14),
+        Peripheral::Dac => (ResetRegister::Rst0, 15),
+        Peripheral::Lcd => (ResetRegister::Rst0, 16),
+        Peripheral::Afec => (ResetRegister::Rst0, 17),
+        Peripheral::Adc => (ResetRegister::Rst0, 18),
+        Peripheral::I2c2 => (ResetRegister::Rst0, 20),
+        Peripheral::I2c1 => (ResetRegister::Rst0, 21),
+        Peripheral::I2c0 => (ResetRegister::Rst0, 22),
+        Peripheral::Qspi => (ResetRegister::Rst0, 23),
+        Peripheral::Ssp2 => (ResetRegister::Rst0, 24),
+        Peripheral::Ssp1 => (ResetRegister::Rst0, 25),
+        Peripheral::Ssp0 => (ResetRegister::Rst0, 26),
+        Peripheral::Lpuart => (ResetRegister::Rst0, 27),
+        Peripheral::Uart3 => (ResetRegister::Rst0, 28),
+        Peripheral::Uart2 => (ResetRegister::Rst0, 29),
+        Peripheral::Uart1 => (ResetRegister::Rst0, 30),
+        Peripheral::Uart0 => (ResetRegister::Rst0, 31),
+        Peripheral::Dma1 => (ResetRegister::Rst1, 0),
+        Peripheral::Dma0 => (ResetRegister::Rst1, 1),
+        Peripheral::I2s => (ResetRegister::Rst1, 2),
+        Peripheral::Rng => (ResetRegister::Rst1, 3),
+        Peripheral::Lptimer1 => (ResetRegister::Rst1, 4),
+        Peripheral::Syscfg | Peripheral::Pwr => {
+            return Err(Error::ResetUnsupported(peripheral));
+        }
+    };
+    Ok((bit.0, 1 << bit.1))
+}
+
+fn reset_needs_release_delay(peripheral: Peripheral) -> bool {
+    matches!(
+        peripheral,
+        Peripheral::Lptimer0
+            | Peripheral::Lptimer1
+            | Peripheral::Lcd
+            | Peripheral::Rtc
+            | Peripheral::Iwdg
+            | Peripheral::Lpuart
+    )
+}
+
+fn set_reset_line(peripheral: Peripheral, asserted: bool) -> Result<(), Error> {
+    let (register, mask) = reset_bit(peripheral)?;
+    critical_section::with(|_| {
+        let rcc = rcc();
+        match register {
+            ResetRegister::Rst0 => rcc
+                .rst0()
+                .modify(|r, w| unsafe { w.bits(update_bits(r.bits(), mask, !asserted)) }),
+            ResetRegister::Rst1 => rcc
+                .rst1()
+                .modify(|r, w| unsafe { w.bits(update_bits(r.bits(), mask, !asserted)) }),
+        };
+    });
+    Ok(())
+}
+
+fn asynchronous_release_delay() -> Result<(), Error> {
+    let hclk_hz = clocks().ok_or(Error::ClocksNotInitialized)?.hclk_hz as u64;
+    let cycles = hclk_hz
+        .saturating_mul(ASYNC_RESET_DELAY_US)
+        .div_ceil(1_000_000)
+        .min(u32::MAX as u64) as u32;
+    cortex_m::asm::delay(cycles);
+    Ok(())
+}
+
+/// Assert a peripheral's active-low reset line.
+pub(crate) fn assert_peripheral_reset(peripheral: Peripheral) -> Result<(), Error> {
+    set_reset_line(peripheral, true)
+}
+
+/// Release a peripheral reset and honor the vendor's asynchronous-domain delay.
+pub(crate) fn release_peripheral_reset(peripheral: Peripheral) -> Result<(), Error> {
+    if reset_needs_release_delay(peripheral) && clocks().is_none() {
+        return Err(Error::ClocksNotInitialized);
+    }
+    set_reset_line(peripheral, false)?;
+    if reset_needs_release_delay(peripheral) {
+        asynchronous_release_delay()?;
+    }
+    Ok(())
+}
+
+/// Pulse a peripheral reset line.
+pub(crate) fn reset_peripheral(peripheral: Peripheral) -> Result<(), Error> {
+    if reset_needs_release_delay(peripheral) && clocks().is_none() {
+        return Err(Error::ClocksNotInitialized);
+    }
+    assert_peripheral_reset(peripheral)?;
+    release_peripheral_reset(peripheral)
+}

--- a/embassy-asr/src/rcc.rs
+++ b/embassy-asr/src/rcc.rs
@@ -237,6 +237,7 @@ impl Clocks {
 
 /// Hardware transition whose status did not become ready.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum WaitTarget {
     /// Internal 48 MHz RC oscillator.
     Rco48m,
@@ -250,6 +251,7 @@ pub enum WaitTarget {
 
 /// RCC configuration or peripheral-control error.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     /// A bounded readiness wait expired.
     Timeout(WaitTarget),
@@ -461,6 +463,7 @@ fn enable_oscillator(oscillator: Oscillator, xo32m_uses_tcxo: bool, poll_limit: 
 
 /// RCC-controlled peripheral clock/reset identifier.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Peripheral {
     Sac,
     Sec,

--- a/embassy-asr/src/rng.rs
+++ b/embassy-asr/src/rng.rs
@@ -1,0 +1,141 @@
+//! True random number generator.
+//!
+//! The vendor RNG implementation lives in the closed-source `libcrypto.a`.
+//! This driver reconstructs the documented register programming from
+//! `algorithm.h` / `rng.h` and the SDK example, and exposes [`rand_core::RngCore`].
+
+use rand_core::RngCore;
+
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, pac, peripherals};
+
+const RNGCLKEN: u32 = 1 << 7;
+const RNGEN: u32 = 1 << 7;
+const DATARDY: u32 = 1 << 0;
+const DATACKERR: u32 = 1 << 1;
+
+/// RNG configuration reconstructed from the vendor crypto headers.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Clock divider field written to `RNGCLK` bits `[6:0]`.
+    pub divider: u8,
+    /// Mode field written to `RNGCR` bits `[6:0]` (entropy/preprocess/postprocess).
+    pub mode: u8,
+}
+
+impl Config {
+    /// Values used by the vendor `crypto/rng` example (`rng_init(0x0f, 0xff)`).
+    pub const fn new() -> Self {
+        Self {
+            divider: 0x0f,
+            mode: 0x7f,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// RNG error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Vendor `DATACKERR` status bit was set.
+    ClockError,
+}
+
+/// Owned RNG peripheral.
+pub struct Rng<'d> {
+    _peri: Peri<'d, peripherals::RNG>,
+}
+
+impl<'d> Rng<'d> {
+    /// Enable the RNG clock domain and start the generator.
+    pub fn new(peri: Peri<'d, peripherals::RNG>, config: Config) -> Self {
+        let _ = rcc::enable_peripheral(Peripheral::Rng);
+        let this = Self { _peri: peri };
+        this.configure(config);
+        this
+    }
+
+    /// Apply configuration and enable generation.
+    pub fn configure(&self, config: Config) {
+        let regs = Self::regs();
+        unsafe {
+            regs.rngclk()
+                .write_with_zero(|w| w.bits((config.divider as u32 & 0x7f) | RNGCLKEN));
+            regs.rngcr()
+                .write_with_zero(|w| w.bits((config.mode as u32 & 0x7f) | RNGEN));
+        }
+    }
+
+    /// Stop the generator.
+    pub fn close(&self) {
+        let regs = Self::regs();
+        unsafe {
+            regs.rngcr().write_with_zero(|w| w.bits(0));
+            regs.rngclk().write_with_zero(|w| w.bits(0));
+        }
+    }
+
+    /// Fill `buf` with random bytes.
+    pub fn try_fill_bytes(&mut self, buf: &mut [u8]) -> Result<(), Error> {
+        let regs = Self::regs();
+        let mut i = 0;
+        while i < buf.len() {
+            while regs.rngsr().read().bits() & DATARDY == 0 {
+                if regs.rngsr().read().bits() & DATACKERR != 0 {
+                    return Err(Error::ClockError);
+                }
+            }
+            let word = regs.rngdata().read().bits();
+            for byte in word.to_le_bytes() {
+                if i >= buf.len() {
+                    break;
+                }
+                buf[i] = byte;
+                i += 1;
+            }
+        }
+        Ok(())
+    }
+
+    /// Return one random `u32`.
+    pub fn try_next_u32(&mut self) -> Result<u32, Error> {
+        let mut bytes = [0u8; 4];
+        self.try_fill_bytes(&mut bytes)?;
+        Ok(u32::from_le_bytes(bytes))
+    }
+
+    #[inline]
+    fn regs() -> pac::Rng {
+        unsafe { pac::Rng::steal() }
+    }
+}
+
+impl Drop for Rng<'_> {
+    fn drop(&mut self) {
+        self.close();
+        let _ = rcc::disable_peripheral(Peripheral::Rng);
+    }
+}
+
+impl RngCore for Rng<'_> {
+    fn next_u32(&mut self) -> u32 {
+        self.try_next_u32().unwrap_or(0)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let lo = RngCore::next_u32(self) as u64;
+        let hi = RngCore::next_u32(self) as u64;
+        lo | (hi << 32)
+    }
+
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        let _ = self.try_fill_bytes(dest);
+    }
+}

--- a/embassy-asr/src/sec.rs
+++ b/embassy-asr/src/sec.rs
@@ -1,0 +1,62 @@
+//! Flash security / access-error status block.
+//!
+//! The vendor SDK does not provide a dedicated SEC driver. Flash programming
+//! checks and clears `SEC.SR.FLASH_ACCESS_ERROR`; this module exposes that
+//! documented status surface and leaves undocumented filter/reset fields alone.
+
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, pac, peripherals};
+
+/// Owned SEC peripheral.
+pub struct Sec<'d> {
+    _peri: Peri<'d, peripherals::SEC>,
+}
+
+impl<'d> Sec<'d> {
+    /// Enable the SEC clock.
+    pub fn new(peri: Peri<'d, peripherals::SEC>) -> Self {
+        let _ = rcc::enable_peripheral(Peripheral::Sec);
+        Self { _peri: peri }
+    }
+
+    /// Whether a flash access-policy error is latched.
+    pub fn flash_access_error(&self) -> bool {
+        Self::regs().sr().read().flash_access_error().bit_is_set()
+    }
+
+    /// Clear the flash access-policy error flag.
+    pub fn clear_flash_access_error(&self) {
+        Self::regs().sr().modify(|_, w| w.flash_access_error().set_bit());
+    }
+
+    /// Raw status register value.
+    pub fn status_bits(&self) -> u32 {
+        Self::regs().sr().read().bits()
+    }
+
+    #[inline]
+    fn regs() -> pac::Sec {
+        unsafe { pac::Sec::steal() }
+    }
+}
+
+/// Crate-private helpers used by the flash driver.
+pub(crate) mod flash_access {
+    use crate::pac;
+
+    pub(crate) fn clear_error() {
+        let sec = unsafe { pac::Sec::steal() };
+        if sec.sr().read().flash_access_error().bit_is_set() {
+            sec.sr().modify(|_, w| w.flash_access_error().set_bit());
+        }
+    }
+
+    pub(crate) fn take_error() -> bool {
+        let sec = unsafe { pac::Sec::steal() };
+        let error = sec.sr().read().flash_access_error().bit_is_set();
+        if error {
+            sec.sr().modify(|_, w| w.flash_access_error().set_bit());
+        }
+        error
+    }
+}

--- a/embassy-asr/src/spi.rs
+++ b/embassy-asr/src/spi.rs
@@ -1,0 +1,1167 @@
+//! Master SPI driver for the ASR6601 SSP0–SSP2 (ARM PL022) blocks.
+//!
+//! Register programming follows the vendor `tremo_spi` driver. The SVD/PAC
+//! currently exposes SSP registers without field accessors, so this module uses
+//! the documented PL022 bit layouts from the SDK headers.
+//!
+//! Alternate-function numbers come from datasheet Table 4-4 (Fun=4 for every
+//! SSP signal listed there). Constructors either take typed pins that encode
+//! that AF, or accept an explicit [`AlternateFunction`] per pin.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicU8, Ordering};
+use core::task::Poll;
+
+use embassy_futures::join::join;
+use embassy_hal_internal::interrupt::InterruptExt;
+use embassy_sync::waitqueue::AtomicWaker;
+use embedded_hal::spi::{Mode as SpiMode, Phase, Polarity};
+
+use crate::dma::{
+    self, AddressMode, ChannelInstance, ControllerInstance, DataWidth as DmaWidth, Request, TransferConfig,
+    TransferOptions,
+};
+use crate::gpio::{AlternateFunction, Flex, Pin as GpioPin, Pull};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt as TypelevelInterrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::pac::ssp0::RegisterBlock;
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, PeripheralType, interrupt, pac, peripherals};
+
+// PL022 / tremo_spi register bits (fields missing from the PAC).
+const CR0_FRF_SHIFT: u32 = 4;
+const CR0_SPO: u32 = 1 << 6;
+const CR0_SPH: u32 = 1 << 7;
+const CR0_SCR_SHIFT: u32 = 8;
+const CR0_SCR_MASK: u32 = 0xff << CR0_SCR_SHIFT;
+
+const CR1_SSE: u32 = 1 << 1;
+const CR1_MS: u32 = 1 << 2;
+
+const SR_TFE: u32 = 1 << 0;
+const SR_TNF: u32 = 1 << 1;
+const SR_RNE: u32 = 1 << 2;
+const SR_BSY: u32 = 1 << 4;
+
+const INT_ROR: u32 = 1 << 0;
+const INT_RT: u32 = 1 << 1;
+const INT_RX: u32 = 1 << 2;
+const INT_TX: u32 = 1 << 3;
+
+const DMA_RX: u32 = 1 << 0;
+const DMA_TX: u32 = 1 << 1;
+
+const DSS_4BIT: u32 = 0x3;
+const DSS_8BIT: u32 = 0x7;
+const DSS_16BIT: u32 = 0xf;
+
+const FRF_MOTOROLA: u32 = 0x0;
+const FRF_TI: u32 = 0x1;
+const FRF_MICROWIRE: u32 = 0x2;
+
+const RESULT_OK: u8 = 0;
+const RESULT_OVERRUN: u8 = 1;
+
+/// SPI driver errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
+pub enum Error {
+    /// RX FIFO overrun (ROR).
+    Overrun,
+    /// Requested SCLK cannot be formed from the current PCLK dividers.
+    InvalidFrequency,
+    /// LSB-first transfers are not supported by the PL022 Motorola frame format.
+    UnsupportedBitOrder,
+    /// Embedded-hal byte transfers require [`DataWidth::Bits8`].
+    InvalidDataWidth,
+    /// Peripheral clocks are not published yet (`rcc::init` has not completed).
+    ClocksNotInitialized,
+    /// DMA transfer failed.
+    Dma(dma::Error),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Overrun => f.write_str("SPI RX overrun"),
+            Self::InvalidFrequency => f.write_str("SPI frequency is out of range"),
+            Self::UnsupportedBitOrder => f.write_str("SPI LSB-first is unsupported"),
+            Self::InvalidDataWidth => f.write_str("SPI data width is not 8 bit"),
+            Self::ClocksNotInitialized => f.write_str("RCC clocks are not initialized"),
+            Self::Dma(err) => write!(f, "SPI DMA error: {err}"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl embedded_hal::spi::Error for Error {
+    fn kind(&self) -> embedded_hal::spi::ErrorKind {
+        match self {
+            Self::Overrun => embedded_hal::spi::ErrorKind::Overrun,
+            _ => embedded_hal::spi::ErrorKind::Other,
+        }
+    }
+}
+
+/// Bit order.
+///
+/// The ASR6601 SSP Motorola frame format only shifts MSB first. Selecting
+/// [`BitOrder::LsbFirst`] returns [`Error::UnsupportedBitOrder`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum BitOrder {
+    /// Most significant bit first (hardware default).
+    MsbFirst,
+    /// Least significant bit first (unsupported on this hardware).
+    LsbFirst,
+}
+
+/// Frame format programmed into `CR0.FRF`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FrameFormat {
+    /// Motorola SPI.
+    Motorola,
+    /// Texas Instruments synchronous serial.
+    Ti,
+    /// National Microwire.
+    Microwire,
+}
+
+impl FrameFormat {
+    const fn cr0_bits(self) -> u32 {
+        match self {
+            Self::Motorola => FRF_MOTOROLA,
+            Self::Ti => FRF_TI,
+            Self::Microwire => FRF_MICROWIRE,
+        }
+    }
+}
+
+/// SSP data size (`CR0.DSS`), matching the vendor SDK constants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DataWidth {
+    /// 4-bit frames.
+    Bits4,
+    /// 8-bit frames.
+    Bits8,
+    /// 16-bit frames.
+    Bits16,
+}
+
+impl DataWidth {
+    const fn dss(self) -> u32 {
+        match self {
+            Self::Bits4 => DSS_4BIT,
+            Self::Bits8 => DSS_8BIT,
+            Self::Bits16 => DSS_16BIT,
+        }
+    }
+
+    const fn is_u16(self) -> bool {
+        matches!(self, Self::Bits16)
+    }
+}
+
+/// SPI configuration.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Config {
+    /// SPI mode (clock polarity / phase).
+    pub mode: SpiMode,
+    /// Desired SCLK frequency in hertz.
+    pub frequency: u32,
+    /// Bit order. Only [`BitOrder::MsbFirst`] is accepted.
+    pub bit_order: BitOrder,
+    /// Frame data width.
+    pub data_width: DataWidth,
+    /// Frame format.
+    pub frame_format: FrameFormat,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            mode: SpiMode {
+                polarity: Polarity::IdleLow,
+                phase: Phase::CaptureOnFirstTransition,
+            },
+            frequency: 1_000_000,
+            bit_order: BitOrder::MsbFirst,
+            data_width: DataWidth::Bits8,
+            frame_format: FrameFormat::Motorola,
+        }
+    }
+}
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Config {
+    fn format(&self, f: defmt::Formatter) {
+        defmt::write!(
+            f,
+            "Config {{ frequency: {=u32}, bit_order: {}, data_width: {}, frame_format: {} }}",
+            self.frequency,
+            self.bit_order,
+            self.data_width,
+            self.frame_format,
+        );
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PclkSel {
+    Pclk0,
+    Pclk1,
+}
+
+struct State {
+    waker: AtomicWaker,
+    result: AtomicU8,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            waker: AtomicWaker::new(),
+            result: AtomicU8::new(RESULT_OK),
+        }
+    }
+}
+
+static STATE_SSP0: State = State::new();
+static STATE_SSP1: State = State::new();
+static STATE_SSP2: State = State::new();
+
+struct Info {
+    regs: *const RegisterBlock,
+    peripheral: Peripheral,
+    pclk: PclkSel,
+    dma_tx: Request,
+    dma_rx: Request,
+    state: &'static State,
+    interrupt: pac::Interrupt,
+}
+
+// Register blocks are Sync; the pointer is unique to the owned SSP instance.
+unsafe impl Sync for Info {}
+
+/// Interrupt handler for one SSP instance.
+///
+/// Clears RX overrun / timeout, masks TX/RX FIFO interrupts, and wakes any
+/// async waiter registered by the driver.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let info = T::info();
+        let regs = &*info.regs;
+        let mis = regs.mis().read().bits();
+
+        if mis & INT_ROR != 0 {
+            info.state.result.store(RESULT_OVERRUN, Ordering::Release);
+            regs.icr().write_with_zero(|w| w.bits(INT_ROR));
+        }
+        if mis & INT_RT != 0 {
+            regs.icr().write_with_zero(|w| w.bits(INT_RT));
+        }
+
+        // Mask level-sensitive FIFO interrupts; the waiter re-enables as needed.
+        let mask = mis & (INT_TX | INT_RX);
+        if mask != 0 {
+            regs.imsc().modify(|r, w| w.bits(r.bits() & !mask));
+        }
+
+        info.state.waker.wake();
+    }
+}
+
+/// Master SPI driver.
+pub struct Spi<'d, M: Mode> {
+    info: &'static Info,
+    _sck: Option<Flex<'d>>,
+    _mosi: Option<Flex<'d>>,
+    _miso: Option<Flex<'d>>,
+    _nss: Option<Flex<'d>>,
+    tx_dma: Option<dma::Channel<'d, Async>>,
+    rx_dma: Option<dma::Channel<'d, Async>>,
+    data_width: DataWidth,
+    _mode: PhantomData<&'d mut M>,
+}
+
+fn configure_output_af<'d>(pin: Peri<'d, impl GpioPin>, af: AlternateFunction, pull: Pull) -> Flex<'d> {
+    let mut flex = Flex::new(pin);
+    flex.set_as_output();
+    flex.set_pull(pull);
+    flex.set_alternate_function(af);
+    flex
+}
+
+fn configure_input_af<'d>(pin: Peri<'d, impl GpioPin>, af: AlternateFunction, pull: Pull) -> Flex<'d> {
+    let mut flex = Flex::new(pin);
+    flex.set_as_input();
+    flex.set_pull(pull);
+    flex.set_alternate_function(af);
+    flex
+}
+
+fn sck_pull(mode: SpiMode) -> Pull {
+    match mode.polarity {
+        Polarity::IdleLow => Pull::Down,
+        Polarity::IdleHigh => Pull::Up,
+    }
+}
+
+fn calc_dividers(pclk: u32, freq: u32) -> Result<(u8, u8), Error> {
+    if freq == 0 || pclk == 0 {
+        return Err(Error::InvalidFrequency);
+    }
+
+    // SCLK = PCLK / (CPSDVSR * (SCR + 1)), CPSDVSR even in 2..=254, SCR in 0..=255.
+    let mut best: Option<(u8, u8, u32)> = None;
+    for cpsdvsr in (2u32..=254).step_by(2) {
+        let base = pclk / cpsdvsr;
+        if base < freq {
+            continue;
+        }
+        let scr_plus = base / freq;
+        if scr_plus == 0 || scr_plus > 256 {
+            continue;
+        }
+        for candidate in (scr_plus.saturating_sub(1)..=(scr_plus + 1).min(256)).rev() {
+            if candidate == 0 {
+                continue;
+            }
+            let scr = candidate - 1;
+            let actual = base / candidate;
+            if actual == 0 {
+                continue;
+            }
+            let err = actual.abs_diff(freq);
+            match best {
+                Some((_, _, best_err)) if err >= best_err => {}
+                _ => best = Some((cpsdvsr as u8, scr as u8, err)),
+            }
+            if err == 0 {
+                return Ok((cpsdvsr as u8, scr as u8));
+            }
+        }
+    }
+
+    best.map(|(c, s, _)| (c, s)).ok_or(Error::InvalidFrequency)
+}
+
+impl<'d, M: Mode> Spi<'d, M> {
+    fn new_inner<T: Instance>(
+        _spi: Peri<'d, T>,
+        sck: Option<Flex<'d>>,
+        mosi: Option<Flex<'d>>,
+        miso: Option<Flex<'d>>,
+        nss: Option<Flex<'d>>,
+        tx_dma: Option<dma::Channel<'d, Async>>,
+        rx_dma: Option<dma::Channel<'d, Async>>,
+        config: Config,
+        enable_irq: bool,
+    ) -> Result<Self, Error> {
+        let info = T::info();
+
+        let _ = rcc::enable_peripheral(info.peripheral);
+        let _ = rcc::reset_peripheral(info.peripheral);
+
+        let mut spi = Self {
+            info,
+            _sck: sck,
+            _mosi: mosi,
+            _miso: miso,
+            _nss: nss,
+            tx_dma,
+            rx_dma,
+            data_width: config.data_width,
+            _mode: PhantomData,
+        };
+
+        spi.configure(&config)?;
+
+        info.state.result.store(RESULT_OK, Ordering::Release);
+        unsafe {
+            let regs = &*info.regs;
+            regs.imsc().write_with_zero(|w| w.bits(0));
+            regs.icr().write_with_zero(|w| w.bits(INT_ROR | INT_RT));
+        }
+
+        if enable_irq {
+            info.interrupt.unpend();
+            unsafe {
+                info.interrupt.enable();
+            }
+        }
+
+        spi.set_enabled(true);
+        Ok(spi)
+    }
+
+    fn configure(&mut self, config: &Config) -> Result<(), Error> {
+        if config.bit_order == BitOrder::LsbFirst {
+            return Err(Error::UnsupportedBitOrder);
+        }
+
+        let clocks = rcc::clocks().ok_or(Error::ClocksNotInitialized)?;
+        let pclk = match self.info.pclk {
+            PclkSel::Pclk0 => clocks.pclk0_hz,
+            PclkSel::Pclk1 => clocks.pclk1_hz,
+        };
+        let (cpsdvsr, scr) = calc_dividers(pclk, config.frequency)?;
+
+        let mut cr0 = config.data_width.dss();
+        cr0 |= config.frame_format.cr0_bits() << CR0_FRF_SHIFT;
+        if config.mode.polarity == Polarity::IdleHigh {
+            cr0 |= CR0_SPO;
+        }
+        if config.mode.phase == Phase::CaptureOnSecondTransition {
+            cr0 |= CR0_SPH;
+        }
+        cr0 |= (scr as u32) << CR0_SCR_SHIFT;
+
+        self.set_enabled(false);
+        unsafe {
+            let regs = &*self.info.regs;
+            regs.cpsr().write_with_zero(|w| w.bits(cpsdvsr as u32));
+            regs.cr0().write_with_zero(|w| w.bits(cr0));
+            // Master mode, SSP disabled until set_enabled(true).
+            regs.cr1().write_with_zero(|w| w.bits(0));
+            let mut dma_cr = 0;
+            if self.tx_dma.is_some() {
+                dma_cr |= DMA_TX;
+            }
+            if self.rx_dma.is_some() {
+                dma_cr |= DMA_RX;
+            }
+            regs.dma_cr().write_with_zero(|w| w.bits(dma_cr));
+        }
+        self.data_width = config.data_width;
+        Ok(())
+    }
+
+    fn set_enabled(&mut self, enabled: bool) {
+        unsafe {
+            let regs = &*self.info.regs;
+            regs.cr1().modify(|r, w| {
+                let bits = if enabled {
+                    (r.bits() & !CR1_MS) | CR1_SSE
+                } else {
+                    r.bits() & !CR1_SSE
+                };
+                w.bits(bits)
+            });
+        }
+    }
+
+    fn sr(&self) -> u32 {
+        unsafe { (*self.info.regs).sr().read().bits() }
+    }
+
+    fn take_error(&self) -> Result<(), Error> {
+        match self.info.state.result.swap(RESULT_OK, Ordering::AcqRel) {
+            RESULT_OVERRUN => Err(Error::Overrun),
+            _ => Ok(()),
+        }
+    }
+
+    fn drain_rx(&mut self) {
+        unsafe {
+            let regs = &*self.info.regs;
+            while regs.sr().read().bits() & SR_RNE != 0 {
+                let _ = regs.dr().read().bits();
+            }
+            regs.icr().write_with_zero(|w| w.bits(INT_ROR | INT_RT));
+        }
+        self.info.state.result.store(RESULT_OK, Ordering::Release);
+    }
+
+    fn write_frame(&mut self, frame: u16) {
+        unsafe {
+            (*self.info.regs).dr().write_with_zero(|w| w.bits(frame as u32));
+        }
+    }
+
+    fn read_frame(&mut self) -> u16 {
+        unsafe { (*self.info.regs).dr().read().bits() as u16 }
+    }
+
+    /// Reconfigure the SPI peripheral.
+    pub fn set_config(&mut self, config: &Config) -> Result<(), Error> {
+        self.configure(config)?;
+        self.set_enabled(true);
+        Ok(())
+    }
+
+    /// Change only the SCLK frequency.
+    pub fn set_frequency(&mut self, frequency: u32) -> Result<(), Error> {
+        let clocks = rcc::clocks().ok_or(Error::ClocksNotInitialized)?;
+        let pclk = match self.info.pclk {
+            PclkSel::Pclk0 => clocks.pclk0_hz,
+            PclkSel::Pclk1 => clocks.pclk1_hz,
+        };
+        let (cpsdvsr, scr) = calc_dividers(pclk, frequency)?;
+        self.set_enabled(false);
+        unsafe {
+            let regs = &*self.info.regs;
+            regs.cpsr().write_with_zero(|w| w.bits(cpsdvsr as u32));
+            regs.cr0()
+                .modify(|r, w| w.bits((r.bits() & !CR0_SCR_MASK) | ((scr as u32) << CR0_SCR_SHIFT)));
+        }
+        self.set_enabled(true);
+        Ok(())
+    }
+
+    /// Block until the SSP is idle.
+    pub fn blocking_flush(&mut self) -> Result<(), Error> {
+        while self.sr() & SR_BSY != 0 {}
+        self.take_error()
+    }
+
+    /// Blocking write. Received bytes are discarded.
+    pub fn blocking_write(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.ensure_u8()?;
+        for &b in data {
+            while self.sr() & SR_TNF == 0 {}
+            self.write_frame(b as u16);
+            while self.sr() & SR_RNE == 0 {}
+            let _ = self.read_frame();
+        }
+        self.blocking_flush()?;
+        self.drain_rx();
+        Ok(())
+    }
+
+    /// Blocking read. Dummy `0x00` frames are transmitted.
+    pub fn blocking_read(&mut self, data: &mut [u8]) -> Result<(), Error> {
+        self.blocking_transfer(data, &[])
+    }
+
+    /// Blocking full-duplex transfer.
+    pub fn blocking_transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
+        self.ensure_u8()?;
+        let len = read.len().max(write.len());
+        for i in 0..len {
+            let tx = write.get(i).copied().unwrap_or(0);
+            while self.sr() & SR_TNF == 0 {}
+            self.write_frame(tx as u16);
+            while self.sr() & SR_RNE == 0 {}
+            let rx = self.read_frame() as u8;
+            if let Some(slot) = read.get_mut(i) {
+                *slot = rx;
+            }
+        }
+        self.blocking_flush()
+    }
+
+    /// Blocking in-place full-duplex transfer.
+    pub fn blocking_transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Error> {
+        self.ensure_u8()?;
+        for b in data {
+            while self.sr() & SR_TNF == 0 {}
+            self.write_frame(*b as u16);
+            while self.sr() & SR_RNE == 0 {}
+            *b = self.read_frame() as u8;
+        }
+        self.blocking_flush()
+    }
+
+    /// Blocking write of 16-bit frames. Requires [`DataWidth::Bits16`].
+    pub fn blocking_write_u16(&mut self, data: &[u16]) -> Result<(), Error> {
+        if !self.data_width.is_u16() {
+            return Err(Error::InvalidDataWidth);
+        }
+        for &w in data {
+            while self.sr() & SR_TNF == 0 {}
+            self.write_frame(w);
+            while self.sr() & SR_RNE == 0 {}
+            let _ = self.read_frame();
+        }
+        self.blocking_flush()?;
+        self.drain_rx();
+        Ok(())
+    }
+
+    /// Blocking read of 16-bit frames. Requires [`DataWidth::Bits16`].
+    pub fn blocking_read_u16(&mut self, data: &mut [u16]) -> Result<(), Error> {
+        if !self.data_width.is_u16() {
+            return Err(Error::InvalidDataWidth);
+        }
+        for slot in data.iter_mut() {
+            while self.sr() & SR_TNF == 0 {}
+            self.write_frame(0);
+            while self.sr() & SR_RNE == 0 {}
+            *slot = self.read_frame();
+        }
+        self.blocking_flush()
+    }
+
+    fn ensure_u8(&self) -> Result<(), Error> {
+        if self.data_width == DataWidth::Bits8 {
+            Ok(())
+        } else {
+            Err(Error::InvalidDataWidth)
+        }
+    }
+
+    fn dr_ptr(&self) -> *mut u32 {
+        unsafe { (*self.info.regs).dr().as_ptr() }
+    }
+}
+
+impl<'d> Spi<'d, Blocking> {
+    /// Create a blocking master with SCK, MOSI, and MISO.
+    pub fn new_blocking<T: Instance, Sck: SckPin<T>, Mosi: MosiPin<T>, Miso: MisoPin<T>>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, Sck>,
+        mosi: Peri<'d, Mosi>,
+        miso: Peri<'d, Miso>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, Sck::AF, pull)),
+            Some(configure_output_af(mosi, Mosi::AF, Pull::None)),
+            Some(configure_input_af(miso, Miso::AF, Pull::None)),
+            None,
+            None,
+            None,
+            config,
+            false,
+        )
+    }
+
+    /// Create a blocking master with explicit alternate-function numbers.
+    pub fn new_blocking_af<T: Instance>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, impl GpioPin + 'd>,
+        sck_af: AlternateFunction,
+        mosi: Peri<'d, impl GpioPin + 'd>,
+        mosi_af: AlternateFunction,
+        miso: Peri<'d, impl GpioPin + 'd>,
+        miso_af: AlternateFunction,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, sck_af, pull)),
+            Some(configure_output_af(mosi, mosi_af, Pull::None)),
+            Some(configure_input_af(miso, miso_af, Pull::None)),
+            None,
+            None,
+            None,
+            config,
+            false,
+        )
+    }
+
+    /// Blocking transmit-only master (MOSI + SCK).
+    pub fn new_blocking_txonly<T: Instance, Sck: SckPin<T>, Mosi: MosiPin<T>>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, Sck>,
+        mosi: Peri<'d, Mosi>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, Sck::AF, pull)),
+            Some(configure_output_af(mosi, Mosi::AF, Pull::None)),
+            None,
+            None,
+            None,
+            None,
+            config,
+            false,
+        )
+    }
+
+    /// Blocking receive-only master (MISO + SCK).
+    pub fn new_blocking_rxonly<T: Instance, Sck: SckPin<T>, Miso: MisoPin<T>>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, Sck>,
+        miso: Peri<'d, Miso>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, Sck::AF, pull)),
+            None,
+            Some(configure_input_af(miso, Miso::AF, Pull::None)),
+            None,
+            None,
+            None,
+            config,
+            false,
+        )
+    }
+
+    /// Blocking master that also muxes the hardware NSS/FSS pin.
+    pub fn new_blocking_with_nss<T: Instance, Sck: SckPin<T>, Mosi: MosiPin<T>, Miso: MisoPin<T>, Nss: NssPin<T>>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, Sck>,
+        mosi: Peri<'d, Mosi>,
+        miso: Peri<'d, Miso>,
+        nss: Peri<'d, Nss>,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, Sck::AF, pull)),
+            Some(configure_output_af(mosi, Mosi::AF, Pull::None)),
+            Some(configure_input_af(miso, Miso::AF, Pull::None)),
+            Some(configure_output_af(nss, Nss::AF, Pull::Up)),
+            None,
+            None,
+            config,
+            false,
+        )
+    }
+}
+
+impl<'d> Spi<'d, Async> {
+    /// Create an async master using SSP FIFO interrupts (no DMA).
+    pub fn new<T: Instance, Sck: SckPin<T>, Mosi: MosiPin<T>, Miso: MisoPin<T>>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, Sck>,
+        mosi: Peri<'d, Mosi>,
+        miso: Peri<'d, Miso>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, Sck::AF, pull)),
+            Some(configure_output_af(mosi, Mosi::AF, Pull::None)),
+            Some(configure_input_af(miso, Miso::AF, Pull::None)),
+            None,
+            None,
+            None,
+            config,
+            true,
+        )
+    }
+
+    /// Create an async master with explicit alternate-function numbers.
+    pub fn new_af<T: Instance>(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, impl GpioPin + 'd>,
+        sck_af: AlternateFunction,
+        mosi: Peri<'d, impl GpioPin + 'd>,
+        mosi_af: AlternateFunction,
+        miso: Peri<'d, impl GpioPin + 'd>,
+        miso_af: AlternateFunction,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, sck_af, pull)),
+            Some(configure_output_af(mosi, mosi_af, Pull::None)),
+            Some(configure_input_af(miso, miso_af, Pull::None)),
+            None,
+            None,
+            None,
+            config,
+            true,
+        )
+    }
+
+    /// Create an async master that uses DMA for transfers.
+    ///
+    /// Bind both the SSP interrupt (overrun / timeout) and the DMA controller
+    /// interrupt(s) used by the supplied channels.
+    pub fn new_with_dma<
+        T: Instance,
+        Sck: SckPin<T>,
+        Mosi: MosiPin<T>,
+        Miso: MisoPin<T>,
+        TxDma: ChannelInstance,
+        RxDma: ChannelInstance,
+    >(
+        spi: Peri<'d, T>,
+        sck: Peri<'d, Sck>,
+        mosi: Peri<'d, Mosi>,
+        miso: Peri<'d, Miso>,
+        tx_dma: Peri<'d, TxDma>,
+        rx_dma: Peri<'d, RxDma>,
+        irq: impl Binding<T::Interrupt, InterruptHandler<T>>
+        + Binding<<TxDma::Controller as ControllerInstance>::Interrupt, dma::InterruptHandler<TxDma::Controller>>
+        + Binding<<RxDma::Controller as ControllerInstance>::Interrupt, dma::InterruptHandler<RxDma::Controller>>
+        + Copy
+        + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        let pull = sck_pull(config.mode);
+        let tx = dma::Channel::new(tx_dma, irq);
+        let rx = dma::Channel::new(rx_dma, irq);
+        Self::new_inner::<T>(
+            spi,
+            Some(configure_output_af(sck, Sck::AF, pull)),
+            Some(configure_output_af(mosi, Mosi::AF, Pull::None)),
+            Some(configure_input_af(miso, Miso::AF, Pull::None)),
+            None,
+            Some(tx),
+            Some(rx),
+            config,
+            true,
+        )
+    }
+
+    async fn wait_sr(&mut self, mask: u32) -> Result<(), Error> {
+        poll_fn(|cx| {
+            if let Err(e) = self.take_error() {
+                return Poll::Ready(Err(e));
+            }
+            if self.sr() & mask != 0 {
+                return Poll::Ready(Ok(()));
+            }
+            self.info.state.waker.register(cx.waker());
+            unsafe {
+                let regs = &*self.info.regs;
+                let ie = if mask & SR_TNF != 0 { INT_TX } else { 0 }
+                    | if mask & (SR_RNE | SR_TFE) != 0 {
+                        INT_RX | INT_RT | INT_TX
+                    } else {
+                        0
+                    }
+                    | INT_ROR;
+                regs.imsc().modify(|r, w| w.bits(r.bits() | ie));
+            }
+            if self.sr() & mask != 0 {
+                return Poll::Ready(Ok(()));
+            }
+            if let Err(e) = self.take_error() {
+                return Poll::Ready(Err(e));
+            }
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// Async write using FIFO interrupts (or DMA when configured).
+    pub async fn write(&mut self, data: &[u8]) -> Result<(), Error> {
+        self.ensure_u8()?;
+        if data.is_empty() {
+            return Ok(());
+        }
+        if self.tx_dma.is_some() {
+            return self.write_dma(data).await;
+        }
+        for &b in data {
+            self.wait_sr(SR_TNF).await?;
+            self.write_frame(b as u16);
+            self.wait_sr(SR_RNE).await?;
+            let _ = self.read_frame();
+        }
+        self.flush_async().await
+    }
+
+    /// Async read using FIFO interrupts (or DMA when configured).
+    pub async fn read(&mut self, data: &mut [u8]) -> Result<(), Error> {
+        self.transfer(data, &[]).await
+    }
+
+    /// Async full-duplex transfer.
+    pub async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
+        self.ensure_u8()?;
+        if read.is_empty() && write.is_empty() {
+            return Ok(());
+        }
+        if self.tx_dma.is_some() && self.rx_dma.is_some() {
+            return self.transfer_dma(read, write).await;
+        }
+
+        let len = read.len().max(write.len());
+        for i in 0..len {
+            let tx = write.get(i).copied().unwrap_or(0);
+            self.wait_sr(SR_TNF).await?;
+            self.write_frame(tx as u16);
+            self.wait_sr(SR_RNE).await?;
+            let rx = self.read_frame() as u8;
+            if let Some(slot) = read.get_mut(i) {
+                *slot = rx;
+            }
+        }
+        self.flush_async().await
+    }
+
+    /// Async in-place full-duplex transfer.
+    pub async fn transfer_in_place(&mut self, data: &mut [u8]) -> Result<(), Error> {
+        self.ensure_u8()?;
+        if self.tx_dma.is_some() && self.rx_dma.is_some() {
+            // SAFETY: exclusive borrow of `data`; DMA reads TX from the same
+            // buffer while writing RX back into it, matching full-duplex SPI.
+            let write = unsafe { core::slice::from_raw_parts(data.as_ptr(), data.len()) };
+            return self.transfer_dma(data, write).await;
+        }
+        for b in data.iter_mut() {
+            self.wait_sr(SR_TNF).await?;
+            self.write_frame(*b as u16);
+            self.wait_sr(SR_RNE).await?;
+            *b = self.read_frame() as u8;
+        }
+        self.flush_async().await
+    }
+
+    async fn flush_async(&mut self) -> Result<(), Error> {
+        while self.sr() & SR_BSY != 0 {
+            self.wait_sr(SR_TFE).await?;
+            if self.sr() & SR_BSY == 0 {
+                break;
+            }
+        }
+        self.take_error()
+    }
+
+    async fn write_dma(&mut self, data: &[u8]) -> Result<(), Error> {
+        let dr = self.dr_ptr();
+        let request = self.info.dma_tx;
+        let tx = self.tx_dma.as_mut().unwrap();
+        unsafe { tx.write(data, dr.cast(), request, TransferOptions::default()) }
+            .map_err(Error::Dma)?
+            .await
+            .map_err(Error::Dma)?;
+
+        while self.sr() & SR_BSY != 0 {}
+        self.drain_rx();
+        self.take_error()
+    }
+
+    async fn transfer_dma(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Error> {
+        let dr = self.dr_ptr();
+        let tx_req = self.info.dma_tx;
+        let rx_req = self.info.dma_rx;
+        let rx_len = read.len();
+        let tx_len = write.len();
+
+        if rx_len == 0 {
+            return self.write_dma(write).await;
+        }
+
+        let tx = self.tx_dma.as_mut().unwrap();
+        let rx = self.rx_dma.as_mut().unwrap();
+
+        // Start RX before TX so early clocks are not lost.
+        let rx_xfer =
+            unsafe { rx.read(dr.cast::<u8>(), read, rx_req, TransferOptions::default()) }.map_err(Error::Dma)?;
+
+        let tx_future = async {
+            if tx_len == 0 {
+                let dummy = 0u8;
+                let mut config = TransferConfig::memory_to_peripheral(DmaWidth::Bits8, tx_req);
+                config.source_address = AddressMode::Fixed;
+                unsafe { tx.transfer_raw(&dummy as *const u8, dr.cast(), rx_len, config) }
+                    .map_err(Error::Dma)?
+                    .await
+                    .map_err(Error::Dma)?;
+            } else if tx_len >= rx_len {
+                unsafe { tx.write(write, dr.cast(), tx_req, TransferOptions::default()) }
+                    .map_err(Error::Dma)?
+                    .await
+                    .map_err(Error::Dma)?;
+            } else {
+                unsafe { tx.write(&write[..tx_len], dr.cast(), tx_req, TransferOptions::default()) }
+                    .map_err(Error::Dma)?
+                    .await
+                    .map_err(Error::Dma)?;
+
+                let dummy = 0u8;
+                let mut config = TransferConfig::memory_to_peripheral(DmaWidth::Bits8, tx_req);
+                config.source_address = AddressMode::Fixed;
+                let remaining = rx_len - tx_len;
+                unsafe { tx.transfer_raw(&dummy as *const u8, dr.cast(), remaining, config) }
+                    .map_err(Error::Dma)?
+                    .await
+                    .map_err(Error::Dma)?;
+            }
+            Ok::<(), Error>(())
+        };
+
+        let (tx_res, rx_res) = join(tx_future, rx_xfer).await;
+        tx_res?;
+        rx_res.map_err(Error::Dma)?;
+
+        if tx_len > rx_len {
+            while self.sr() & SR_BSY != 0 {}
+            self.drain_rx();
+        }
+        self.take_error()
+    }
+}
+
+impl<'d, M: Mode> Drop for Spi<'d, M> {
+    fn drop(&mut self) {
+        self.set_enabled(false);
+        unsafe {
+            let regs = &*self.info.regs;
+            regs.imsc().write_with_zero(|w| w.bits(0));
+            regs.dma_cr().write_with_zero(|w| w.bits(0));
+            regs.icr().write_with_zero(|w| w.bits(INT_ROR | INT_RT));
+        }
+        self.info.interrupt.disable();
+    }
+}
+
+mod sealed {
+    use super::Info;
+
+    pub trait Instance {
+        fn info() -> &'static Info;
+    }
+}
+
+/// SSP instance.
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// NVIC vector for this SSP.
+    type Interrupt: TypelevelInterrupt;
+}
+
+macro_rules! impl_instance {
+    ($peri:ident, $pac:ident, $rcc:ident, $pclk:ident, $tx:ident, $rx:ident, $state:ident, $irq:ident) => {
+        impl sealed::Instance for peripherals::$peri {
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    regs: pac::$pac::PTR,
+                    peripheral: Peripheral::$rcc,
+                    pclk: PclkSel::$pclk,
+                    dma_tx: Request::$tx,
+                    dma_rx: Request::$rx,
+                    state: &$state,
+                    interrupt: pac::Interrupt::$irq,
+                };
+                &INFO
+            }
+        }
+
+        impl Instance for peripherals::$peri {
+            type Interrupt = interrupt::typelevel::$irq;
+        }
+    };
+}
+
+impl_instance!(SSP0, Ssp0, Ssp0, Pclk0, Ssp0Tx, Ssp0Rx, STATE_SSP0, SSP0);
+impl_instance!(SSP1, Ssp1, Ssp1, Pclk1, Ssp1Tx, Ssp1Rx, STATE_SSP1, SSP1);
+impl_instance!(SSP2, Ssp2, Ssp2, Pclk1, Ssp2Tx, Ssp2Rx, STATE_SSP2, SSP2);
+
+/// SCK pin for an SSP instance.
+pub trait SckPin<T: Instance>: GpioPin {
+    /// Datasheet alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+/// MOSI / SSP_TX pin for an SSP instance.
+pub trait MosiPin<T: Instance>: GpioPin {
+    /// Datasheet alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+/// MISO / SSP_RX pin for an SSP instance.
+pub trait MisoPin<T: Instance>: GpioPin {
+    /// Datasheet alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+/// NSS / SSP_FSS pin for an SSP instance.
+pub trait NssPin<T: Instance>: GpioPin {
+    /// Datasheet alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+macro_rules! impl_pin {
+    ($pin:ident, $instance:ident, $trait:ident, $af:ident) => {
+        impl $trait<peripherals::$instance> for peripherals::$pin {
+            const AF: AlternateFunction = AlternateFunction::$af;
+        }
+    };
+}
+
+// Table 4-4: every documented SSP remap uses Fun=4.
+impl_pin!(PA0, SSP0, SckPin, Function4);
+impl_pin!(PA1, SSP0, NssPin, Function4);
+impl_pin!(PA2, SSP0, MosiPin, Function4);
+impl_pin!(PA3, SSP0, MisoPin, Function4);
+impl_pin!(PB7, SSP0, MisoPin, Function4);
+impl_pin!(PC12, SSP0, SckPin, Function4);
+impl_pin!(PC13, SSP0, NssPin, Function4);
+impl_pin!(PC15, SSP0, MisoPin, Function4);
+
+impl_pin!(PA4, SSP1, SckPin, Function4);
+impl_pin!(PA5, SSP1, NssPin, Function4);
+impl_pin!(PA6, SSP1, MosiPin, Function4);
+impl_pin!(PA7, SSP1, MisoPin, Function4);
+impl_pin!(PB8, SSP1, SckPin, Function4);
+impl_pin!(PB9, SSP1, NssPin, Function4);
+impl_pin!(PB10, SSP1, MosiPin, Function4);
+impl_pin!(PB11, SSP1, MisoPin, Function4);
+
+impl_pin!(PA8, SSP2, SckPin, Function4);
+impl_pin!(PA9, SSP2, NssPin, Function4);
+impl_pin!(PA10, SSP2, MosiPin, Function4);
+impl_pin!(PA11, SSP2, MisoPin, Function4);
+impl_pin!(PB12, SSP2, SckPin, Function4);
+impl_pin!(PB13, SSP2, NssPin, Function4);
+impl_pin!(PB14, SSP2, MosiPin, Function4);
+impl_pin!(PB15, SSP2, MisoPin, Function4);
+
+impl<'d, M: Mode> embedded_hal::spi::ErrorType for Spi<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_hal::spi::SpiBus<u8> for Spi<'d, M> {
+    fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_read(words)
+    }
+
+    fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_write(words)
+    }
+
+    fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        self.blocking_transfer(read, write)
+    }
+
+    fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        self.blocking_transfer_in_place(words)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush()
+    }
+}
+
+impl<'d> embedded_hal_async::spi::SpiBus<u8> for Spi<'d, Async> {
+    async fn read(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        self.read(words).await
+    }
+
+    async fn write(&mut self, words: &[u8]) -> Result<(), Self::Error> {
+        self.write(words).await
+    }
+
+    async fn transfer(&mut self, read: &mut [u8], write: &[u8]) -> Result<(), Self::Error> {
+        self.transfer(read, write).await
+    }
+
+    async fn transfer_in_place(&mut self, words: &mut [u8]) -> Result<(), Self::Error> {
+        self.transfer_in_place(words).await
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.flush_async().await
+    }
+}

--- a/embassy-asr/src/syscfg.rs
+++ b/embassy-asr/src/syscfg.rs
@@ -1,0 +1,255 @@
+//! System configuration controller.
+//!
+//! The vendor SDK uses this block for DMA request routing, a software boot-mode
+//! flag, and I2S master word-select generation. The PAC currently exposes the
+//! SYSCFG registers as raw words, so this module only touches bits exercised by
+//! the SDK and preserves every other bit.
+
+use crate::{Peri, pac, peripherals};
+
+const DMA_REQUEST_MASK: u32 = 0x3f;
+
+const BOOT_MODE_FLAG: u32 = 1 << 29;
+
+const I2S_MASTER_ENABLE: u32 = 1 << 14;
+// All divisors emitted by the vendor SDK need six bits. Bit 22 is the next
+// documented field, but bit 21 is otherwise undocumented and is left alone.
+const I2S_WORD_SELECT_DIVIDER_MASK: u32 = 0x3f << 15;
+const I2S_WORD_SELECT_ENABLE: u32 = 1 << 22;
+
+/// DMA controller whose request input is being routed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DmaController {
+    /// DMA controller 0, routed through SYSCFG CR0.
+    Dma0,
+    /// DMA controller 1, routed through SYSCFG CR1.
+    Dma1,
+}
+
+/// Channel within a DMA controller.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DmaChannel {
+    Channel0,
+    Channel1,
+    Channel2,
+    Channel3,
+}
+
+impl DmaChannel {
+    const fn request_shift(self) -> u32 {
+        // The SDK assigns one byte per channel in descending channel order:
+        // channel 0 occupies bits 29:24 and channel 3 occupies bits 5:0.
+        match self {
+            Self::Channel0 => 24,
+            Self::Channel1 => 16,
+            Self::Channel2 => 8,
+            Self::Channel3 => 0,
+        }
+    }
+}
+
+/// Peripheral request routed to a DMA channel.
+///
+/// Values match `dma_hand_shake_t` in the ASR6601 vendor SDK. The gaps in that
+/// table are intentionally not representable.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum DmaRequest {
+    LoracTx = 4,
+    LoracRx = 5,
+    Dac = 6,
+    Adc = 7,
+    Scc = 9,
+    I2c2Tx = 10,
+    I2c2Rx = 11,
+    I2c1Tx = 12,
+    I2c1Rx = 13,
+    I2c0Tx = 14,
+    I2c0Rx = 15,
+    Ssp2Tx = 16,
+    Ssp2Rx = 17,
+    Ssp1Tx = 18,
+    Ssp1Rx = 19,
+    Ssp0Tx = 20,
+    Ssp0Rx = 21,
+    LpuartTx = 22,
+    LpuartRx = 23,
+    Uart3Tx = 24,
+    Uart3Rx = 25,
+    Uart2Tx = 26,
+    Uart2Rx = 27,
+    Uart1Tx = 28,
+    Uart1Rx = 29,
+    Uart0Tx = 30,
+    Uart0Rx = 31,
+    Timer0Channel3 = 32,
+    Timer0Channel2 = 33,
+    Timer0Channel1 = 34,
+    Timer0Channel0 = 35,
+    Timer0Trigger = 36,
+    Timer0Update = 37,
+    Timer1Channel3 = 38,
+    Timer1Channel2 = 39,
+    Timer1Channel1 = 40,
+    Timer1Channel0 = 41,
+    Timer1Trigger = 42,
+    Timer1Update = 43,
+    Timer2Channel1 = 44,
+    Timer2Channel0 = 45,
+    Timer2Trigger = 46,
+    Timer2Update = 47,
+    Timer3Channel1 = 48,
+    Timer3Channel0 = 49,
+    Timer3Trigger = 50,
+    Timer3Update = 51,
+    BasicTimer1Update = 52,
+    BasicTimer0Update = 53,
+}
+
+/// I2S sample word size used to derive the vendor word-select divisor.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum I2sWordSize {
+    /// The DesignWare I2S "don't care" encoding.
+    DontCare,
+    Bits12,
+    Bits16,
+    Bits20,
+    Bits24,
+    Bits32,
+}
+
+impl I2sWordSize {
+    const fn word_select_divider(self) -> u32 {
+        // These are the exact results of the SDK's i2s_calculate_devision().
+        match self {
+            Self::DontCare | Self::Bits20 => 21,
+            Self::Bits12 => 13,
+            Self::Bits16 => 17,
+            Self::Bits24 => 25,
+            Self::Bits32 => 33,
+        }
+    }
+}
+
+/// Owned access to the system configuration controller.
+///
+/// Dropping this value does not gate the SYSCFG clock because DMA and I2S
+/// drivers may still depend on routes configured here.
+pub struct Syscfg<'d> {
+    _peri: Peri<'d, peripherals::SYSCFG>,
+}
+
+impl<'d> Syscfg<'d> {
+    /// Create an owned SYSCFG controller and enable its peripheral clock.
+    pub fn new(peri: Peri<'d, peripherals::SYSCFG>) -> Self {
+        enable_clock();
+        Self { _peri: peri }
+    }
+
+    /// Route a peripheral request to one DMA controller channel.
+    ///
+    /// This replaces only the selected channel's six-bit request field.
+    pub fn route_dma_request(&mut self, controller: DmaController, channel: DmaChannel, request: DmaRequest) {
+        configure_dma_request(controller, channel, request);
+    }
+
+    /// Return the SDK software boot-mode flag.
+    ///
+    /// The vendor OTA bootloader uses CR4 bit 29 as a software marker. No
+    /// reset-retention behavior is implied by this API.
+    pub fn boot_mode_flag(&self) -> bool {
+        enable_clock();
+        regs().cr4().read().bits() & BOOT_MODE_FLAG != 0
+    }
+
+    /// Set or clear the SDK software boot-mode flag.
+    pub fn set_boot_mode_flag(&mut self, set: bool) {
+        enable_clock();
+        modify_cr4(BOOT_MODE_FLAG, if set { BOOT_MODE_FLAG } else { 0 });
+    }
+
+    /// Configure the I2S master word-select divisor for a sample word size.
+    ///
+    /// This enables I2S master generation but does not enable the word-select
+    /// output. The I2S driver can enable that output after its data block is
+    /// ready, matching the vendor initialization order.
+    pub fn configure_i2s_master(&mut self, word_size: I2sWordSize) {
+        configure_i2s_master(word_size);
+    }
+
+    /// Enable or disable the I2S master word-select output.
+    pub fn set_i2s_word_select_output_enabled(&mut self, enabled: bool) {
+        set_i2s_word_select_output_enabled(enabled);
+    }
+}
+
+fn regs() -> pac::Syscfg {
+    // Register access is kept inside this module. All read-modify-write
+    // sequences are serialized below, and the HAL ownership token remains the
+    // public way to perform stand-alone SYSCFG configuration.
+    unsafe { pac::Syscfg::steal() }
+}
+
+fn enable_clock() {
+    critical_section::with(|_| {
+        // The vendor's rcc_enable_peripheral_clk(SYSCFG, true) operation only
+        // sets this gate and requires no synchronization wait.
+        unsafe { pac::Rcc::steal() }
+            .cgr0()
+            .modify(|_, w| w.syscfg_clk_en().set_bit());
+    });
+}
+
+fn modify_cr4(mask: u32, value: u32) {
+    critical_section::with(|_| {
+        regs()
+            .cr4()
+            .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value & mask)) });
+    });
+}
+
+fn modify_cr10(mask: u32, value: u32) {
+    critical_section::with(|_| {
+        regs()
+            .cr10()
+            .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | (value & mask)) });
+    });
+}
+
+pub(crate) fn configure_dma_request(controller: DmaController, channel: DmaChannel, request: DmaRequest) {
+    enable_clock();
+
+    let shift = channel.request_shift();
+    let mask = DMA_REQUEST_MASK << shift;
+    let value = (request as u32) << shift;
+
+    critical_section::with(|_| match controller {
+        DmaController::Dma0 => {
+            regs()
+                .cr0()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | value) });
+        }
+        DmaController::Dma1 => {
+            regs()
+                .cr1()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !mask) | value) });
+        }
+    });
+}
+
+pub(crate) fn configure_i2s_master(word_size: I2sWordSize) {
+    enable_clock();
+
+    let mask = I2S_MASTER_ENABLE | I2S_WORD_SELECT_DIVIDER_MASK;
+    let value = I2S_MASTER_ENABLE | (word_size.word_select_divider() << 15);
+    modify_cr10(mask, value);
+}
+
+pub(crate) fn set_i2s_word_select_output_enabled(enabled: bool) {
+    enable_clock();
+    modify_cr10(I2S_WORD_SELECT_ENABLE, if enabled { I2S_WORD_SELECT_ENABLE } else { 0 });
+}

--- a/embassy-asr/src/time_driver.rs
+++ b/embassy-asr/src/time_driver.rs
@@ -12,7 +12,9 @@ use embassy_hal_internal::interrupt::{InterruptExt, Priority};
 use embassy_time_driver::{Driver, TICK_HZ};
 use embassy_time_queue_utils::Queue;
 
+use crate::afec;
 use crate::pac::{self, Interrupt, interrupt};
+use crate::rcc::{self, Peripheral as RccPeripheral};
 
 const TIMER_TICK_HZ: u64 = 32_768;
 const MIN_ALARM_TICKS: u64 = 164; // Five milliseconds, as required by the vendor timer.
@@ -24,12 +26,9 @@ const RTC_CYC_ENABLE: u32 = 1 << 24;
 const RTC_CYC_INTERRUPT: u32 = 1 << 4;
 const RTC_CYC_STATUS: u32 = 1 << 4;
 
-const RCC_SR_ALL_DONE: u32 = 0x3f;
-const RCC_SR_RTC_AON_DONE: u32 = 1 << 1;
-
-// AFEC analog register 0x02 controls the 32 kHz oscillators. Clearing bits
-// 13 and 14 enables XO32K, matching rcc_enable_oscillator(RCC_OSC_XO32K).
-const AFEC_ANALOG_02: *mut u32 = 0x4000_8008 as *mut u32;
+// AFEC analog register 0x02 bits 13/14 power-gate XO32K. Clearing them matches
+// `rcc_enable_oscillator(RCC_OSC_XO32K)`.
+const ANALOG_XO32K_POWER_DOWN: u32 = (1 << 13) | (1 << 14);
 
 struct AsrTimeDriver {
     initialized: AtomicBool,
@@ -77,8 +76,7 @@ fn calendar_ticks(time: u32, date: u32, subsecond: u32) -> u64 {
     let month = ((date >> 6) & 0x0f) + ((date >> 10) & 0x01) * 10;
     let year = 2000 + ((date >> 14) & 0x0f) + ((date >> 18) & 0x0f) * 10;
 
-    const DAYS_BEFORE_MONTH: [u32; 12] =
-        [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+    const DAYS_BEFORE_MONTH: [u32; 12] = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
 
     let years = year.saturating_sub(2000);
     let mut days = years * 365 + (years + 3) / 4;
@@ -110,37 +108,22 @@ fn read_calendar_ticks() -> u64 {
 
 impl AsrTimeDriver {
     fn init(&'static self) {
-        assert!(
-            TICK_HZ == TIMER_TICK_HZ,
-            "embassy-asr: time tick rate must be 32768 Hz"
-        );
+        assert!(TICK_HZ == TIMER_TICK_HZ, "embassy-asr: time tick rate must be 32768 Hz");
 
-        let rcc = unsafe { pac::Rcc::steal() };
-        rcc.cgr0().modify(|_, w| w.afec_clk_en().set_bit());
-
-        unsafe {
-            let value = core::ptr::read_volatile(AFEC_ANALOG_02);
-            core::ptr::write_volatile(AFEC_ANALOG_02, value & !((1 << 13) | (1 << 14)));
-        }
+        // Shared AFEC analog helper also gates the AFEC clock.
+        afec::analog::REG_02.clear_bits(ANALOG_XO32K_POWER_DOWN);
 
         // Reinitialize RTC and select XO32K while its functional clock is off.
-        // The ordering and synchronization match rcc_enable_peripheral_clk().
-        rcc.cgr1().modify(|_, w| w.rtc_clk_en().clear_bit());
-        while rcc.sr().read().bits() & RCC_SR_ALL_DONE != RCC_SR_ALL_DONE {}
-        while rcc.sr1().read().rtc_clk_en_sync().bit_is_set() {}
-        rcc.cgr2()
-            .modify(|_, w| w.rtc_aon_clk_en().clear_bit());
-        while rcc.sr().read().bits() & RCC_SR_RTC_AON_DONE == 0 {}
+        // Clock/reset helpers match `rcc_enable_peripheral_clk` / reset sequencing,
+        // including the vendor 92 µs asynchronous-domain delay after reset release.
+        rcc::disable_peripheral(RccPeripheral::Rtc).expect("embassy-asr: failed to disable RTC clock");
+        rcc::reset_peripheral(RccPeripheral::Rtc).expect("embassy-asr: failed to reset RTC");
 
-        rcc.rst0().modify(|_, w| w.rtc_rst_n().clear_bit());
-        rcc.rst0().modify(|_, w| w.rtc_rst_n().set_bit());
-        cortex_m::asm::delay(5_000);
+        unsafe { pac::Rcc::steal() }
+            .cr1()
+            .modify(|_, w| w.rtc_clk_sel().xo32k());
 
-        rcc.cr1().modify(|_, w| w.rtc_clk_sel().xo32k());
-        rcc.cgr1().modify(|_, w| w.rtc_clk_en().set_bit());
-        while rcc.sr().read().bits() & RCC_SR_ALL_DONE != RCC_SR_ALL_DONE {}
-        rcc.cgr2().modify(|_, w| w.rtc_aon_clk_en().set_bit());
-        while rcc.sr().read().bits() & RCC_SR_RTC_AON_DONE == 0 {}
+        rcc::enable_peripheral(RccPeripheral::Rtc).expect("embassy-asr: failed to enable RTC clock");
 
         wait_sync();
         unsafe {
@@ -150,9 +133,7 @@ impl AsrTimeDriver {
 
             // Epoch: Saturday 2000-01-01 00:00:00.
             rtc().calendar().write_with_zero(|w| w.bits(0));
-            rtc()
-                .calendar_h()
-                .write_with_zero(|w| w.bits((6 << 11) | (1 << 6) | 1));
+            rtc().calendar_h().write_with_zero(|w| w.bits((6 << 11) | (1 << 6) | 1));
         }
         wait_sync();
         rtc()
@@ -166,14 +147,20 @@ impl AsrTimeDriver {
         unsafe { Interrupt::RTC.enable() };
     }
 
-    fn stop_alarm(&self) {
-        wait_sync();
+    /// Disable the cyclic counter and its interrupt. Caller must ensure RTC
+    /// register writes are allowed (`wait_sync` / `sync_ready`).
+    fn disable_cyc(&self) {
         rtc()
             .ctrl()
             .modify(|r, w| unsafe { w.bits(r.bits() & !RTC_CYC_ENABLE) });
         rtc()
             .cr1()
             .modify(|r, w| unsafe { w.bits(r.bits() & !RTC_CYC_INTERRUPT) });
+    }
+
+    fn stop_alarm(&self) {
+        wait_sync();
+        self.disable_cyc();
     }
 
     fn on_interrupt(&self) {
@@ -188,12 +175,12 @@ impl AsrTimeDriver {
             return;
         }
 
-        self.stop_alarm();
+        // Already synchronized above; avoid a second wait before disable.
+        self.disable_cyc();
+        // Clearing status requires a sync after the control-register writes.
         wait_sync();
         unsafe {
-            rtc()
-                .sr()
-                .write_with_zero(|w| w.bits(RTC_CYC_STATUS));
+            rtc().sr().write_with_zero(|w| w.bits(RTC_CYC_STATUS));
         }
 
         critical_section::with(|cs| self.trigger_alarm(cs));
@@ -220,20 +207,17 @@ impl AsrTimeDriver {
             return false;
         }
 
-        let duration = (timestamp - now)
-            .clamp(MIN_ALARM_TICKS, u32::MAX as u64) as u32;
+        let duration = (timestamp - now).clamp(MIN_ALARM_TICKS, u32::MAX as u64) as u32;
 
         wait_sync();
         unsafe {
             rtc().cyc_max().write_with_zero(|w| w.bits(duration));
-            rtc()
-                .sr()
-                .write_with_zero(|w| w.bits(RTC_CYC_STATUS));
+            rtc().sr().write_with_zero(|w| w.bits(RTC_CYC_STATUS));
         }
         wait_sync();
-        rtc().ctrl().modify(|r, w| unsafe {
-            w.bits(r.bits() | RTC_CYC_WAKE_ENABLE | RTC_CYC_ENABLE)
-        });
+        rtc()
+            .ctrl()
+            .modify(|r, w| unsafe { w.bits(r.bits() | RTC_CYC_WAKE_ENABLE | RTC_CYC_ENABLE) });
         rtc()
             .cr1()
             .modify(|r, w| unsafe { w.bits(r.bits() | RTC_CYC_INTERRUPT) });
@@ -277,4 +261,66 @@ pub(crate) fn init() {
 #[interrupt]
 fn RTC() {
     DRIVER.on_interrupt();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pack BCD calendar date fields the same way the driver writes `calendar_h`.
+    fn pack_date(year: u32, month: u32, day: u32, weekday: u32) -> u32 {
+        let y = year - 2000;
+        let y_ones = y % 10;
+        let y_tens = y / 10;
+        let m_ones = month % 10;
+        let m_tens = month / 10;
+        let d_ones = day % 10;
+        let d_tens = day / 10;
+        d_ones | (d_tens << 4) | (m_ones << 6) | (m_tens << 10) | (weekday << 11) | (y_ones << 14) | (y_tens << 18)
+    }
+
+    fn pack_time(hour: u32, minute: u32, second: u32) -> u32 {
+        let s_ones = second % 10;
+        let s_tens = second / 10;
+        let m_ones = minute % 10;
+        let m_tens = minute / 10;
+        let h_ones = hour % 10;
+        let h_tens = hour / 10;
+        s_ones | (s_tens << 4) | (m_ones << 7) | (m_tens << 11) | (h_ones << 14) | (h_tens << 18)
+    }
+
+    #[test]
+    fn epoch_is_zero() {
+        let date = pack_date(2000, 1, 1, 6);
+        assert_eq!(calendar_ticks(0, date, 0), 0);
+        assert_eq!(date, (6 << 11) | (1 << 6) | 1);
+    }
+
+    #[test]
+    fn one_second_and_subsecond() {
+        let date = pack_date(2000, 1, 1, 6);
+        let time = pack_time(0, 0, 1);
+        assert_eq!(calendar_ticks(time, date, 0), TIMER_TICK_HZ);
+        assert_eq!(calendar_ticks(0, date, 100), 100);
+    }
+
+    #[test]
+    fn leap_day_2000() {
+        let jan1 = pack_date(2000, 1, 1, 6);
+        let mar1 = pack_date(2000, 3, 1, 3);
+        let jan1_ticks = calendar_ticks(0, jan1, 0);
+        let mar1_ticks = calendar_ticks(0, mar1, 0);
+        // 2000 is a leap year in the RTC's simplified %4 rule: 31 + 29 days.
+        assert_eq!(mar1_ticks - jan1_ticks, 60 * 86_400 * TIMER_TICK_HZ);
+    }
+
+    #[test]
+    fn non_leap_feb_2001() {
+        let jan1 = pack_date(2001, 1, 1, 1);
+        let mar1 = pack_date(2001, 3, 1, 4);
+        assert_eq!(
+            calendar_ticks(0, mar1, 0) - calendar_ticks(0, jan1, 0),
+            59 * 86_400 * TIMER_TICK_HZ
+        );
+    }
 }

--- a/embassy-asr/src/time_driver.rs
+++ b/embassy-asr/src/time_driver.rs
@@ -1,0 +1,280 @@
+//! `embassy-time` driver using the ASR6601 RTC.
+//!
+//! This follows the vendor LoRa timer implementation: the always-on calendar is
+//! the monotonic clock and the cyclic counter provides one-shot wakeups.
+
+use core::cell::{Cell, RefCell};
+use core::sync::atomic::{AtomicBool, Ordering};
+use core::task::Waker;
+
+use critical_section::{CriticalSection, Mutex};
+use embassy_hal_internal::interrupt::{InterruptExt, Priority};
+use embassy_time_driver::{Driver, TICK_HZ};
+use embassy_time_queue_utils::Queue;
+
+use crate::pac::{self, Interrupt, interrupt};
+
+const TIMER_TICK_HZ: u64 = 32_768;
+const MIN_ALARM_TICKS: u64 = 164; // Five milliseconds, as required by the vendor timer.
+
+const RTC_SYNC_READY: u32 = 0x0dff;
+const RTC_CALENDAR_ENABLE: u32 = 1 << 28;
+const RTC_CYC_WAKE_ENABLE: u32 = 1 << 25;
+const RTC_CYC_ENABLE: u32 = 1 << 24;
+const RTC_CYC_INTERRUPT: u32 = 1 << 4;
+const RTC_CYC_STATUS: u32 = 1 << 4;
+
+const RCC_SR_ALL_DONE: u32 = 0x3f;
+const RCC_SR_RTC_AON_DONE: u32 = 1 << 1;
+
+// AFEC analog register 0x02 controls the 32 kHz oscillators. Clearing bits
+// 13 and 14 enables XO32K, matching rcc_enable_oscillator(RCC_OSC_XO32K).
+const AFEC_ANALOG_02: *mut u32 = 0x4000_8008 as *mut u32;
+
+struct AsrTimeDriver {
+    initialized: AtomicBool,
+    alarm: Mutex<Cell<u64>>,
+    queue: Mutex<RefCell<Queue>>,
+}
+
+embassy_time_driver::time_driver_impl!(static DRIVER: AsrTimeDriver = AsrTimeDriver {
+    initialized: AtomicBool::new(false),
+    alarm: Mutex::new(Cell::new(u64::MAX)),
+    queue: Mutex::new(RefCell::new(Queue::new())),
+});
+
+fn rtc() -> pac::Rtc {
+    unsafe { pac::Rtc::steal() }
+}
+
+fn sync_ready() -> bool {
+    rtc().sr1().read().bits() & RTC_SYNC_READY == RTC_SYNC_READY
+}
+
+fn wait_sync() {
+    while !sync_ready() {}
+}
+
+fn read_stable(register: impl Fn(&pac::Rtc) -> u32) -> u32 {
+    loop {
+        let first = register(&rtc());
+        if first == register(&rtc()) {
+            return first;
+        }
+    }
+}
+
+fn is_leap_year(year: u32) -> bool {
+    year % 4 == 0
+}
+
+fn calendar_ticks(time: u32, date: u32, subsecond: u32) -> u64 {
+    let second = (time & 0x0f) + ((time >> 4) & 0x07) * 10;
+    let minute = ((time >> 7) & 0x0f) + ((time >> 11) & 0x07) * 10;
+    let hour = ((time >> 14) & 0x0f) + ((time >> 18) & 0x03) * 10;
+
+    let day = (date & 0x0f) + ((date >> 4) & 0x03) * 10;
+    let month = ((date >> 6) & 0x0f) + ((date >> 10) & 0x01) * 10;
+    let year = 2000 + ((date >> 14) & 0x0f) + ((date >> 18) & 0x0f) * 10;
+
+    const DAYS_BEFORE_MONTH: [u32; 12] =
+        [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334];
+
+    let years = year.saturating_sub(2000);
+    let mut days = years * 365 + (years + 3) / 4;
+    if (1..=12).contains(&month) {
+        days += DAYS_BEFORE_MONTH[(month - 1) as usize];
+        if month > 2 && is_leap_year(year) {
+            days += 1;
+        }
+    }
+    days += day.saturating_sub(1);
+
+    let seconds = days as u64 * 86_400 + hour as u64 * 3_600 + minute as u64 * 60 + second as u64;
+    seconds * TIMER_TICK_HZ + subsecond as u64
+}
+
+fn read_calendar_ticks() -> u64 {
+    loop {
+        let subsecond = rtc().sub_second_cnt().read().bits();
+        let time = read_stable(|rtc| rtc.calendar_r().read().bits());
+        let date = read_stable(|rtc| rtc.calendar_r_h().read().bits());
+
+        // Retry across a subsecond wrap so the calendar and fractional part
+        // always describe the same instant.
+        if subsecond != 0 && subsecond == rtc().sub_second_cnt().read().bits() {
+            return calendar_ticks(time, date, subsecond);
+        }
+    }
+}
+
+impl AsrTimeDriver {
+    fn init(&'static self) {
+        assert!(
+            TICK_HZ == TIMER_TICK_HZ,
+            "embassy-asr: time tick rate must be 32768 Hz"
+        );
+
+        let rcc = unsafe { pac::Rcc::steal() };
+        rcc.cgr0().modify(|_, w| w.afec_clk_en().set_bit());
+
+        unsafe {
+            let value = core::ptr::read_volatile(AFEC_ANALOG_02);
+            core::ptr::write_volatile(AFEC_ANALOG_02, value & !((1 << 13) | (1 << 14)));
+        }
+
+        // Reinitialize RTC and select XO32K while its functional clock is off.
+        // The ordering and synchronization match rcc_enable_peripheral_clk().
+        rcc.cgr1().modify(|_, w| w.rtc_clk_en().clear_bit());
+        while rcc.sr().read().bits() & RCC_SR_ALL_DONE != RCC_SR_ALL_DONE {}
+        while rcc.sr1().read().rtc_clk_en_sync().bit_is_set() {}
+        rcc.cgr2()
+            .modify(|_, w| w.rtc_aon_clk_en().clear_bit());
+        while rcc.sr().read().bits() & RCC_SR_RTC_AON_DONE == 0 {}
+
+        rcc.rst0().modify(|_, w| w.rtc_rst_n().clear_bit());
+        rcc.rst0().modify(|_, w| w.rtc_rst_n().set_bit());
+        cortex_m::asm::delay(5_000);
+
+        rcc.cr1().modify(|_, w| w.rtc_clk_sel().xo32k());
+        rcc.cgr1().modify(|_, w| w.rtc_clk_en().set_bit());
+        while rcc.sr().read().bits() & RCC_SR_ALL_DONE != RCC_SR_ALL_DONE {}
+        rcc.cgr2().modify(|_, w| w.rtc_aon_clk_en().set_bit());
+        while rcc.sr().read().bits() & RCC_SR_RTC_AON_DONE == 0 {}
+
+        wait_sync();
+        unsafe {
+            rtc().ctrl().write_with_zero(|w| w.bits(0));
+            rtc().cr1().write_with_zero(|w| w.bits(0));
+            rtc().sr().write_with_zero(|w| w.bits(0x7f));
+
+            // Epoch: Saturday 2000-01-01 00:00:00.
+            rtc().calendar().write_with_zero(|w| w.bits(0));
+            rtc()
+                .calendar_h()
+                .write_with_zero(|w| w.bits((6 << 11) | (1 << 6) | 1));
+        }
+        wait_sync();
+        rtc()
+            .ctrl()
+            .modify(|r, w| unsafe { w.bits(r.bits() | RTC_CALENDAR_ENABLE) });
+        wait_sync();
+
+        self.initialized.store(true, Ordering::Release);
+        Interrupt::RTC.unpend();
+        Interrupt::RTC.set_priority(Priority::P2);
+        unsafe { Interrupt::RTC.enable() };
+    }
+
+    fn stop_alarm(&self) {
+        wait_sync();
+        rtc()
+            .ctrl()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !RTC_CYC_ENABLE) });
+        rtc()
+            .cr1()
+            .modify(|r, w| unsafe { w.bits(r.bits() & !RTC_CYC_INTERRUPT) });
+    }
+
+    fn on_interrupt(&self) {
+        // RTC registers cross an asynchronous clock domain. Avoid spinning in
+        // interrupt context; an uncleared level source will retrigger once the
+        // synchronized status is readable.
+        if !sync_ready() {
+            return;
+        }
+
+        if rtc().sr().read().bits() & RTC_CYC_STATUS == 0 {
+            return;
+        }
+
+        self.stop_alarm();
+        wait_sync();
+        unsafe {
+            rtc()
+                .sr()
+                .write_with_zero(|w| w.bits(RTC_CYC_STATUS));
+        }
+
+        critical_section::with(|cs| self.trigger_alarm(cs));
+    }
+
+    fn trigger_alarm(&self, cs: CriticalSection) {
+        let mut next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        while !self.set_alarm(cs, next) {
+            next = self.queue.borrow(cs).borrow_mut().next_expiration(self.now());
+        }
+    }
+
+    fn set_alarm(&self, cs: CriticalSection, timestamp: u64) -> bool {
+        self.stop_alarm();
+        self.alarm.borrow(cs).set(timestamp);
+
+        if timestamp == u64::MAX {
+            return true;
+        }
+
+        let now = self.now();
+        if timestamp <= now {
+            self.alarm.borrow(cs).set(u64::MAX);
+            return false;
+        }
+
+        let duration = (timestamp - now)
+            .clamp(MIN_ALARM_TICKS, u32::MAX as u64) as u32;
+
+        wait_sync();
+        unsafe {
+            rtc().cyc_max().write_with_zero(|w| w.bits(duration));
+            rtc()
+                .sr()
+                .write_with_zero(|w| w.bits(RTC_CYC_STATUS));
+        }
+        wait_sync();
+        rtc().ctrl().modify(|r, w| unsafe {
+            w.bits(r.bits() | RTC_CYC_WAKE_ENABLE | RTC_CYC_ENABLE)
+        });
+        rtc()
+            .cr1()
+            .modify(|r, w| unsafe { w.bits(r.bits() | RTC_CYC_INTERRUPT) });
+
+        if timestamp <= self.now() {
+            self.stop_alarm();
+            self.alarm.borrow(cs).set(u64::MAX);
+            return false;
+        }
+
+        true
+    }
+}
+
+impl Driver for AsrTimeDriver {
+    fn now(&self) -> u64 {
+        if self.initialized.load(Ordering::Acquire) {
+            read_calendar_ticks()
+        } else {
+            0
+        }
+    }
+
+    fn schedule_wake(&self, at: u64, waker: &Waker) {
+        critical_section::with(|cs| {
+            let mut queue = self.queue.borrow(cs).borrow_mut();
+            if queue.schedule_wake(at, waker) {
+                let mut next = queue.next_expiration(self.now());
+                while !self.set_alarm(cs, next) {
+                    next = queue.next_expiration(self.now());
+                }
+            }
+        });
+    }
+}
+
+pub(crate) fn init() {
+    DRIVER.init();
+}
+
+#[interrupt]
+fn RTC() {
+    DRIVER.on_interrupt();
+}

--- a/embassy-asr/src/timer.rs
+++ b/embassy-asr/src/timer.rs
@@ -1,0 +1,1189 @@
+//! General-purpose timers (TIMER0–TIMER3 / GPTimer).
+//!
+//! Register programming follows the vendor `tremo_timer` driver and the
+//! ASR6601 SDK `gptimer` examples (`simple_timer`, `pwm`, `input_capture`).
+//!
+//! This is an Embassy-style subset: up-counting, PWM output, input capture,
+//! update/CC interrupts, and typed alternate-function pins from the datasheet
+//! mux tables. Encoder, slave-mode, DMA burst, and OR remaps are omitted.
+//!
+//! Several multi-bit CR1/CCMR/SMCR/OR fields and the data registers lack PAC
+//! field accessors; those are programmed with the bit masks from
+//! `tremo_timer.h`.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicU32, Ordering};
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::InterruptExt;
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::gpio::{AlternateFunction, Flex, Pin as GpioPin, Pull};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt as TypelevelInterrupt};
+use crate::rcc::{self, Peripheral as RccPeripheral};
+use crate::{Peri, PeripheralType, interrupt, pac, peripherals};
+
+const CR1_CEN: u32 = 1 << 0;
+const CR1_DIR: u32 = 1 << 4;
+const CR1_CMS_MASK: u32 = 0x60;
+const CR1_ARPE: u32 = 1 << 7;
+const CR1_CKD_MASK: u32 = 0x300;
+
+const CCMR_OC_MODE_MASK_EVEN: u32 = 0x70;
+const CCMR_OC_MODE_MASK_ODD: u32 = 0x7000;
+const CCMR_CC_SEL_MASK_EVEN: u32 = 0x3;
+const CCMR_CC_SEL_MASK_ODD: u32 = 0x300;
+const CCMR_IC_FILTER_MASK_EVEN: u32 = 0xf0;
+const CCMR_IC_FILTER_MASK_ODD: u32 = 0xf000;
+const CCMR_OCPE_EVEN: u32 = 1 << 3;
+const CCMR_OCPE_ODD: u32 = 1 << 11;
+
+const OC_PWM1_EVEN: u32 = 0x60;
+const OC_PWM1_ODD: u32 = 0x6000;
+const OC_PWM2_EVEN: u32 = 0x70;
+const OC_PWM2_ODD: u32 = 0x7000;
+
+const CC_SEL_INPUT_SAME_EVEN: u32 = 0x1;
+const CC_SEL_INPUT_SAME_ODD: u32 = 0x100;
+
+const CCER_CC0E: u32 = 1 << 0;
+const CCER_CC0P: u32 = 1 << 1;
+const CCER_CC0NP: u32 = 1 << 3;
+const CCER_CC1E: u32 = 1 << 4;
+const CCER_CC1P: u32 = 1 << 5;
+const CCER_CC1NP: u32 = 1 << 7;
+const CCER_CC2E: u32 = 1 << 8;
+const CCER_CC2P: u32 = 1 << 9;
+const CCER_CC2NP: u32 = 1 << 11;
+const CCER_CC3E: u32 = 1 << 12;
+const CCER_CC3P: u32 = 1 << 13;
+const CCER_CC3NP: u32 = 1 << 15;
+
+const SR_IT_MASK: u32 = 0x5f;
+const DIER_IT_MASK: u32 = 0x5f;
+
+static WAKERS: [AtomicWaker; 4] = [const { AtomicWaker::new() }; 4];
+static PENDING: [AtomicU32; 4] = [const { AtomicU32::new(0) }; 4];
+
+/// TIMER driver error.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// Requested frequency cannot be represented with 16-bit PSC/ARR.
+    InvalidFrequency,
+    /// Kernel clock is unknown (RCC not initialized) or zero.
+    ClockUnavailable,
+    /// RCC rejected the clock or reset request.
+    Rcc(rcc::Error),
+}
+
+impl From<rcc::Error> for Error {
+    fn from(value: rcc::Error) -> Self {
+        Self::Rcc(value)
+    }
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::InvalidFrequency => write!(f, "TIMER frequency cannot be represented"),
+            Self::ClockUnavailable => write!(f, "TIMER kernel clock unavailable"),
+            Self::Rcc(err) => write!(f, "TIMER RCC error: {err:?}"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+/// Capture/compare channel (vendor 0-based indexing).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u8)]
+pub enum Channel {
+    Ch0 = 0,
+    Ch1 = 1,
+    Ch2 = 2,
+    Ch3 = 3,
+}
+
+impl Channel {
+    /// Channel index `0..=3`.
+    pub const fn index(self) -> usize {
+        self as usize
+    }
+}
+
+/// Channel 0 marker.
+pub enum Ch0 {}
+/// Channel 1 marker.
+pub enum Ch1 {}
+/// Channel 2 marker.
+pub enum Ch2 {}
+/// Channel 3 marker.
+pub enum Ch3 {}
+
+mod sealed {
+    use super::*;
+
+    pub trait Instance {
+        fn regs() -> &'static pac::timer0::RegisterBlock;
+        fn rcc_peripheral() -> RccPeripheral;
+        fn nv_interrupt() -> pac::Interrupt;
+        const INDEX: usize;
+        fn kernel_clock_hz() -> Option<u32>;
+    }
+
+    pub trait TimerChannel {}
+}
+
+/// Compile-time timer channel.
+#[allow(private_bounds)]
+pub trait TimerChannel: sealed::TimerChannel {
+    /// Runtime channel value.
+    const CHANNEL: Channel;
+}
+
+impl sealed::TimerChannel for Ch0 {}
+impl sealed::TimerChannel for Ch1 {}
+impl sealed::TimerChannel for Ch2 {}
+impl sealed::TimerChannel for Ch3 {}
+
+impl TimerChannel for Ch0 {
+    const CHANNEL: Channel = Channel::Ch0;
+}
+impl TimerChannel for Ch1 {
+    const CHANNEL: Channel = Channel::Ch1;
+}
+impl TimerChannel for Ch2 {
+    const CHANNEL: Channel = Channel::Ch2;
+}
+impl TimerChannel for Ch3 {
+    const CHANNEL: Channel = Channel::Ch3;
+}
+
+/// Dead-time sampling clock division (`CR1.CKD`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[repr(u32)]
+pub enum ClockDivision {
+    Div1 = 0x0,
+    Div2 = 0x100,
+    Div4 = 0x200,
+}
+
+/// PWM output compare mode.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum PwmMode {
+    /// PWM mode 1.
+    Mode1,
+    /// PWM mode 2.
+    Mode2,
+}
+
+/// Output polarity for PWM / OC.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum OutputPolarity {
+    /// Active high (`high_level = true` in the vendor OC init).
+    ActiveHigh,
+    /// Active low.
+    ActiveLow,
+}
+
+/// Input-capture edge polarity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum CapturePolarity {
+    Rising,
+    Falling,
+    Both,
+}
+
+/// Interrupt / status flags (`DIER` / `SR`).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct InterruptFlags(u32);
+
+impl InterruptFlags {
+    pub const UPDATE: Self = Self(1 << 0);
+    pub const CC0: Self = Self(1 << 1);
+    pub const CC1: Self = Self(1 << 2);
+    pub const CC2: Self = Self(1 << 3);
+    pub const CC3: Self = Self(1 << 4);
+    pub const TRIGGER: Self = Self(1 << 6);
+
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    pub const fn bits(self) -> u32 {
+        self.0 & SR_IT_MASK
+    }
+
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Capture/compare flag for `channel`.
+    pub const fn cc(channel: Channel) -> Self {
+        Self(1 << (channel as u32 + 1))
+    }
+}
+
+impl core::ops::BitOr for InterruptFlags {
+    type Output = Self;
+
+    fn bitor(self, rhs: Self) -> Self::Output {
+        self.union(rhs)
+    }
+}
+
+impl core::ops::BitOrAssign for InterruptFlags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        *self = self.union(rhs);
+    }
+}
+
+/// Basic up-counter configuration (vendor `timer_init_t`, up mode only).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Prescaler loaded into `PSC` (`0..=0xFFFF`).
+    pub prescaler: u16,
+    /// Auto-reload period loaded into `ARR` (`0..=0xFFFF`).
+    pub period: u16,
+    /// Dead-time sampling clock division.
+    pub clock_division: ClockDivision,
+    /// Auto-reload preload enable.
+    pub autoreload_preload: bool,
+}
+
+impl Config {
+    /// Defaults matching the simple-timer example shape (caller sets PSC/ARR).
+    pub const fn new() -> Self {
+        Self {
+            prescaler: 0,
+            period: 0xffff,
+            clock_division: ClockDivision::Div1,
+            autoreload_preload: false,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// PWM configuration shared by all channels of one timer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct PwmConfig {
+    /// Output compare mode.
+    pub mode: PwmMode,
+    /// Output polarity.
+    pub polarity: OutputPolarity,
+    /// Auto-reload preload enable.
+    pub autoreload_preload: bool,
+}
+
+impl PwmConfig {
+    /// PWM mode 1, active-high, no ARR preload.
+    pub const fn new() -> Self {
+        Self {
+            mode: PwmMode::Mode1,
+            polarity: OutputPolarity::ActiveHigh,
+            autoreload_preload: false,
+        }
+    }
+}
+
+impl Default for PwmConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// GPTimer peripheral instance.
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// NVIC vector for this instance.
+    type Interrupt: TypelevelInterrupt;
+}
+
+macro_rules! impl_timer {
+    ($name:ident, $pac:ident, $rcc:ident, $irq:ident, $index:expr, $clock:ident) => {
+        impl sealed::Instance for peripherals::$name {
+            #[inline]
+            fn regs() -> &'static pac::timer0::RegisterBlock {
+                unsafe { &*pac::$pac::ptr() }
+            }
+
+            #[inline]
+            fn rcc_peripheral() -> RccPeripheral {
+                RccPeripheral::$rcc
+            }
+
+            #[inline]
+            fn nv_interrupt() -> pac::Interrupt {
+                pac::Interrupt::$irq
+            }
+
+            const INDEX: usize = $index;
+
+            fn kernel_clock_hz() -> Option<u32> {
+                rcc::clocks().map(|c| c.$clock)
+            }
+        }
+
+        impl Instance for peripherals::$name {
+            type Interrupt = interrupt::typelevel::$irq;
+        }
+    };
+}
+
+// TIMER0/2 sit on the 0x4000_xxxx bus (PCLK0); TIMER1/3 on 0x4001_xxxx (PCLK1).
+impl_timer!(TIMER0, Timer0, Timer0, TIMER0, 0, pclk0_hz);
+impl_timer!(TIMER1, Timer1, Timer1, TIMER1, 1, pclk1_hz);
+impl_timer!(TIMER2, Timer2, Timer2, TIMER2, 2, pclk0_hz);
+impl_timer!(TIMER3, Timer3, Timer3, TIMER3, 3, pclk1_hz);
+
+/// Interrupt handler for one GPTimer instance.
+///
+/// Clears pending `SR` flags that are enabled in `DIER` and wakes tasks waiting
+/// on [`Timer::wait_for`], [`SimplePwm::wait_for`], or [`InputCapture::wait_for`].
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let regs = T::regs();
+        let pending = regs.sr().read().bits() & regs.dier().read().bits() & SR_IT_MASK;
+        if pending == 0 {
+            return;
+        }
+
+        // Vendor `timer_clear_status`: write zeros to the flags being cleared.
+        unsafe {
+            regs.sr().write_with_zero(|w| w.bits(!pending));
+        }
+
+        PENDING[T::INDEX].fetch_or(pending, Ordering::Release);
+        WAKERS[T::INDEX].wake();
+    }
+}
+
+fn enable_instance<T: Instance>() -> Result<(), Error> {
+    rcc::enable_peripheral(T::rcc_peripheral())?;
+    rcc::reset_peripheral(T::rcc_peripheral())?;
+    T::nv_interrupt().disable();
+    T::nv_interrupt().unpend();
+    PENDING[T::INDEX].store(0, Ordering::Release);
+    Ok(())
+}
+
+fn apply_basic_config<T: Instance>(config: Config) {
+    let regs = T::regs();
+    regs.cr1().modify(|r, w| unsafe {
+        let mut bits = r.bits();
+        bits &= !(CR1_DIR | CR1_CMS_MASK | CR1_CKD_MASK | CR1_ARPE | CR1_CEN);
+        bits |= config.clock_division as u32;
+        if config.autoreload_preload {
+            bits |= CR1_ARPE;
+        }
+        w.bits(bits)
+    });
+
+    unsafe {
+        regs.arr().write_with_zero(|w| w.bits(u32::from(config.period)));
+        regs.psc().write_with_zero(|w| w.bits(u32::from(config.prescaler)));
+        regs.egr().write_with_zero(|w| w.ug().set_bit());
+        regs.sr().write_with_zero(|w| w.bits(!InterruptFlags::UPDATE.bits()));
+    }
+}
+
+fn set_enabled<T: Instance>(enabled: bool) {
+    T::regs().cr1().modify(|r, w| unsafe {
+        let bits = if enabled {
+            r.bits() | CR1_CEN
+        } else {
+            r.bits() & !CR1_CEN
+        };
+        w.bits(bits)
+    });
+}
+
+fn set_interrupt_enabled<T: Instance>(flags: InterruptFlags, enabled: bool) {
+    let mask = flags.bits() & DIER_IT_MASK;
+    T::regs().dier().modify(|r, w| unsafe {
+        let bits = if enabled { r.bits() | mask } else { r.bits() & !mask };
+        w.bits(bits)
+    });
+
+    if T::regs().dier().read().bits() & DIER_IT_MASK != 0 {
+        T::nv_interrupt().unpend();
+        unsafe { T::nv_interrupt().enable() };
+    } else {
+        T::nv_interrupt().disable();
+    }
+}
+
+fn clear_interrupt<T: Instance>(flags: InterruptFlags) {
+    let mask = flags.bits();
+    unsafe {
+        T::regs().sr().write_with_zero(|w| w.bits(!mask));
+    }
+    PENDING[T::INDEX].fetch_and(!mask, Ordering::AcqRel);
+}
+
+async fn wait_for_flags<T: Instance>(flags: InterruptFlags) -> InterruptFlags {
+    let mask = flags.bits();
+    poll_fn(|cx| {
+        WAKERS[T::INDEX].register(cx.waker());
+
+        let latched = PENDING[T::INDEX].load(Ordering::Acquire) & mask;
+        if latched != 0 {
+            PENDING[T::INDEX].fetch_and(!latched, Ordering::AcqRel);
+            return Poll::Ready(InterruptFlags(latched));
+        }
+
+        let live = T::regs().sr().read().bits() & mask;
+        if live != 0 {
+            clear_interrupt::<T>(InterruptFlags(live));
+            return Poll::Ready(InterruptFlags(live));
+        }
+
+        Poll::Pending
+    })
+    .await
+}
+
+fn compute_psc_arr(pclk: u32, frequency_hz: u32) -> Result<(u16, u16), Error> {
+    if frequency_hz == 0 || pclk == 0 {
+        return Err(Error::InvalidFrequency);
+    }
+
+    let ticks = pclk / frequency_hz;
+    if ticks == 0 {
+        return Err(Error::InvalidFrequency);
+    }
+
+    // Prefer a large ARR for duty-cycle resolution: ticks = (PSC+1)*(ARR+1).
+    if ticks <= 0x1_0000 {
+        return Ok((0, (ticks - 1) as u16));
+    }
+
+    for psc in 1u32..=0xffff {
+        let arr_plus = ticks / (psc + 1);
+        if arr_plus == 0 {
+            break;
+        }
+        if arr_plus <= 0x1_0000 && (psc + 1) * arr_plus == ticks {
+            return Ok((psc as u16, (arr_plus - 1) as u16));
+        }
+        if arr_plus <= 0x1_0000 {
+            // Closest representable period with this PSC.
+            return Ok((psc as u16, (arr_plus - 1) as u16));
+        }
+    }
+
+    Err(Error::InvalidFrequency)
+}
+
+fn channel_enable_mask(channel: Channel) -> u32 {
+    match channel {
+        Channel::Ch0 => CCER_CC0E,
+        Channel::Ch1 => CCER_CC1E,
+        Channel::Ch2 => CCER_CC2E,
+        Channel::Ch3 => CCER_CC3E,
+    }
+}
+
+fn channel_polarity_mask(channel: Channel) -> u32 {
+    match channel {
+        Channel::Ch0 => CCER_CC0P,
+        Channel::Ch1 => CCER_CC1P,
+        Channel::Ch2 => CCER_CC2P,
+        Channel::Ch3 => CCER_CC3P,
+    }
+}
+
+fn channel_np_mask(channel: Channel) -> u32 {
+    match channel {
+        Channel::Ch0 => CCER_CC0NP,
+        Channel::Ch1 => CCER_CC1NP,
+        Channel::Ch2 => CCER_CC2NP,
+        Channel::Ch3 => CCER_CC3NP,
+    }
+}
+
+fn channel_both_edge_mask(channel: Channel) -> u32 {
+    channel_polarity_mask(channel) | channel_np_mask(channel)
+}
+
+fn set_channel_enable<T: Instance>(channel: Channel, enabled: bool) {
+    let mask = channel_enable_mask(channel);
+    T::regs().ccer().modify(|r, w| unsafe {
+        let bits = if enabled { r.bits() | mask } else { r.bits() & !mask };
+        w.bits(bits)
+    });
+}
+
+fn channel_enabled<T: Instance>(channel: Channel) -> bool {
+    T::regs().ccer().read().bits() & channel_enable_mask(channel) != 0
+}
+
+fn set_compare<T: Instance>(channel: Channel, value: u16) {
+    let regs = T::regs();
+    let bits = u32::from(value);
+    unsafe {
+        match channel {
+            Channel::Ch0 => {
+                regs.ccr0().write_with_zero(|w| w.bits(bits));
+            }
+            Channel::Ch1 => {
+                regs.ccr1().write_with_zero(|w| w.bits(bits));
+            }
+            Channel::Ch2 => {
+                regs.ccr2().write_with_zero(|w| w.bits(bits));
+            }
+            Channel::Ch3 => {
+                regs.ccr3().write_with_zero(|w| w.bits(bits));
+            }
+        }
+    }
+}
+
+fn get_compare<T: Instance>(channel: Channel) -> u16 {
+    let regs = T::regs();
+    (match channel {
+        Channel::Ch0 => regs.ccr0().read().bits(),
+        Channel::Ch1 => regs.ccr1().read().bits(),
+        Channel::Ch2 => regs.ccr2().read().bits(),
+        Channel::Ch3 => regs.ccr3().read().bits(),
+    }) as u16
+}
+
+fn configure_pwm_channel<T: Instance>(channel: Channel, pwm: PwmConfig, duty: u16) {
+    let regs = T::regs();
+    let enable = channel_enable_mask(channel);
+    let polarity = channel_polarity_mask(channel);
+    let np = channel_np_mask(channel);
+
+    // Disable channel while reconfiguring (vendor `timer_config_oc`).
+    regs.ccer().modify(|r, w| unsafe { w.bits(r.bits() & !enable) });
+
+    let (mode_mask, mode_bits, sel_mask, ocpe) = if channel.index() % 2 == 0 {
+        let mode = match pwm.mode {
+            PwmMode::Mode1 => OC_PWM1_EVEN,
+            PwmMode::Mode2 => OC_PWM2_EVEN,
+        };
+        (CCMR_OC_MODE_MASK_EVEN, mode, CCMR_CC_SEL_MASK_EVEN, CCMR_OCPE_EVEN)
+    } else {
+        let mode = match pwm.mode {
+            PwmMode::Mode1 => OC_PWM1_ODD,
+            PwmMode::Mode2 => OC_PWM2_ODD,
+        };
+        (CCMR_OC_MODE_MASK_ODD, mode, CCMR_CC_SEL_MASK_ODD, CCMR_OCPE_ODD)
+    };
+
+    match channel {
+        Channel::Ch0 | Channel::Ch1 => {
+            regs.ccmr1()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !(mode_mask | sel_mask)) | mode_bits | ocpe) });
+        }
+        Channel::Ch2 | Channel::Ch3 => {
+            regs.ccmr2()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !(mode_mask | sel_mask)) | mode_bits | ocpe) });
+        }
+    }
+
+    set_compare::<T>(channel, duty);
+
+    regs.ccer().modify(|r, w| unsafe {
+        let mut bits = r.bits() & !(polarity | np);
+        if pwm.polarity == OutputPolarity::ActiveLow {
+            bits |= polarity;
+        }
+        bits |= enable;
+        w.bits(bits)
+    });
+}
+
+fn configure_capture_channel<T: Instance>(channel: Channel, polarity: CapturePolarity) {
+    let regs = T::regs();
+    let enable = channel_enable_mask(channel);
+    let both = channel_both_edge_mask(channel);
+
+    regs.ccer().modify(|r, w| unsafe { w.bits(r.bits() & !enable) });
+
+    let (sel_mask, sel_bits, filter_mask, oc_mask) = if channel.index() % 2 == 0 {
+        (
+            CCMR_CC_SEL_MASK_EVEN,
+            CC_SEL_INPUT_SAME_EVEN,
+            CCMR_IC_FILTER_MASK_EVEN,
+            CCMR_OC_MODE_MASK_EVEN,
+        )
+    } else {
+        (
+            CCMR_CC_SEL_MASK_ODD,
+            CC_SEL_INPUT_SAME_ODD,
+            CCMR_IC_FILTER_MASK_ODD,
+            CCMR_OC_MODE_MASK_ODD,
+        )
+    };
+
+    match channel {
+        Channel::Ch0 | Channel::Ch1 => {
+            regs.ccmr1()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !(sel_mask | filter_mask | oc_mask)) | sel_bits) });
+        }
+        Channel::Ch2 | Channel::Ch3 => {
+            regs.ccmr2()
+                .modify(|r, w| unsafe { w.bits((r.bits() & !(sel_mask | filter_mask | oc_mask)) | sel_bits) });
+        }
+    }
+
+    let polarity_bits = match polarity {
+        CapturePolarity::Rising => 0,
+        CapturePolarity::Falling => channel_polarity_mask(channel),
+        CapturePolarity::Both => both,
+    };
+
+    regs.ccer()
+        .modify(|r, w| unsafe { w.bits((r.bits() & !both) | polarity_bits | enable) });
+}
+
+fn configure_output_af<'d>(pin: Peri<'d, impl GpioPin>, af: AlternateFunction) -> Flex<'d> {
+    let mut flex = Flex::new(pin);
+    flex.set_as_output();
+    flex.set_pull(Pull::None);
+    flex.set_alternate_function(af);
+    flex
+}
+
+fn configure_input_af<'d>(pin: Peri<'d, impl GpioPin>, af: AlternateFunction) -> Flex<'d> {
+    let mut flex = Flex::new(pin);
+    flex.set_as_input();
+    flex.set_pull(Pull::None);
+    flex.set_alternate_function(af);
+    flex
+}
+
+/// Owned general-purpose timer in basic up-counting mode.
+pub struct Timer<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Timer<'d, T> {
+    /// Enable clocks, reset the block, apply `config`, and leave the counter stopped.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, Error> {
+        enable_instance::<T>()?;
+        let this = Self { _peri: peri };
+        apply_basic_config::<T>(config);
+        Ok(this)
+    }
+
+    /// Re-apply basic timer configuration while the counter is stopped.
+    pub fn configure(&self, config: Config) {
+        set_enabled::<T>(false);
+        apply_basic_config::<T>(config);
+    }
+
+    /// Start or stop the counter (`CR1.CEN`).
+    pub fn set_enabled(&self, enabled: bool) {
+        set_enabled::<T>(enabled);
+    }
+
+    /// Whether the counter is enabled.
+    pub fn is_enabled(&self) -> bool {
+        T::regs().cr1().read().bits() & CR1_CEN != 0
+    }
+
+    /// Current counter value.
+    pub fn counter(&self) -> u16 {
+        T::regs().cnt().read().bits() as u16
+    }
+
+    /// Auto-reload period (`ARR`).
+    pub fn period(&self) -> u16 {
+        T::regs().arr().read().bits() as u16
+    }
+
+    /// Set the auto-reload period.
+    pub fn set_period(&self, period: u16) {
+        unsafe {
+            T::regs().arr().write_with_zero(|w| w.bits(u32::from(period)));
+        }
+    }
+
+    /// Prescaler (`PSC`).
+    pub fn prescaler(&self) -> u16 {
+        T::regs().psc().read().bits() as u16
+    }
+
+    /// Kernel clock frequency in hertz.
+    pub fn clock_hz(&self) -> Result<u32, Error> {
+        T::kernel_clock_hz()
+            .filter(|&hz| hz != 0)
+            .ok_or(Error::ClockUnavailable)
+    }
+
+    /// Tick frequency after the prescaler: `f_kernel / (PSC + 1)`.
+    pub fn tick_hz(&self) -> Result<u32, Error> {
+        let pclk = self.clock_hz()?;
+        Ok(pclk / (u32::from(self.prescaler()) + 1))
+    }
+
+    /// Enable or disable interrupt sources and unmask the NVIC when any are set.
+    pub fn set_interrupt_enabled(&self, flags: InterruptFlags, enabled: bool) {
+        set_interrupt_enabled::<T>(flags, enabled);
+    }
+
+    /// Clear status flags (vendor `timer_clear_status`).
+    pub fn clear_interrupt(&self, flags: InterruptFlags) {
+        clear_interrupt::<T>(flags);
+    }
+
+    /// Raw pending `SR` bits masked to the interrupt set.
+    pub fn interrupt_status(&self) -> InterruptFlags {
+        InterruptFlags(T::regs().sr().read().bits() & SR_IT_MASK)
+    }
+
+    /// Wait until any of `flags` is reported by [`InterruptHandler`].
+    pub async fn wait_for(&self, flags: InterruptFlags) -> InterruptFlags {
+        wait_for_flags::<T>(flags).await
+    }
+}
+
+impl<'d, T: Instance> Drop for Timer<'d, T> {
+    fn drop(&mut self) {
+        T::nv_interrupt().disable();
+        set_enabled::<T>(false);
+        let _ = rcc::disable_peripheral(T::rcc_peripheral());
+    }
+}
+
+/// PWM pin wrapper that owns the GPIO in the correct alternate function.
+pub struct PwmPin<'d, T: Instance, C: TimerChannel> {
+    pin: Flex<'d>,
+    _phantom: PhantomData<(T, C)>,
+}
+
+impl<'d, T: Instance, C: TimerChannel> PwmPin<'d, T, C> {
+    /// Mux a datasheet-documented timer channel pin as a PWM output.
+    pub fn new<P: TimerPin<T, C>>(pin: Peri<'d, P>) -> Self {
+        Self {
+            pin: configure_output_af(pin, P::AF),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Mux `pin` with an explicit alternate function as a PWM output.
+    pub fn new_af(pin: Peri<'d, impl GpioPin>, af: AlternateFunction) -> Self {
+        Self {
+            pin: configure_output_af(pin, af),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// Input-capture pin wrapper.
+pub struct CapturePin<'d, T: Instance, C: TimerChannel> {
+    pin: Flex<'d>,
+    _phantom: PhantomData<(T, C)>,
+}
+
+impl<'d, T: Instance, C: TimerChannel> CapturePin<'d, T, C> {
+    /// Mux a datasheet-documented timer channel pin as a capture input.
+    pub fn new<P: TimerPin<T, C>>(pin: Peri<'d, P>) -> Self {
+        Self {
+            pin: configure_input_af(pin, P::AF),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Mux `pin` with an explicit alternate function as a capture input.
+    pub fn new_af(pin: Peri<'d, impl GpioPin>, af: AlternateFunction) -> Self {
+        Self {
+            pin: configure_input_af(pin, af),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+/// One PWM channel obtained from [`SimplePwm::channel`].
+pub struct SimplePwmChannel<'a, T: Instance> {
+    channel: Channel,
+    max_duty: u16,
+    _phantom: PhantomData<&'a mut T>,
+}
+
+impl<'a, T: Instance> SimplePwmChannel<'a, T> {
+    /// Enable the channel output.
+    pub fn enable(&mut self) {
+        set_channel_enable::<T>(self.channel, true);
+    }
+
+    /// Disable the channel output.
+    pub fn disable(&mut self) {
+        set_channel_enable::<T>(self.channel, false);
+    }
+
+    /// Whether the channel output is enabled.
+    pub fn is_enabled(&self) -> bool {
+        channel_enabled::<T>(self.channel)
+    }
+
+    /// Maximum duty cycle (`ARR + 1`).
+    pub fn max_duty_cycle(&self) -> u16 {
+        self.max_duty
+    }
+
+    /// Set the compare value / duty cycle (`0..=max_duty_cycle`).
+    pub fn set_duty_cycle(&mut self, duty: u16) {
+        let value = if self.max_duty == 0 {
+            0
+        } else if duty >= self.max_duty {
+            self.max_duty - 1
+        } else {
+            duty
+        };
+        set_compare::<T>(self.channel, value);
+    }
+
+    /// Current compare value.
+    pub fn get_duty_cycle(&self) -> u16 {
+        get_compare::<T>(self.channel)
+    }
+}
+
+impl<'a, T: Instance> embedded_hal::pwm::ErrorType for SimplePwmChannel<'a, T> {
+    type Error = core::convert::Infallible;
+}
+
+impl<'a, T: Instance> embedded_hal::pwm::SetDutyCycle for SimplePwmChannel<'a, T> {
+    fn max_duty_cycle(&self) -> u16 {
+        SimplePwmChannel::max_duty_cycle(self)
+    }
+
+    fn set_duty_cycle(&mut self, duty: u16) -> Result<(), Self::Error> {
+        SimplePwmChannel::set_duty_cycle(self, duty);
+        Ok(())
+    }
+}
+
+/// Simple up-counting PWM driver for one GPTimer.
+pub struct SimplePwm<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+    _ch0: Option<Flex<'d>>,
+    _ch1: Option<Flex<'d>>,
+    _ch2: Option<Flex<'d>>,
+    _ch3: Option<Flex<'d>>,
+}
+
+impl<'d, T: Instance> SimplePwm<'d, T> {
+    /// Create a PWM timer at `frequency_hz`, optionally attaching channel pins.
+    pub fn new(
+        peri: Peri<'d, T>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        ch0: Option<PwmPin<'d, T, Ch0>>,
+        ch1: Option<PwmPin<'d, T, Ch1>>,
+        ch2: Option<PwmPin<'d, T, Ch2>>,
+        ch3: Option<PwmPin<'d, T, Ch3>>,
+        frequency_hz: u32,
+        pwm: PwmConfig,
+    ) -> Result<Self, Error> {
+        enable_instance::<T>()?;
+
+        let pclk = T::kernel_clock_hz()
+            .filter(|&hz| hz != 0)
+            .ok_or(Error::ClockUnavailable)?;
+        let (prescaler, period) = compute_psc_arr(pclk, frequency_hz)?;
+
+        apply_basic_config::<T>(Config {
+            prescaler,
+            period,
+            clock_division: ClockDivision::Div1,
+            autoreload_preload: pwm.autoreload_preload,
+        });
+
+        let this = Self {
+            _peri: peri,
+            _ch0: ch0.map(|p| p.pin),
+            _ch1: ch1.map(|p| p.pin),
+            _ch2: ch2.map(|p| p.pin),
+            _ch3: ch3.map(|p| p.pin),
+        };
+
+        if this._ch0.is_some() {
+            configure_pwm_channel::<T>(Channel::Ch0, pwm, 0);
+        }
+        if this._ch1.is_some() {
+            configure_pwm_channel::<T>(Channel::Ch1, pwm, 0);
+        }
+        if this._ch2.is_some() {
+            configure_pwm_channel::<T>(Channel::Ch2, pwm, 0);
+        }
+        if this._ch3.is_some() {
+            configure_pwm_channel::<T>(Channel::Ch3, pwm, 0);
+        }
+
+        set_enabled::<T>(true);
+        Ok(this)
+    }
+
+    /// Maximum duty cycle (`ARR + 1`).
+    pub fn max_duty_cycle(&self) -> u16 {
+        (T::regs().arr().read().bits() as u16).saturating_add(1)
+    }
+
+    /// Output frequency programmed into PSC/ARR.
+    pub fn frequency_hz(&self) -> Result<u32, Error> {
+        let pclk = T::kernel_clock_hz()
+            .filter(|&hz| hz != 0)
+            .ok_or(Error::ClockUnavailable)?;
+        let psc = T::regs().psc().read().bits() + 1;
+        let arr = T::regs().arr().read().bits() + 1;
+        Ok(pclk / psc / arr)
+    }
+
+    /// Borrow a channel for duty-cycle control.
+    pub fn channel(&mut self, channel: Channel) -> SimplePwmChannel<'_, T> {
+        SimplePwmChannel {
+            channel,
+            max_duty: self.max_duty_cycle(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Borrow channel 0.
+    pub fn ch0(&mut self) -> SimplePwmChannel<'_, T> {
+        self.channel(Channel::Ch0)
+    }
+
+    /// Borrow channel 1.
+    pub fn ch1(&mut self) -> SimplePwmChannel<'_, T> {
+        self.channel(Channel::Ch1)
+    }
+
+    /// Borrow channel 2.
+    pub fn ch2(&mut self) -> SimplePwmChannel<'_, T> {
+        self.channel(Channel::Ch2)
+    }
+
+    /// Borrow channel 3.
+    pub fn ch3(&mut self) -> SimplePwmChannel<'_, T> {
+        self.channel(Channel::Ch3)
+    }
+
+    /// Enable or disable interrupt sources.
+    pub fn set_interrupt_enabled(&self, flags: InterruptFlags, enabled: bool) {
+        set_interrupt_enabled::<T>(flags, enabled);
+    }
+
+    /// Clear status flags.
+    pub fn clear_interrupt(&self, flags: InterruptFlags) {
+        clear_interrupt::<T>(flags);
+    }
+
+    /// Wait until any of `flags` is reported by [`InterruptHandler`].
+    pub async fn wait_for(&self, flags: InterruptFlags) -> InterruptFlags {
+        wait_for_flags::<T>(flags).await
+    }
+
+    /// Start or stop the counter.
+    pub fn set_enabled(&self, enabled: bool) {
+        set_enabled::<T>(enabled);
+    }
+}
+
+impl<'d, T: Instance> Drop for SimplePwm<'d, T> {
+    fn drop(&mut self) {
+        T::nv_interrupt().disable();
+        set_enabled::<T>(false);
+        let _ = rcc::disable_peripheral(T::rcc_peripheral());
+    }
+}
+
+/// Input-capture driver for a single channel.
+pub struct InputCapture<'d, T: Instance> {
+    _peri: Peri<'d, T>,
+    _pin: Flex<'d>,
+    channel: Channel,
+}
+
+impl<'d, T: Instance> InputCapture<'d, T> {
+    /// Configure up-counting capture on one channel.
+    pub fn new<C: TimerChannel>(
+        peri: Peri<'d, T>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        pin: CapturePin<'d, T, C>,
+        config: Config,
+        polarity: CapturePolarity,
+    ) -> Result<Self, Error> {
+        enable_instance::<T>()?;
+        apply_basic_config::<T>(config);
+        configure_capture_channel::<T>(C::CHANNEL, polarity);
+        set_enabled::<T>(true);
+
+        Ok(Self {
+            _peri: peri,
+            _pin: pin.pin,
+            channel: C::CHANNEL,
+        })
+    }
+
+    /// Capture channel.
+    pub fn channel(&self) -> Channel {
+        self.channel
+    }
+
+    /// Latest captured counter value (`CCR`).
+    pub fn capture(&self) -> u16 {
+        get_compare::<T>(self.channel)
+    }
+
+    /// Current free-running counter.
+    pub fn counter(&self) -> u16 {
+        T::regs().cnt().read().bits() as u16
+    }
+
+    /// Enable or disable the capture interrupt for this channel.
+    pub fn set_interrupt_enabled(&self, enabled: bool) {
+        set_interrupt_enabled::<T>(InterruptFlags::cc(self.channel), enabled);
+    }
+
+    /// Clear the capture flag for this channel.
+    pub fn clear_interrupt(&self) {
+        clear_interrupt::<T>(InterruptFlags::cc(self.channel));
+    }
+
+    /// Wait for the next capture event on this channel.
+    pub async fn wait_for_capture(&self) -> u16 {
+        let _ = wait_for_flags::<T>(InterruptFlags::cc(self.channel)).await;
+        self.capture()
+    }
+
+    /// Wait until any of `flags` is reported by [`InterruptHandler`].
+    pub async fn wait_for(&self, flags: InterruptFlags) -> InterruptFlags {
+        wait_for_flags::<T>(flags).await
+    }
+
+    /// Start or stop the counter.
+    pub fn set_enabled(&self, enabled: bool) {
+        set_enabled::<T>(enabled);
+    }
+}
+
+impl<'d, T: Instance> Drop for InputCapture<'d, T> {
+    fn drop(&mut self) {
+        T::nv_interrupt().disable();
+        set_enabled::<T>(false);
+        let _ = rcc::disable_peripheral(T::rcc_peripheral());
+    }
+}
+
+/// Datasheet-documented timer channel pin for an instance.
+pub trait TimerPin<T: Instance, C: TimerChannel>: GpioPin {
+    /// Alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+/// Datasheet-documented external trigger pin for an instance.
+pub trait EtrPin<T: Instance>: GpioPin {
+    /// Alternate-function number for this pin/signal.
+    const AF: AlternateFunction;
+}
+
+macro_rules! impl_timer_pin {
+    ($pin:ident, $instance:ident, $ch:ident, $af:ident) => {
+        impl TimerPin<peripherals::$instance, $ch> for peripherals::$pin {
+            const AF: AlternateFunction = AlternateFunction::$af;
+        }
+    };
+}
+
+macro_rules! impl_etr_pin {
+    ($pin:ident, $instance:ident, $af:ident) => {
+        impl EtrPin<peripherals::$instance> for peripherals::$pin {
+            const AF: AlternateFunction = AlternateFunction::$af;
+        }
+    };
+}
+
+// Datasheet Table 4-4 (Fun=4..7). GPIO00=PA0 … GPIO15=PA15, GPIO16=PB0, …
+impl_timer_pin!(PA0, TIMER0, Ch0, Function6);
+impl_timer_pin!(PA5, TIMER0, Ch0, Function6);
+impl_timer_pin!(PA10, TIMER0, Ch0, Function6);
+impl_timer_pin!(PA1, TIMER0, Ch1, Function6);
+impl_timer_pin!(PA14, TIMER0, Ch1, Function6);
+impl_timer_pin!(PA2, TIMER0, Ch2, Function6);
+impl_timer_pin!(PA3, TIMER0, Ch3, Function6);
+impl_etr_pin!(PA0, TIMER0, Function7);
+impl_etr_pin!(PA5, TIMER0, Function7);
+impl_etr_pin!(PA10, TIMER0, Function7);
+
+impl_timer_pin!(PA8, TIMER1, Ch0, Function6);
+impl_timer_pin!(PA15, TIMER1, Ch0, Function6);
+impl_timer_pin!(PB12, TIMER1, Ch0, Function6);
+impl_timer_pin!(PC13, TIMER1, Ch0, Function6);
+impl_timer_pin!(PA9, TIMER1, Ch1, Function6);
+impl_timer_pin!(PB0, TIMER1, Ch1, Function6);
+impl_timer_pin!(PB13, TIMER1, Ch1, Function6);
+impl_timer_pin!(PA11, TIMER1, Ch2, Function6);
+impl_timer_pin!(PB14, TIMER1, Ch2, Function6);
+impl_timer_pin!(PC15, TIMER1, Ch2, Function6);
+impl_timer_pin!(PA12, TIMER1, Ch3, Function6);
+impl_timer_pin!(PB15, TIMER1, Ch3, Function6);
+impl_etr_pin!(PC8, TIMER1, Function7);
+impl_etr_pin!(PC12, TIMER1, Function6);
+
+impl_timer_pin!(PA2, TIMER2, Ch0, Function7);
+impl_timer_pin!(PC15, TIMER2, Ch0, Function7);
+impl_timer_pin!(PA3, TIMER2, Ch1, Function7);
+impl_timer_pin!(PC9, TIMER2, Ch1, Function7);
+impl_etr_pin!(PA1, TIMER2, Function7);
+impl_etr_pin!(PB15, TIMER2, Function7);
+
+impl_timer_pin!(PA8, TIMER3, Ch0, Function7);
+impl_timer_pin!(PA15, TIMER3, Ch0, Function7);
+impl_timer_pin!(PB12, TIMER3, Ch0, Function7);
+impl_timer_pin!(PC13, TIMER3, Ch0, Function7);
+impl_timer_pin!(PA9, TIMER3, Ch1, Function7);
+impl_timer_pin!(PB0, TIMER3, Ch1, Function7);
+impl_timer_pin!(PB13, TIMER3, Ch1, Function7);
+impl_etr_pin!(PA4, TIMER3, Function7);
+impl_etr_pin!(PB14, TIMER3, Function7);
+
+/// Mux a documented ETR pin and return the owned GPIO wrap.
+pub fn take_etr_pin<'d, T: Instance>(pin: Peri<'d, impl EtrPin<T>>) -> Flex<'d> {
+    // AF is read through a local helper trait object-free path.
+    take_etr_pin_inner(pin)
+}
+
+fn take_etr_pin_inner<'d, T: Instance, P: EtrPin<T>>(pin: Peri<'d, P>) -> Flex<'d> {
+    configure_input_af(pin, P::AF)
+}
+
+/// Alternate-function numbers used by the SDK TIMER0 PWM example.
+pub mod af {
+    use crate::gpio::AlternateFunction;
+
+    /// Channel pins on TIMER0 (SDK `gpio_set_iomux(..., 6)`).
+    pub const TIMER_CH: AlternateFunction = AlternateFunction::Function6;
+    /// ETR pin on TIMER0 (SDK `gpio_set_iomux(..., 7)`).
+    pub const TIMER0_ETR: AlternateFunction = AlternateFunction::Function7;
+}

--- a/embassy-asr/src/uart.rs
+++ b/embassy-asr/src/uart.rs
@@ -1,0 +1,1077 @@
+//! UART0–UART3 driver for the ASR6601.
+//!
+//! Register programming follows the vendor `tremo_uart` driver (PL011-style
+//! UART). Pin mux numbers are supplied explicitly by the caller; this crate
+//! does not invent a pinmux matrix.
+//!
+//! # Unsafe contracts
+//!
+//! - [`InterruptHandler::on_interrupt`] may be called only from the vector bound
+//!   through [`crate::bind_interrupts!`] for the matching UART instance.
+//! - DMA helpers require the supplied channel to remain exclusively owned for
+//!   the transfer, and the buffer to stay valid and DMA-accessible until the
+//!   future (or blocking call) returns.
+//! - Constructing a driver steals the PAC register block for that UART. The
+//!   owned [`Peri`] token is the exclusivity proof; do not also use
+//!   `pac::Uart*::steal()` from application code while the driver is alive.
+
+use core::future::poll_fn;
+use core::marker::PhantomData;
+use core::sync::atomic::{AtomicU8, Ordering, compiler_fence};
+use core::task::Poll;
+
+use embassy_hal_internal::interrupt::Priority;
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::dma::{self, Channel as DmaChannel, Request, TransferOptions};
+use crate::gpio::{AlternateFunction, AnyPin, Flex, Pin};
+use crate::interrupt::typelevel::{Binding, Handler, Interrupt};
+use crate::mode::{Async, Blocking, Mode};
+use crate::pac::uart0::RegisterBlock;
+use crate::rcc::{self, Peripheral};
+use crate::{interrupt, pac, peripherals};
+
+const FLAG_TXFE: u32 = 1 << 7;
+const FLAG_TXFF: u32 = 1 << 5;
+const FLAG_RXFE: u32 = 1 << 4;
+const FLAG_BUSY: u32 = 1 << 3;
+
+const INT_RX: u32 = 1 << 4;
+const INT_TX: u32 = 1 << 5;
+const INT_RT: u32 = 1 << 6;
+const INT_FE: u32 = 1 << 7;
+const INT_PE: u32 = 1 << 8;
+const INT_BE: u32 = 1 << 9;
+const INT_OE: u32 = 1 << 10;
+const INT_RX_ALL: u32 = INT_RX | INT_RT | INT_FE | INT_PE | INT_BE | INT_OE;
+
+const DR_FE: u32 = 1 << 8;
+const DR_PE: u32 = 1 << 9;
+const DR_BE: u32 = 1 << 10;
+const DR_OE: u32 = 1 << 11;
+const DR_ERROR_MASK: u32 = DR_FE | DR_PE | DR_BE | DR_OE;
+
+const RCO4M_HZ: u32 = 3_600_000;
+const XO32K_HZ: u32 = 32_768;
+const XO24M_HZ: u32 = 24_000_000;
+
+static STATE: [State; 4] = [const { State::new() }; 4];
+
+struct State {
+    tx_waker: AtomicWaker,
+    rx_waker: AtomicWaker,
+    /// Number of live [`UartTx`]/ [`UartRx`] halves.
+    refcount: AtomicU8,
+}
+
+impl State {
+    const fn new() -> Self {
+        Self {
+            tx_waker: AtomicWaker::new(),
+            rx_waker: AtomicWaker::new(),
+            refcount: AtomicU8::new(0),
+        }
+    }
+}
+
+struct Info {
+    index: usize,
+    base: usize,
+    rcc: Peripheral,
+    /// `true` when the default UART clock is PCLK0; otherwise PCLK1.
+    pclk0: bool,
+    dma_tx: Request,
+    dma_rx: Request,
+    state: &'static State,
+}
+
+impl Info {
+    fn regs(&self) -> &'static RegisterBlock {
+        unsafe { &*(self.base as *const RegisterBlock) }
+    }
+}
+
+/// UART interrupt handler.
+pub struct InterruptHandler<T: Instance> {
+    _phantom: PhantomData<T>,
+}
+
+impl<T: Instance> Handler<T::Interrupt> for InterruptHandler<T> {
+    unsafe fn on_interrupt() {
+        let info = T::info();
+        let regs = info.regs();
+        let mis = regs.mis().read().bits();
+
+        if mis == 0 {
+            return;
+        }
+
+        if mis & INT_TX != 0 {
+            // Disable TX interrupt; the TX task re-enables when needed.
+            let imsc = regs.imsc().read().bits() & !INT_TX;
+            unsafe {
+                regs.imsc().write_with_zero(|w| w.bits(imsc));
+            }
+            info.state.tx_waker.wake();
+        }
+
+        if mis & INT_RX_ALL != 0 {
+            let imsc = regs.imsc().read().bits() & !INT_RX_ALL;
+            unsafe {
+                regs.imsc().write_with_zero(|w| w.bits(imsc));
+            }
+            info.state.rx_waker.wake();
+        }
+
+        // ICR is write-1-to-clear; the PAC models it without field accessors.
+        unsafe {
+            regs.icr().write_with_zero(|w| w.bits(mis));
+        }
+    }
+}
+
+/// Number of data bits.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum DataBits {
+    /// 5 data bits.
+    DataBits5,
+    /// 6 data bits.
+    DataBits6,
+    /// 7 data bits.
+    DataBits7,
+    /// 8 data bits.
+    DataBits8,
+}
+
+/// Parity selection.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Parity {
+    /// No parity bit.
+    None,
+    /// Odd parity.
+    Odd,
+    /// Even parity.
+    Even,
+}
+
+/// Number of stop bits.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum StopBits {
+    /// One stop bit.
+    STOP1,
+    /// Two stop bits.
+    STOP2,
+}
+
+/// Hardware flow control.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum FlowControl {
+    /// No RTS/CTS.
+    None,
+    /// RTS only.
+    Rts,
+    /// CTS only.
+    Cts,
+    /// RTS and CTS.
+    RtsCts,
+}
+
+/// UART configuration.
+#[non_exhaustive]
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct Config {
+    /// Baud rate in bits per second.
+    pub baudrate: u32,
+    /// Number of data bits.
+    pub data_bits: DataBits,
+    /// Parity.
+    pub parity: Parity,
+    /// Number of stop bits.
+    pub stop_bits: StopBits,
+    /// Hardware flow control.
+    pub flow_control: FlowControl,
+    /// Enable the TX/RX FIFOs (`LCR_H.FEN`).
+    ///
+    /// The vendor SDK defaults this to disabled; enabling it is recommended for
+    /// interrupt-driven and DMA transfers.
+    pub fifo: bool,
+}
+
+impl Config {
+    /// Create a 115200 8N1 configuration with FIFOs enabled.
+    pub const fn new() -> Self {
+        Self {
+            baudrate: 115_200,
+            data_bits: DataBits::DataBits8,
+            parity: Parity::None,
+            stop_bits: StopBits::STOP1,
+            flow_control: FlowControl::None,
+            fifo: true,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Configuration error.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum ConfigError {
+    /// Baud rate cannot be represented for the active UART clock.
+    Baudrate,
+    /// RCC clocks have not been published by [`crate::init`].
+    ClocksNotInitialized,
+    /// Neither an RX nor a TX pin was supplied.
+    NoRxOrTx,
+    /// Flow-control pins required by [`Config::flow_control`] were missing.
+    MissingFlowControlPin,
+    /// Enabling or resetting the UART clock failed.
+    Rcc(rcc::Error),
+}
+
+/// UART transfer / framing error.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// RX FIFO overrun.
+    Overrun,
+    /// Framing error.
+    Framing,
+    /// Parity error.
+    Parity,
+    /// Break condition.
+    Break,
+    /// DMA helper failed.
+    Dma(dma::Error),
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Overrun => write!(f, "UART overrun"),
+            Self::Framing => write!(f, "UART framing error"),
+            Self::Parity => write!(f, "UART parity error"),
+            Self::Break => write!(f, "UART break"),
+            Self::Dma(_) => write!(f, "UART DMA error"),
+        }
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl embedded_io::Error for Error {
+    fn kind(&self) -> embedded_io::ErrorKind {
+        match self {
+            Self::Overrun => embedded_io::ErrorKind::OutOfMemory,
+            Self::Framing | Self::Parity | Self::Break => embedded_io::ErrorKind::InvalidData,
+            Self::Dma(_) => embedded_io::ErrorKind::Other,
+        }
+    }
+}
+
+fn decode_dr_error(value: u32) -> Result<u8, Error> {
+    if value & DR_OE != 0 {
+        return Err(Error::Overrun);
+    }
+    if value & DR_BE != 0 {
+        return Err(Error::Break);
+    }
+    if value & DR_PE != 0 {
+        return Err(Error::Parity);
+    }
+    if value & DR_FE != 0 {
+        return Err(Error::Framing);
+    }
+    Ok((value & 0xff) as u8)
+}
+
+fn calc_baud_div(uart_clk: u32, baud: u32) -> Option<(u32, u32)> {
+    let temp = 16u32.checked_mul(baud)?;
+    if baud == 0 || uart_clk < temp {
+        return None;
+    }
+
+    let int_div = uart_clk / temp;
+    let remainder = uart_clk % temp;
+    let temp = 8 * remainder / baud;
+    let fac_div = (temp >> 1) + (temp & 1);
+    Some((int_div, fac_div & 0x3f))
+}
+
+fn uart_clock_hz(info: &'static Info) -> Result<u32, ConfigError> {
+    let clocks = rcc::clocks().ok_or(ConfigError::ClocksNotInitialized)?;
+    let rcc_regs = unsafe { pac::Rcc::steal() };
+    let shift = match info.index {
+        0 => 15,
+        1 => 13,
+        2 => 11,
+        3 => 9,
+        _ => unreachable!(),
+    };
+    let sel = (rcc_regs.cr2().read().bits() >> shift) & 0x3;
+    Ok(match sel {
+        1 => RCO4M_HZ,
+        2 => XO32K_HZ,
+        3 => XO24M_HZ,
+        _ if info.pclk0 => clocks.pclk0_hz,
+        _ => clocks.pclk1_hz,
+    })
+}
+
+fn erase_pin<'d>(
+    pin: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+) -> Option<(Peri<'d, AnyPin>, AlternateFunction)> {
+    pin.map(|(p, af)| (p.into(), af))
+}
+
+fn configure_pin(pin: Peri<'_, impl Pin>, af: AlternateFunction, output: bool) -> Peri<'_, AnyPin> {
+    let mut flex = Flex::new(pin);
+    if output {
+        flex.set_as_output();
+    } else {
+        flex.set_as_input();
+    }
+    flex.set_alternate_function(af);
+    flex.into_inner()
+}
+
+fn apply_config(info: &'static Info, config: Config, has_rx: bool, has_tx: bool) -> Result<(), ConfigError> {
+    let uart_clk = uart_clock_hz(info)?;
+    let (ibrd, fbrd) = calc_baud_div(uart_clk, config.baudrate).ok_or(ConfigError::Baudrate)?;
+
+    let regs = info.regs();
+
+    // Disable UART and flush FIFOs by clearing FEN, matching `uart_init`.
+    regs.cr().modify(|_, w| w.uart_en().clear_bit());
+    regs.lcr_h().modify(|_, w| w.fen().clear_bit());
+    unsafe {
+        regs.imsc().write_with_zero(|w| w.bits(0));
+        regs.ibrd().write_with_zero(|w| w.bits(ibrd));
+        regs.fbrd().write_with_zero(|w| w.bits(fbrd));
+    }
+
+    let wlen = match config.data_bits {
+        DataBits::DataBits5 => pac::uart0::lcr_h::Wlen::Value5,
+        DataBits::DataBits6 => pac::uart0::lcr_h::Wlen::Value6,
+        DataBits::DataBits7 => pac::uart0::lcr_h::Wlen::Value7,
+        DataBits::DataBits8 => pac::uart0::lcr_h::Wlen::Value8,
+    };
+    let stop = match config.stop_bits {
+        StopBits::STOP1 => pac::uart0::lcr_h::Stop::Value1,
+        StopBits::STOP2 => pac::uart0::lcr_h::Stop::Value2,
+    };
+
+    regs.lcr_h().modify(|_, w| {
+        w.wlen().variant(wlen);
+        w.stop().variant(stop);
+        w.fen().bit(config.fifo);
+        match config.parity {
+            Parity::None => {
+                w.pen().clear_bit();
+            }
+            Parity::Odd => {
+                w.pen().set_bit();
+                w.eps_even().clear_bit();
+            }
+            Parity::Even => {
+                w.pen().set_bit();
+                w.eps_even().set_bit();
+            }
+        }
+        w
+    });
+
+    let mode = match (has_rx, has_tx) {
+        (true, true) => pac::uart0::cr::UartMode::Txrx,
+        (true, false) => pac::uart0::cr::UartMode::Rx,
+        (false, true) => pac::uart0::cr::UartMode::Tx,
+        (false, false) => return Err(ConfigError::NoRxOrTx),
+    };
+    let flow = match config.flow_control {
+        FlowControl::None => pac::uart0::cr::FlowCtrl::None,
+        FlowControl::Rts => pac::uart0::cr::FlowCtrl::Rts,
+        FlowControl::Cts => pac::uart0::cr::FlowCtrl::Cts,
+        FlowControl::RtsCts => pac::uart0::cr::FlowCtrl::CtsRts,
+    };
+
+    regs.cr().modify(|_, w| {
+        w.uart_mode().variant(mode);
+        w.flow_ctrl().variant(flow);
+        w
+    });
+
+    // Prefer a low TX interrupt threshold so TX wakes soon when space appears.
+    regs.ifls().modify(|_, w| {
+        w.tx().variant(pac::uart0::ifls::Tx::Value1_8);
+        w.rx().variant(pac::uart0::ifls::Rx::Value1_8);
+        w
+    });
+
+    regs.cr().modify(|_, w| w.uart_en().set_bit());
+    Ok(())
+}
+
+fn enable_clock(info: &'static Info) -> Result<(), ConfigError> {
+    rcc::enable_peripheral(info.rcc).map_err(ConfigError::Rcc)?;
+    rcc::reset_peripheral(info.rcc).map_err(ConfigError::Rcc)?;
+    Ok(())
+}
+
+fn shutdown(info: &'static Info) {
+    let regs = info.regs();
+    regs.cr().modify(|_, w| w.uart_en().clear_bit());
+    unsafe {
+        regs.imsc().write_with_zero(|w| w.bits(0));
+        regs.dmacr().write_with_zero(|w| w.bits(0));
+    }
+    let _ = rcc::disable_peripheral(info.rcc);
+}
+
+fn flag(regs: &RegisterBlock, mask: u32) -> bool {
+    regs.fr().read().bits() & mask != 0
+}
+
+fn read_dr(regs: &RegisterBlock) -> Result<u8, Error> {
+    let value = regs.dr().read().bits();
+    // Writing RSC_ECR clears sticky receive-status bits (PL011 / SDK).
+    if value & DR_ERROR_MASK != 0 {
+        unsafe {
+            regs.rsc_ecr().write_with_zero(|w| w.bits(0));
+        }
+    }
+    decode_dr_error(value)
+}
+
+fn write_dr(regs: &RegisterBlock, byte: u8) {
+    unsafe {
+        regs.dr().write_with_zero(|w| w.bits(u32::from(byte)));
+    }
+}
+
+fn set_imsc_bits(regs: &RegisterBlock, mask: u32, enable: bool) {
+    let value = regs.imsc().read().bits();
+    let value = if enable { value | mask } else { value & !mask };
+    unsafe {
+        regs.imsc().write_with_zero(|w| w.bits(value));
+    }
+}
+
+fn set_dma_req(regs: &RegisterBlock, tx: bool, enable: bool) {
+    regs.dmacr().modify(|_, w| {
+        if tx {
+            w.tx_en().bit(enable);
+        } else {
+            w.rx_en().bit(enable);
+        }
+        w
+    });
+}
+
+/// Bidirectional UART driver.
+pub struct Uart<'d, M: Mode> {
+    tx: UartTx<'d, M>,
+    rx: UartRx<'d, M>,
+}
+
+/// Transmit half of a UART.
+pub struct UartTx<'d, M: Mode> {
+    info: &'static Info,
+    _pin: Option<Peri<'d, AnyPin>>,
+    _rts: Option<Peri<'d, AnyPin>>,
+    _mode: PhantomData<&'d mut M>,
+}
+
+/// Receive half of a UART.
+pub struct UartRx<'d, M: Mode> {
+    info: &'static Info,
+    _pin: Option<Peri<'d, AnyPin>>,
+    _cts: Option<Peri<'d, AnyPin>>,
+    _mode: PhantomData<&'d mut M>,
+}
+
+impl<'d> Uart<'d, Blocking> {
+    /// Create a blocking UART.
+    ///
+    /// `rx` / `tx` are `(pin, alternate_function)` pairs. Supply `None` for
+    /// unused directions. Flow-control pins are not configured here; use
+    /// [`Self::new_blocking_with_flow_control`] when RTS/CTS are required.
+    pub fn new_blocking<T: Instance>(
+        peri: Peri<'d, T>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner::<T>(peri, erase_pin(rx), erase_pin(tx), None, None, config, false)
+    }
+
+    /// Create a blocking UART with explicit RTS/CTS pins and AF selectors.
+    pub fn new_blocking_with_flow_control<T: Instance>(
+        peri: Peri<'d, T>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        rts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        cts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner::<T>(
+            peri,
+            erase_pin(rx),
+            erase_pin(tx),
+            erase_pin(rts),
+            erase_pin(cts),
+            config,
+            false,
+        )
+    }
+}
+
+impl<'d> Uart<'d, Async> {
+    /// Create an interrupt-driven asynchronous UART.
+    ///
+    /// `irq` proves the UART vector is bound to [`InterruptHandler<T>`].
+    pub fn new<T: Instance>(
+        peri: Peri<'d, T>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner::<T>(peri, erase_pin(rx), erase_pin(tx), None, None, config, true)
+    }
+
+    /// Create an asynchronous UART with explicit RTS/CTS pins and AF selectors.
+    pub fn new_with_flow_control<T: Instance>(
+        peri: Peri<'d, T>,
+        rx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        rts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        cts: Option<(Peri<'d, impl Pin>, AlternateFunction)>,
+        _irq: impl Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner::<T>(
+            peri,
+            erase_pin(rx),
+            erase_pin(tx),
+            erase_pin(rts),
+            erase_pin(cts),
+            config,
+            true,
+        )
+    }
+
+    /// Write `buffer` using interrupt-driven TX.
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.write(buffer).await
+    }
+
+    /// Read into `buffer` until it is full using interrupt-driven RX.
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.read(buffer).await
+    }
+
+    /// Wait until the transmit FIFO and shift register are empty.
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.tx.flush().await
+    }
+
+    /// Write `buffer` with a DMA channel (memory-to-peripheral).
+    ///
+    /// Enables UART TX DMA for the duration of the transfer. Prefer
+    /// [`Config::fifo`] enabled.
+    pub async fn write_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.write_dma(channel, buffer).await
+    }
+
+    /// Read `buffer.len()` bytes with a DMA channel (peripheral-to-memory).
+    pub async fn read_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.read_dma(channel, buffer).await
+    }
+}
+
+impl<'d, M: Mode> Uart<'d, M> {
+    fn new_inner<T: Instance>(
+        _peri: Peri<'d, T>,
+        rx: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        tx: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        rts: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        cts: Option<(Peri<'d, AnyPin>, AlternateFunction)>,
+        config: Config,
+        enable_irq: bool,
+    ) -> Result<Self, ConfigError> {
+        match config.flow_control {
+            FlowControl::Rts if rts.is_none() => return Err(ConfigError::MissingFlowControlPin),
+            FlowControl::Cts if cts.is_none() => return Err(ConfigError::MissingFlowControlPin),
+            FlowControl::RtsCts if rts.is_none() || cts.is_none() => {
+                return Err(ConfigError::MissingFlowControlPin);
+            }
+            _ => {}
+        }
+
+        let info = T::info();
+        enable_clock(info)?;
+
+        let has_rx = rx.is_some();
+        let has_tx = tx.is_some();
+
+        let rx_pin = rx.map(|(p, af)| configure_pin(p, af, false));
+        let tx_pin = tx.map(|(p, af)| configure_pin(p, af, true));
+        let rts_pin = rts.map(|(p, af)| configure_pin(p, af, true));
+        let cts_pin = cts.map(|(p, af)| configure_pin(p, af, false));
+
+        apply_config(info, config, has_rx, has_tx)?;
+
+        info.state.refcount.store(2, Ordering::Release);
+
+        if enable_irq {
+            T::Interrupt::unpend();
+            T::Interrupt::set_priority(Priority::P3);
+            unsafe {
+                T::Interrupt::enable();
+            }
+        }
+
+        Ok(Self {
+            tx: UartTx {
+                info,
+                _pin: tx_pin,
+                _rts: rts_pin,
+                _mode: PhantomData,
+            },
+            rx: UartRx {
+                info,
+                _pin: rx_pin,
+                _cts: cts_pin,
+                _mode: PhantomData,
+            },
+        })
+    }
+
+    /// Split into independent TX and RX drivers.
+    pub fn split(self) -> (UartTx<'d, M>, UartRx<'d, M>) {
+        (self.tx, self.rx)
+    }
+
+    /// Reborrow as independent TX and RX drivers.
+    pub fn split_ref(&mut self) -> (&mut UartTx<'d, M>, &mut UartRx<'d, M>) {
+        (&mut self.tx, &mut self.rx)
+    }
+
+    /// Blocking write of the entire buffer.
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.blocking_write(buffer)
+    }
+
+    /// Blocking read that fills the entire buffer.
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.rx.blocking_read(buffer)
+    }
+
+    /// Blocking flush of the transmitter.
+    pub fn blocking_flush(&mut self) -> Result<(), Error> {
+        self.tx.blocking_flush()
+    }
+
+    /// Blocking DMA write.
+    pub fn blocking_write_dma(&mut self, channel: &mut DmaChannel<'_, Blocking>, buffer: &[u8]) -> Result<(), Error> {
+        self.tx.blocking_write_dma(channel, buffer)
+    }
+
+    /// Blocking DMA read of `buffer.len()` bytes.
+    pub fn blocking_read_dma(
+        &mut self,
+        channel: &mut DmaChannel<'_, Blocking>,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        self.rx.blocking_read_dma(channel, buffer)
+    }
+}
+
+impl<'d, M: Mode> UartTx<'d, M> {
+    fn regs(&self) -> &'static RegisterBlock {
+        self.info.regs()
+    }
+
+    /// Blocking write of the entire buffer.
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        let regs = self.regs();
+        for &byte in buffer {
+            while flag(regs, FLAG_TXFF) {}
+            write_dr(regs, byte);
+        }
+        Ok(())
+    }
+
+    /// Blocking flush: wait until TX FIFO empty and UART not busy.
+    pub fn blocking_flush(&mut self) -> Result<(), Error> {
+        let regs = self.regs();
+        while !flag(regs, FLAG_TXFE) || flag(regs, FLAG_BUSY) {}
+        Ok(())
+    }
+
+    /// Blocking DMA write.
+    pub fn blocking_write_dma(&mut self, channel: &mut DmaChannel<'_, Blocking>, buffer: &[u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let dest = regs.dr().as_ptr();
+        set_dma_req(regs, true, true);
+        let result = unsafe {
+            channel
+                .start_write(buffer, dest.cast::<u8>(), self.info.dma_tx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .blocking_wait()
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, true, false);
+        result
+    }
+}
+
+impl<'d> UartTx<'d, Async> {
+    /// Interrupt-driven write of the entire buffer.
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        let info = self.info;
+        let regs = info.regs();
+        for &byte in buffer {
+            poll_fn(|cx| {
+                if !flag(regs, FLAG_TXFF) {
+                    return Poll::Ready(());
+                }
+                info.state.tx_waker.register(cx.waker());
+                set_imsc_bits(regs, INT_TX, true);
+                if !flag(regs, FLAG_TXFF) {
+                    set_imsc_bits(regs, INT_TX, false);
+                    return Poll::Ready(());
+                }
+                Poll::Pending
+            })
+            .await;
+            write_dr(regs, byte);
+        }
+        set_imsc_bits(regs, INT_TX, false);
+        Ok(())
+    }
+
+    /// Wait until TX FIFO empty and UART not busy.
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        let info = self.info;
+        let regs = info.regs();
+        poll_fn(|cx| {
+            if flag(regs, FLAG_TXFE) && !flag(regs, FLAG_BUSY) {
+                return Poll::Ready(());
+            }
+            // TX interrupt fires when FIFO drops to the threshold; also useful while draining.
+            info.state.tx_waker.register(cx.waker());
+            set_imsc_bits(regs, INT_TX, true);
+            if flag(regs, FLAG_TXFE) && !flag(regs, FLAG_BUSY) {
+                set_imsc_bits(regs, INT_TX, false);
+                return Poll::Ready(());
+            }
+            Poll::Pending
+        })
+        .await;
+        set_imsc_bits(regs, INT_TX, false);
+        Ok(())
+    }
+
+    /// DMA write using an async DMA channel.
+    pub async fn write_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &[u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let dest = regs.dr().as_ptr();
+        set_dma_req(regs, true, true);
+        compiler_fence(Ordering::SeqCst);
+        let result = unsafe {
+            channel
+                .write(buffer, dest.cast::<u8>(), self.info.dma_tx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .await
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, true, false);
+        result
+    }
+}
+
+impl<'d, M: Mode> UartRx<'d, M> {
+    fn regs(&self) -> &'static RegisterBlock {
+        self.info.regs()
+    }
+
+    /// Blocking read that fills the entire buffer.
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        let regs = self.regs();
+        for slot in buffer.iter_mut() {
+            while flag(regs, FLAG_RXFE) {}
+            *slot = read_dr(regs)?;
+        }
+        Ok(())
+    }
+
+    /// Blocking DMA read of `buffer.len()` bytes.
+    pub fn blocking_read_dma(
+        &mut self,
+        channel: &mut DmaChannel<'_, Blocking>,
+        buffer: &mut [u8],
+    ) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let src = regs.dr().as_ptr();
+        set_dma_req(regs, false, true);
+        let result = unsafe {
+            channel
+                .start_read(src.cast::<u8>(), buffer, self.info.dma_rx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .blocking_wait()
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, false, false);
+        result
+    }
+
+    fn nb_read_byte(&mut self) -> Result<Option<u8>, Error> {
+        let regs = self.regs();
+        if flag(regs, FLAG_RXFE) {
+            Ok(None)
+        } else {
+            Ok(Some(read_dr(regs)?))
+        }
+    }
+}
+
+impl<'d> UartRx<'d, Async> {
+    async fn wait_rx_ready(&mut self) {
+        let info = self.info;
+        let regs = info.regs();
+        poll_fn(|cx| {
+            if !flag(regs, FLAG_RXFE) {
+                return Poll::Ready(());
+            }
+            info.state.rx_waker.register(cx.waker());
+            set_imsc_bits(regs, INT_RX_ALL, true);
+            if !flag(regs, FLAG_RXFE) {
+                set_imsc_bits(regs, INT_RX_ALL, false);
+                return Poll::Ready(());
+            }
+            Poll::Pending
+        })
+        .await;
+        set_imsc_bits(regs, INT_RX_ALL, false);
+    }
+
+    /// Interrupt-driven read that fills the entire buffer.
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        for slot in buffer.iter_mut() {
+            self.wait_rx_ready().await;
+            *slot = read_dr(self.regs())?;
+        }
+        Ok(())
+    }
+
+    /// DMA read of `buffer.len()` bytes.
+    pub async fn read_dma(&mut self, channel: &mut DmaChannel<'_, Async>, buffer: &mut [u8]) -> Result<(), Error> {
+        if buffer.is_empty() {
+            return Ok(());
+        }
+        let regs = self.regs();
+        let src = regs.dr().as_ptr();
+        set_dma_req(regs, false, true);
+        compiler_fence(Ordering::SeqCst);
+        let result = unsafe {
+            channel
+                .read(src.cast::<u8>(), buffer, self.info.dma_rx, TransferOptions::default())
+                .map_err(Error::Dma)?
+                .await
+                .map_err(Error::Dma)
+        };
+        set_dma_req(regs, false, false);
+        result
+    }
+}
+
+impl<'d, M: Mode> Drop for UartTx<'d, M> {
+    fn drop(&mut self) {
+        if self.info.state.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
+            shutdown(self.info);
+        }
+    }
+}
+
+impl<'d, M: Mode> Drop for UartRx<'d, M> {
+    fn drop(&mut self) {
+        if self.info.state.refcount.fetch_sub(1, Ordering::AcqRel) == 1 {
+            shutdown(self.info);
+        }
+    }
+}
+
+// --- embedded-io -----------------------------------------------------------
+
+impl<'d, M: Mode> embedded_io::ErrorType for Uart<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_io::ErrorType for UartTx<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_io::ErrorType for UartRx<'d, M> {
+    type Error = Error;
+}
+
+impl<'d, M: Mode> embedded_io::Write for UartTx<'d, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.blocking_write(buf)?;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.blocking_flush()
+    }
+}
+
+impl<'d, M: Mode> embedded_io::Write for Uart<'d, M> {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.tx.write(buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        self.tx.flush()
+    }
+}
+
+impl<'d, M: Mode> embedded_io::Read for UartRx<'d, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        // Block for the first byte, then drain the FIFO without further waits.
+        while flag(self.regs(), FLAG_RXFE) {}
+        let mut n = 0;
+        while n < buf.len() {
+            match self.nb_read_byte()? {
+                Some(b) => {
+                    buf[n] = b;
+                    n += 1;
+                }
+                None => break,
+            }
+        }
+        Ok(n)
+    }
+}
+
+impl<'d, M: Mode> embedded_io::Read for Uart<'d, M> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.rx.read(buf)
+    }
+}
+
+impl<'d> embedded_io_async::Write for UartTx<'d, Async> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        UartTx::write(self, buf).await?;
+        Ok(buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        UartTx::flush(self).await
+    }
+}
+
+impl<'d> embedded_io_async::Write for Uart<'d, Async> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        Uart::write(self, buf).await?;
+        Ok(buf.len())
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Uart::flush(self).await
+    }
+}
+
+impl<'d> embedded_io_async::Read for UartRx<'d, Async> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+        self.wait_rx_ready().await;
+        let mut n = 0;
+        while n < buf.len() {
+            match self.nb_read_byte()? {
+                Some(b) => {
+                    buf[n] = b;
+                    n += 1;
+                }
+                None => break,
+            }
+        }
+        Ok(n)
+    }
+}
+
+impl<'d> embedded_io_async::Read for Uart<'d, Async> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        embedded_io_async::Read::read(&mut self.rx, buf).await
+    }
+}
+
+// --- Instance --------------------------------------------------------------
+
+mod sealed {
+    use super::Info;
+
+    pub trait Instance {
+        fn info() -> &'static Info;
+    }
+}
+
+/// UART instance (UART0–UART3).
+#[allow(private_bounds)]
+pub trait Instance: sealed::Instance + PeripheralType + 'static {
+    /// NVIC vector for this UART.
+    type Interrupt: Interrupt;
+}
+
+macro_rules! impl_uart {
+    ($peri:ident, $interrupt:ident, $index:expr, $base:expr, $rcc:ident, $pclk0:expr, $dma_tx:ident, $dma_rx:ident) => {
+        impl sealed::Instance for peripherals::$peri {
+            fn info() -> &'static Info {
+                static INFO: Info = Info {
+                    index: $index,
+                    base: $base,
+                    rcc: Peripheral::$rcc,
+                    pclk0: $pclk0,
+                    dma_tx: Request::$dma_tx,
+                    dma_rx: Request::$dma_rx,
+                    state: &STATE[$index],
+                };
+                &INFO
+            }
+        }
+
+        impl Instance for peripherals::$peri {
+            type Interrupt = interrupt::typelevel::$interrupt;
+        }
+    };
+}
+
+impl_uart!(UART0, UART0, 0, 0x4000_3000, Uart0, true, Uart0Tx, Uart0Rx);
+impl_uart!(UART1, UART1, 1, 0x4000_4000, Uart1, true, Uart1Tx, Uart1Rx);
+impl_uart!(UART2, UART2, 2, 0x4001_0000, Uart2, false, Uart2Tx, Uart2Rx);
+impl_uart!(UART3, UART3, 3, 0x4001_1000, Uart3, false, Uart3Tx, Uart3Rx);

--- a/embassy-asr/src/wdg.rs
+++ b/embassy-asr/src/wdg.rs
@@ -1,0 +1,100 @@
+//! Window / system watchdog (ARM SP805-style WDG block).
+//!
+//! Register programming follows the vendor `tremo_wdg` driver.
+
+use crate::rcc::{self, Peripheral};
+use crate::{Peri, pac, peripherals};
+
+const LOCK_TOKEN: u32 = 0x1acc_e551;
+const CONTROL_RESEN: u32 = 1 << 1;
+const CONTROL_INTEN: u32 = 1 << 0;
+const RCC_RST_CR_WDG_RESET_REQ_EN: u32 = 1 << 4;
+
+/// Owned system watchdog.
+pub struct Watchdog<'d> {
+    _peri: Peri<'d, peripherals::WDG>,
+}
+
+impl<'d> Watchdog<'d> {
+    /// Enable the WDG clocks and leave the watchdog stopped.
+    pub fn new(peri: Peri<'d, peripherals::WDG>) -> Self {
+        let _ = rcc::enable_peripheral(Peripheral::Wdg);
+        Self { _peri: peri }
+    }
+
+    /// Start the watchdog with the given reload value.
+    ///
+    /// Per the vendor driver, the first timeout asserts the WDG interrupt and
+    /// reloads the counter; a second timeout without a feed resets the system.
+    pub fn start(&self, reload_value: u32) {
+        unlock();
+        let regs = Self::regs();
+        unsafe {
+            regs.load().write_with_zero(|w| w.bits(reload_value));
+            regs.control()
+                .write_with_zero(|w| w.bits(CONTROL_RESEN | CONTROL_INTEN));
+        }
+        lock();
+
+        critical_section::with(|_| {
+            let rcc = unsafe { pac::Rcc::steal() };
+            rcc.rst_cr()
+                .modify(|r, w| unsafe { w.bits(r.bits() | RCC_RST_CR_WDG_RESET_REQ_EN) });
+        });
+    }
+
+    /// Feed the watchdog and clear its interrupt.
+    pub fn pet(&self) {
+        unlock();
+        unsafe {
+            Self::regs().intclr().write_with_zero(|w| w.bits(1));
+        }
+        lock();
+    }
+
+    /// Stop the watchdog and disable its reset request.
+    pub fn stop(&self) {
+        critical_section::with(|_| {
+            let rcc = unsafe { pac::Rcc::steal() };
+            rcc.rst_cr()
+                .modify(|r, w| unsafe { w.bits(r.bits() & !RCC_RST_CR_WDG_RESET_REQ_EN) });
+        });
+
+        unlock();
+        let regs = Self::regs();
+        unsafe {
+            regs.control().write_with_zero(|w| w.bits(0));
+            regs.load().write_with_zero(|w| w.bits(0xffff_ffff));
+        }
+        lock();
+    }
+
+    /// Current down-counter value.
+    pub fn value(&self) -> u32 {
+        Self::regs().value().read().bits()
+    }
+
+    #[inline]
+    fn regs() -> pac::Wdg {
+        unsafe { pac::Wdg::steal() }
+    }
+}
+
+fn unlock() {
+    unsafe {
+        Watchdog::regs().lock().write_with_zero(|w| w.bits(LOCK_TOKEN));
+    }
+}
+
+fn lock() {
+    unsafe {
+        Watchdog::regs().lock().write_with_zero(|w| w.bits(!LOCK_TOKEN));
+    }
+}
+
+impl Drop for Watchdog<'_> {
+    fn drop(&mut self) {
+        self.stop();
+        let _ = rcc::disable_peripheral(Peripheral::Wdg);
+    }
+}

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -202,9 +202,6 @@ metadata-name = ["embassy-executor-macros/metadata-name"]
 
 ## Enable the thread-mode executor (using WFE/SEV in Cortex-M, WFI in other embedded platforms)
 executor-thread = []
-## Keep the Cortex-M thread executor awake while halting debug is enabled.
-## This permits RTT on targets which make their debug memory bus inaccessible in WFE.
-executor-thread-debug-spin = []
 ## Enable the interrupt-mode executor (available in Cortex-M only)
 executor-interrupt = []
 ## Enable tracing hooks

--- a/embassy-executor/Cargo.toml
+++ b/embassy-executor/Cargo.toml
@@ -202,6 +202,9 @@ metadata-name = ["embassy-executor-macros/metadata-name"]
 
 ## Enable the thread-mode executor (using WFE/SEV in Cortex-M, WFI in other embedded platforms)
 executor-thread = []
+## Keep the Cortex-M thread executor awake while halting debug is enabled.
+## This permits RTT on targets which make their debug memory bus inaccessible in WFE.
+executor-thread-debug-spin = []
 ## Enable the interrupt-mode executor (available in Cortex-M only)
 executor-interrupt = []
 ## Enable tracing hooks

--- a/embassy-executor/src/platform/cortex_m.rs
+++ b/embassy-executor/src/platform/cortex_m.rs
@@ -103,21 +103,6 @@ mod thread {
             loop {
                 unsafe {
                     self.inner.poll();
-
-                    #[cfg(feature = "executor-thread-debug-spin")]
-                    {
-                        // Some targets gate the AHB debug path in WFE even
-                        // though halting debug is enabled. Stay awake only
-                        // while a debugger has C_DEBUGEN asserted.
-                        const DHCSR: *const u32 = 0xe000_edf0 as *const u32;
-                        if core::ptr::read_volatile(DHCSR) & 1 != 0 {
-                            core::hint::spin_loop();
-                        } else {
-                            asm!("wfe");
-                        }
-                    }
-
-                    #[cfg(not(feature = "executor-thread-debug-spin"))]
                     asm!("wfe");
                 };
             }

--- a/embassy-executor/src/platform/cortex_m.rs
+++ b/embassy-executor/src/platform/cortex_m.rs
@@ -103,6 +103,21 @@ mod thread {
             loop {
                 unsafe {
                     self.inner.poll();
+
+                    #[cfg(feature = "executor-thread-debug-spin")]
+                    {
+                        // Some targets gate the AHB debug path in WFE even
+                        // though halting debug is enabled. Stay awake only
+                        // while a debugger has C_DEBUGEN asserted.
+                        const DHCSR: *const u32 = 0xe000_edf0 as *const u32;
+                        if core::ptr::read_volatile(DHCSR) & 1 != 0 {
+                            core::hint::spin_loop();
+                        } else {
+                            asm!("wfe");
+                        }
+                    }
+
+                    #[cfg(not(feature = "executor-thread-debug-spin"))]
                     asm!("wfe");
                 };
             }


### PR DESCRIPTION
Hello,
I'm having the misfortune of having to work in with this somewhat obscure Arm China STAR-MC1 (similar to cortex m4) mcu, with an integrated SX1262 LoRa radio.

This patch adds support for this mcu to embassy. It has been tested to work in its basic features and even running the lora-rs stack for LoRaWAN.

As you can probably guess, most of the driver code here has been generated by an LLM spinning on the official C sdk. I plan to do a major cleanup and testing campaign before considering it ready



