### PR TITLE
ambiq: Implement IOM and I2C Master driver

### DIFF
--- a/embassy-ambiq/src/gpio.rs
+++ b/embassy-ambiq/src/gpio.rs
@@ -40,6 +40,9 @@ pub(crate) trait SealedConfigure {
     /// Write the 3-bit function-select field for this pad.
     fn set_fncsel_bits(&self, sel: u8);
 
+    /// Configure the pad specifically for I2C (sets fncsel, inpen, and pullup)
+    fn configure_i2c_pad(&self, sel: u8);
+
     /// Configure the pad as an input with the given pull configuration.
     fn configure_as_input(&self, pull: Pull);
 
@@ -105,6 +108,18 @@ macro_rules! pins {
                         with_padkey(|| {
                             gpio.$padreg().modify(|w| {
                                 w.[<set_pad $n fncsel>](pac::gpio::vals::[<Pad $n fncsel>]::from_bits(sel))
+                            });
+                        });
+                    }
+
+                    #[inline(always)]
+                    fn configure_i2c_pad(&self, sel: u8) {
+                        let gpio = pac::GPIO;
+                        with_padkey(|| {
+                            gpio.$padreg().modify(|w| {
+                                w.[<set_pad $n fncsel>](pac::gpio::vals::[<Pad $n fncsel>]::from_bits(sel));
+                                w.[<set_pad $n inpen>](true);
+                                w.[<set_pad $n pull>](true);
                             });
                         });
                     }

--- a/embassy-ambiq/src/i2c.rs
+++ b/embassy-ambiq/src/i2c.rs
@@ -1,0 +1,333 @@
+//! I2C driver
+
+use embassy_hal_internal::Peri;
+
+use crate::gpio::SealedConfigure;
+use crate::iom::{Instance, Iom};
+use crate::pac;
+
+// I2C Pin Marker Traits
+#[allow(private_bounds)]
+pub trait SdaPin<T: Instance>: crate::gpio::Pin + SealedConfigure {
+    const FNCSEL: u8;
+}
+#[allow(private_bounds)]
+pub trait SclPin<T: Instance>: crate::gpio::Pin + SealedConfigure {
+    const FNCSEL: u8;
+}
+
+macro_rules! impl_i2c_pin {
+    ($pin:ident, $iom:ident, $fncsel:expr, $trait:ident) => {
+        impl $trait<crate::peripherals::$iom> for crate::peripherals::$pin {
+            const FNCSEL: u8 = $fncsel;
+        }
+    };
+}
+
+// IOM0
+impl_i2c_pin!(P5, IOM0, 0, SclPin);
+impl_i2c_pin!(P6, IOM0, 0, SdaPin);
+
+// IOM1
+impl_i2c_pin!(P8, IOM1, 0, SclPin);
+impl_i2c_pin!(P9, IOM1, 0, SdaPin);
+
+// IOM2
+impl_i2c_pin!(P27, IOM2, 4, SclPin);
+impl_i2c_pin!(P25, IOM2, 4, SdaPin);
+
+// IOM3
+impl_i2c_pin!(P42, IOM3, 4, SclPin);
+impl_i2c_pin!(P43, IOM3, 4, SdaPin);
+
+// IOM4
+impl_i2c_pin!(P39, IOM4, 4, SclPin);
+impl_i2c_pin!(P40, IOM4, 4, SdaPin);
+
+// IOM5
+impl_i2c_pin!(P48, IOM5, 4, SclPin);
+impl_i2c_pin!(P49, IOM5, 4, SdaPin);
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Frequency {
+    Freq100kHz,
+    Freq400kHz,
+    Freq1MHz,
+}
+
+/// Configuration for the I2C driver
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct Config {
+    /// I2C operating frequency
+    pub frequency: Frequency,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            frequency: Frequency::Freq100kHz,
+        }
+    }
+}
+
+pub struct I2c<'d, T: Instance> {
+    _iom: Iom<'d, T>,
+}
+
+async fn wait_complete<T: Instance>() -> Result<(), Error> {
+    use pac::shared::Cmdstat;
+    let regs = T::regs();
+    let state = T::state();
+
+    core::future::poll_fn(|cx| {
+        state.waker.register(cx.waker());
+        let s = regs.cmdstat().read().cmdstat();
+        match s {
+            Cmdstat::Idle | Cmdstat::Err => {
+                regs.intclr().write(|w| w.set_cmdcmp(true));
+                core::task::Poll::Ready(())
+            }
+            _ => {
+                regs.inten().modify(|w| w.set_cmdcmp(true));
+                core::task::Poll::Pending
+            }
+        }
+    })
+    .await;
+
+    let intstat = regs.intstat().read();
+
+    // Clear errors so they don't persist to the next transaction
+    regs.intclr().write(|w| {
+        w.set_nak(true);
+        w.set_fovfl(true);
+        w.set_fundfl(true);
+        w.set_iacc(true);
+        w.set_icmd(true);
+    });
+
+    if intstat.nak() {
+        return Err(Error::NoAcknowledge);
+    }
+    if intstat.fovfl() {
+        return Err(Error::Overflow);
+    }
+    if intstat.fundfl() {
+        return Err(Error::Underflow);
+    }
+    if intstat.iacc() {
+        return Err(Error::IllegalAccess);
+    }
+    if intstat.icmd() {
+        return Err(Error::IllegalCommand);
+    }
+
+    Ok(())
+}
+
+impl<'d, T: Instance> I2c<'d, T> {
+    pub fn new<Scl: SclPin<T>, Sda: SdaPin<T>>(
+        peri: Peri<'d, T>,
+        scl: Peri<'d, Scl>,
+        sda: Peri<'d, Sda>,
+        _config: Config,
+    ) -> Self {
+        // Configure pins for I2C (pullups + input enable + fncsel)
+        scl.configure_i2c_pad(Scl::FNCSEL);
+        sda.configure_i2c_pad(Sda::FNCSEL);
+
+        let iom = Iom::new(peri);
+        let regs = T::regs();
+
+        // Disable IOM first
+        regs.submodctrl().write(|w| {
+            w.set_smod0en(false);
+            w.set_smod1en(false);
+        });
+
+        // Set frequency (Simplified)
+        // HFRC 48MHz / 8 = 6MHz source. The IOM divider produces an SCL period of
+        // 2*(TOTPER+1) source clocks, so TOTPER+1 = 30 -> 6MHz/60 = 100kHz.
+        // LOWPER+1 = 15 -> ~50% duty.
+        regs.clkcfg().write(|w| {
+            w.set_ioclken(true);
+            w.set_diven(true);
+            w.set_fsel(pac::shared::Fsel::HfrcDiv8); // 48MHz / 8 = 6MHz
+            w.set_totper(29); // SCL = 6MHz / (2*30) = 100kHz
+            w.set_lowper(14); // ~50% duty
+        });
+
+        // Enable IOM (I2C Master is smod1)
+        regs.submodctrl().modify(|w| w.set_smod1en(true));
+
+        Self { _iom: iom }
+    }
+}
+
+impl<'d, T: Instance> embedded_hal_async::i2c::I2c for I2c<'d, T> {
+    async fn read(&mut self, address: u8, read: &mut [u8]) -> Result<(), Self::Error> {
+        let regs = T::regs();
+        regs.devcfg().write(|w| w.set_devaddr(address as u16));
+
+        let mut offset = 0;
+        while offset < read.len() {
+            let chunk_size = core::cmp::min(read.len() - offset, 32);
+            let is_last = offset + chunk_size == read.len();
+
+            regs.cmd().write(|w| {
+                w.set_cmd(pac::iom0::vals::Cmd::Read);
+                w.set_tsize(chunk_size as u16);
+                w.set_cont(!is_last);
+            });
+
+            wait_complete::<T>().await?;
+
+            for chunk_words in read[offset..offset + chunk_size].chunks_mut(4) {
+                let word = regs.fifopop().read();
+                for (i, b) in chunk_words.iter_mut().enumerate() {
+                    *b = (word >> (i * 8)) as u8;
+                }
+            }
+
+            offset += chunk_size;
+        }
+
+        Ok(())
+    }
+
+    async fn write(&mut self, address: u8, write: &[u8]) -> Result<(), Self::Error> {
+        let regs = T::regs();
+        regs.devcfg().write(|w| w.set_devaddr(address as u16));
+
+        if write.is_empty() {
+            // Handle empty write (e.g. for bus scanning)
+            regs.cmd().write(|w| {
+                w.set_cmd(pac::iom0::vals::Cmd::Write);
+                w.set_tsize(0);
+                w.set_cont(false);
+            });
+            wait_complete::<T>().await?;
+            return Ok(());
+        }
+
+        let mut offset = 0;
+        while offset < write.len() {
+            let chunk_size = core::cmp::min(write.len() - offset, 32);
+            let chunk = &write[offset..offset + chunk_size];
+
+            for chunk_words in chunk.chunks(4) {
+                let mut word: u32 = 0;
+                for (i, &b) in chunk_words.iter().enumerate() {
+                    word |= (b as u32) << (i * 8);
+                }
+                regs.fifopush().write_value(word);
+            }
+
+            let is_last = offset + chunk_size == write.len();
+
+            regs.cmd().write(|w| {
+                w.set_cmd(pac::iom0::vals::Cmd::Write);
+                w.set_tsize(chunk_size as u16);
+                w.set_cont(!is_last);
+            });
+
+            wait_complete::<T>().await?;
+
+            offset += chunk_size;
+        }
+
+        Ok(())
+    }
+
+    async fn write_read(&mut self, address: u8, write: &[u8], read: &mut [u8]) -> Result<(), Self::Error> {
+        let regs = T::regs();
+        regs.devcfg().write(|w| w.set_devaddr(address as u16));
+
+        // Write Phase (cont = true so we issue a repeated START before the read)
+        let mut offset = 0;
+        while offset < write.len() {
+            let chunk_size = core::cmp::min(write.len() - offset, 32);
+            let chunk = &write[offset..offset + chunk_size];
+
+            for chunk_words in chunk.chunks(4) {
+                let mut word: u32 = 0;
+                for (i, &b) in chunk_words.iter().enumerate() {
+                    word |= (b as u32) << (i * 8);
+                }
+                regs.fifopush().write_value(word);
+            }
+
+            regs.cmd().write(|w| {
+                w.set_cmd(pac::iom0::vals::Cmd::Write);
+                w.set_tsize(chunk_size as u16);
+                w.set_cont(true);
+            });
+
+            wait_complete::<T>().await?;
+
+            offset += chunk_size;
+        }
+
+        // Read Phase
+        offset = 0;
+        while offset < read.len() {
+            let chunk_size = core::cmp::min(read.len() - offset, 32);
+            let is_last = offset + chunk_size == read.len();
+
+            regs.cmd().write(|w| {
+                w.set_cmd(pac::iom0::vals::Cmd::Read);
+                w.set_tsize(chunk_size as u16);
+                w.set_cont(!is_last);
+            });
+
+            wait_complete::<T>().await?;
+
+            for chunk_words in read[offset..offset + chunk_size].chunks_mut(4) {
+                let word = regs.fifopop().read();
+                for (i, b) in chunk_words.iter_mut().enumerate() {
+                    *b = (word >> (i * 8)) as u8;
+                }
+            }
+
+            offset += chunk_size;
+        }
+
+        Ok(())
+    }
+
+    async fn transaction(
+        &mut self,
+        _address: u8,
+        _operations: &mut [embedded_hal_async::i2c::Operation<'_>],
+    ) -> Result<(), Self::Error> {
+        // Not implemented for now
+        unimplemented!()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Error {
+    NoAcknowledge,
+    Overflow,
+    Underflow,
+    IllegalAccess,
+    IllegalCommand,
+    ArbitrationLoss,
+    BusError,
+}
+
+impl embedded_hal_async::i2c::Error for Error {
+    fn kind(&self) -> embedded_hal_async::i2c::ErrorKind {
+        use embedded_hal_async::i2c::ErrorKind;
+        match self {
+            Error::NoAcknowledge => ErrorKind::NoAcknowledge(embedded_hal_async::i2c::NoAcknowledgeSource::Unknown),
+            Error::Overflow | Error::Underflow | Error::IllegalAccess => ErrorKind::Overrun,
+            Error::ArbitrationLoss => ErrorKind::ArbitrationLoss,
+            Error::BusError | Error::IllegalCommand => ErrorKind::Other,
+        }
+    }
+}
+
+impl<'d, T: Instance> embedded_hal_async::i2c::ErrorType for I2c<'d, T> {
+    type Error = Error;
+}

--- a/embassy-ambiq/src/iom.rs
+++ b/embassy-ambiq/src/iom.rs
@@ -1,0 +1,86 @@
+//! IOM (IO Master) peripheral driver
+
+use apollo3_pac::interrupt;
+use embassy_hal_internal::{Peri, PeripheralType};
+use embassy_sync::waitqueue::AtomicWaker;
+
+use crate::pac;
+
+pub struct State {
+    pub waker: AtomicWaker,
+}
+
+impl State {
+    pub const fn new() -> Self {
+        Self {
+            waker: AtomicWaker::new(),
+        }
+    }
+}
+
+pub trait Instance: PeripheralType + 'static + Send {
+    fn regs() -> pac::iom0::Iom0;
+    fn state() -> &'static State;
+    fn enable_power();
+    fn enable_interrupts();
+    fn disable_interrupts();
+}
+
+macro_rules! impl_iom {
+    ($inst:ident, $pac_inst:ident, $state:ident, $pwr:ident, $pwrstat:ident, $irq:ident) => {
+        static $state: State = State::new();
+        impl Instance for crate::peripherals::$inst {
+            fn regs() -> pac::iom0::Iom0 {
+                pac::$pac_inst
+            }
+            fn state() -> &'static State {
+                &$state
+            }
+            fn enable_power() {
+                pac::PWRCTRL.devpwren().modify(|w| w.$pwr(true));
+                // Wait for the correct power domain to come up.
+                // HCPB powers IOM0/1/2; HCPC powers IOM3/4/5. (HCPA is UART/IOSLAVE.)
+                while !pac::PWRCTRL.devpwrstatus().read().$pwrstat() {}
+            }
+            fn enable_interrupts() {
+                unsafe { cortex_m::peripheral::NVIC::unmask(pac::Interrupt::$irq) };
+            }
+            fn disable_interrupts() {
+                cortex_m::peripheral::NVIC::mask(pac::Interrupt::$irq);
+            }
+        }
+
+        #[pac::interrupt]
+        fn $irq() {
+            let regs = <crate::peripherals::$inst as Instance>::regs();
+            let state = <crate::peripherals::$inst as Instance>::state();
+
+            let intstat = regs.intstat().read();
+            if intstat.cmdcmp() {
+                regs.intclr().write(|w| w.set_cmdcmp(true));
+                regs.inten().modify(|w| w.set_cmdcmp(false)); // Disable until next wait
+                state.waker.wake();
+            }
+        }
+    };
+}
+
+impl_iom!(IOM0, IOM0, IOM0_STATE, set_pwriom0, hcpb, IOMSTR0);
+impl_iom!(IOM1, IOM1, IOM1_STATE, set_pwriom1, hcpb, IOMSTR1);
+impl_iom!(IOM2, IOM2, IOM2_STATE, set_pwriom2, hcpb, IOMSTR2);
+impl_iom!(IOM3, IOM3, IOM3_STATE, set_pwriom3, hcpc, IOMSTR3);
+impl_iom!(IOM4, IOM4, IOM4_STATE, set_pwriom4, hcpc, IOMSTR4);
+impl_iom!(IOM5, IOM5, IOM5_STATE, set_pwriom5, hcpc, IOMSTR5);
+
+pub struct Iom<'d, T: Instance> {
+    #[allow(dead_code)]
+    peri: Peri<'d, T>,
+}
+
+impl<'d, T: Instance> Iom<'d, T> {
+    pub fn new(peri: Peri<'d, T>) -> Self {
+        T::enable_power();
+        T::enable_interrupts();
+        Self { peri }
+    }
+}

--- a/embassy-ambiq/src/lib.rs
+++ b/embassy-ambiq/src/lib.rs
@@ -4,6 +4,8 @@
 pub use apollo3_pac as pac;
 
 pub mod gpio;
+pub mod i2c;
+pub mod iom;
 #[cfg(any(feature = "_stimer", feature = "time-driver-ctimer0"))]
 pub mod time_driver;
 
@@ -13,6 +15,7 @@ embassy_hal_internal::peripherals! {
     P20, P21, P22, P23, P24, P25, P26, P27, P28, P29,
     P30, P31, P32, P33, P34, P35, P36, P37, P38, P39,
     P40, P41, P42, P43, P44, P45, P46, P47, P48, P49,
+    IOM0, IOM1, IOM2, IOM3, IOM4, IOM5,
 }
 
 pub fn init() -> Peripherals {
@@ -33,9 +36,6 @@ pub fn init() -> Peripherals {
             // We do this before setting up any interrupts.
             scb.vtor.write(0x0001_0000);
         }
-
-        // Enable the global GPIO interrupt. Individual pins configure their own routing.
-        cortex_m::peripheral::NVIC::unmask(pac::Interrupt::GPIO);
     }
 
     p

--- a/examples/ambiq/sparkfun-artemis/Cargo.toml
+++ b/examples/ambiq/sparkfun-artemis/Cargo.toml
@@ -19,3 +19,4 @@ embassy-executor = { version = "0.10.0", path = "../../../embassy-executor", fea
 embassy-time = { version = "0.5.1", path = "../../../embassy-time" }
 embassy-ambiq = { path = "../../../embassy-ambiq", default-features = false, features = ["apollo3", "time-driver-stimer-xtal-32768", "svl-vtor"] }
 apollo3-pac = "0.2.0"
+embedded-hal-async = "1.0.0"

--- a/examples/ambiq/sparkfun-artemis/src/bin/i2c_test.rs
+++ b/examples/ambiq/sparkfun-artemis/src/bin/i2c_test.rs
@@ -1,0 +1,32 @@
+#![no_std]
+#![no_main]
+
+use embassy_ambiq::i2c::{Config, I2c};
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_halt as _;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_ambiq::init();
+
+    let config = Config::default();
+    let mut i2c = I2c::new(p.IOM4, p.P39, p.P40, config);
+
+    loop {
+        // Send a test packet to address 0x42
+        let data = [0xde, 0xad, 0xbe, 0xef];
+
+        match embedded_hal_async::i2c::I2c::write(&mut i2c, 0x42, &data).await {
+            Ok(_) => {
+                // Transaction successful (ACK received)
+            }
+            Err(_e) => {
+                // Transaction failed (e.g., NACK)
+                // In a real application we would handle the error here
+            }
+        }
+
+        Timer::after_millis(500).await;
+    }
+}


### PR DESCRIPTION
## What
Extends support for "embassy-ambiq", adding I2C support for the Ambiq Apollo 3, validated with the Sparkfun RedBoard Artemis and a Logic Analyzer

Implemented on this PR:
- IOM (IO Master) abstraction and power management
- I2C Master driver using the "Instance" trait pattern
- Asynchronous, interrupt-driven I2C transactions utilizing the "cmdcmp" hardware interrupt and "embassy-sync" "AtomicWaker"
- "i2c_test" example showing a simple I2C transaction