### PR TITLE
stm32/spi: Disable the SPI peripheral before the ringbuffer is started

### DIFF
--- a/embassy-stm32/src/spi/ringbuffered.rs
+++ b/embassy-stm32/src/spi/ringbuffered.rs
@@ -84,6 +84,10 @@ impl<'d> Spi<'d, Async, Slave> {
     ) -> RingBufferedSpiRx<'d, W> {
         assert!(!dma_buf.is_empty() && dma_buf.len() <= 0xFFFF);
 
+        self.info.regs.cr1().modify(|w| {
+            w.set_spe(false);
+        });
+
         self.set_word_size(W::CONFIG);
 
         let opts = Default::default();


### PR DESCRIPTION
This resolves a "permanent" (at least embassy doesn't recover it) DMA failure when the SPI peripheral reads data _before_ the DMA / ringbuf is enabled.