### PR TITLE
Updated stm32 PAC

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.3"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-3cab0b87f8195f13acae6282236a8ff042d68309" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-87c539515764df442bc50b6235bad891950ba3c4" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-3cab0b87f8195f13acae6282236a8ff042d68309" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-87c539515764df442bc50b6235bad891950ba3c4" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.107"
 quote = "1.0.47"

--- a/embassy-stm32/src/comp.rs
+++ b/embassy-stm32/src/comp.rs
@@ -402,7 +402,13 @@ impl<'d, T: Instance> Comp<'d, T> {
 
         #[cfg(any(comp_u5, comp_v1))]
         let winout = match config.window_output {
+            #[cfg(comp_u5)]
+            WindowOutput::OwnValue => vals::WindowOut::Comp1value,
+            #[cfg(comp_u5)]
+            WindowOutput::XorValue => vals::WindowOut::Comp1xorComp2value,
+            #[cfg(comp_v1)]
             WindowOutput::OwnValue => vals::WindowOut::Comp1Value,
+            #[cfg(comp_v1)]
             WindowOutput::XorValue => vals::WindowOut::Comp1ValueXorComp2Value,
         };
 

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -831,11 +831,7 @@ fn init_hw(config: Config) -> Peripherals {
         {
             use crate::pac::pwr::vals;
             crate::pac::PWR.svmcr().modify(|w| {
-                w.set_io2sv(if config.enable_independent_io_supply {
-                    vals::Io2sv::B0x1
-                } else {
-                    vals::Io2sv::B0x0
-                });
+                w.set_io2sv(config.enable_independent_io_supply);
             });
 
             // Ultra-low-power BOR0 mode for lowest Stop 1 / Standby consumption.
@@ -898,14 +894,14 @@ fn init_hw(config: Config) -> Peripherals {
                     vals::Icrampds::Retained
                 });
                 w.set_prampds(if sram.otg_sram {
-                    vals::Prampds::B0x1
+                    vals::Srampds::PoweredOff
                 } else {
-                    vals::Prampds::B0x0
+                    vals::Srampds::PoweredOn
                 });
                 w.set_pkarampds(if sram.pka_sram {
-                    vals::Pkarampds::B0x1
+                    vals::Srampds::PoweredOff
                 } else {
-                    vals::Pkarampds::B0x0
+                    vals::Srampds::PoweredOn
                 });
             });
         }

--- a/embassy-stm32/src/usb/mod.rs
+++ b/embassy-stm32/src/usb/mod.rs
@@ -107,7 +107,7 @@ fn common_init<T: Instance>() {
         // Enable USB power
         critical_section::with(|_| {
             crate::pac::PWR.svmcr().modify(|w| {
-                w.set_usv(crate::pac::pwr::vals::Usv::B0x1);
+                w.set_usv(true);
             });
             crate::pac::PWR.vosr().modify(|w| {
                 w.set_vdd11usbdis(false);


### PR DESCRIPTION
Some changes on the comparators, and removal of some `B_0x1/B_0x0` enums. STOP2 mode register definition for WBA is now fixed.