### PR TITLE
Fix i2c slave blocking nvic hang

### DIFF
--- a/embassy-stm32/src/i2c/mod.rs
+++ b/embassy-stm32/src/i2c/mod.rs
@@ -156,6 +156,9 @@ impl<'d> I2c<'d, Async, Master> {
         + 'd,
         config: Config,
     ) -> Self {
+        unsafe { T::EventInterrupt::enable() };
+        unsafe { T::ErrorInterrupt::enable() };
+
         Self::new_inner(
             peri,
             new_pin!(scl, config.scl_af()),
@@ -176,6 +179,9 @@ impl<'d> I2c<'d, Async, Master> {
         + 'd,
         config: Config,
     ) -> Self {
+        unsafe { T::EventInterrupt::enable() };
+        unsafe { T::ErrorInterrupt::enable() };
+
         Self::new_inner(
             peri,
             new_pin!(scl, config.scl_af()),
@@ -189,6 +195,11 @@ impl<'d> I2c<'d, Async, Master> {
 
 impl<'d> I2c<'d, Blocking, Master> {
     /// Create a new blocking I2C driver.
+    ///
+    /// This doesn't unmask the event/error NVIC lines since no handler is bound here.
+    /// But they're still the I2C peripheral's lines - slave methods like blocking_listen
+    /// set interrupt-enable bits directly in the peripheral registers, so don't reuse
+    /// this vector for anything else (RTIC dispatch, etc). It's not free, just unmanaged.
     pub fn new_blocking<T: Instance, #[cfg(afio)] A>(
         peri: Peri<'d, T>,
         scl: Peri<'d, if_afio!(impl SclPin<T, A>)>,
@@ -216,9 +227,6 @@ impl<'d, M: Mode> I2c<'d, M, Master> {
         rx_dma: Option<ChannelAndRequest<'d>>,
         config: Config,
     ) -> Self {
-        unsafe { T::EventInterrupt::enable() };
-        unsafe { T::ErrorInterrupt::enable() };
-
         let mut this = Self {
             info: T::info(),
             state: T::state(),

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -10,6 +10,7 @@ use mode::{Master, MultiMaster};
 use stm32_metapac::i2c::vals::{Addmode, Oamsk};
 
 use super::*;
+use crate::atomic::AtomicModify;
 use crate::pac::i2c;
 
 /// Bytes a slave transmits when it is read but has nothing to send.
@@ -1877,7 +1878,7 @@ impl<'d, M: Mode> I2c<'d, M, MultiMaster> {
     pub fn blocking_listen(&mut self) -> Result<SlaveCommand, Error> {
         let timeout = self.timeout();
 
-        self.info.regs.cr1().modify(|reg| {
+        self.info.regs.cr1().set_bits(|reg| {
             reg.set_addrie(true);
             trace!("Enable ADDRIE");
         });
@@ -1967,7 +1968,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     pub async fn listen(&mut self) -> Result<SlaveCommand, Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
         let state = self.state;
-        self.info.regs.cr1().modify(|reg| {
+        self.info.regs.cr1().set_bits(|reg| {
             reg.set_addrie(true);
             trace!("Enable ADDRIE");
         });


### PR DESCRIPTION
Fixes: https://github.com/embassy-rs/embassy/issues/6674#issuecomment-5182959638

Nnew_inner() was always turning on the I2C event/error NVIC interrupts, even for new_blocking(), which never binds a handler. @jasuse found that this breaks the i2c slave mode and that blocking_listen() just polls the ADDR flag directly and doesn't necessarily require interrupt. But, since the ADDR is left uncleared after a match, a real address match goes straight into the unbound default handler and it doesn't come back at all. 

So, to fix this - I did the following: 

- I moved the enable() call into new()/ new_no_dma() only since those are the only constructors which actually bind a handler. new_blocking() doesn't touch those NVIC lines.
- Found one more small thing while I was working on it which I fixed as well. blocking_listen() and listen() set ADDRIE without any critical section but the interrupt handler clears it inside one. So, I wrapped both in critical_section to close that race too.
- Also added docs comment on new_blocking() saying that the interrupt line still belongs to I2c and shouldn't be reused for anything else

