### PR TITLE
stm32/i2c: add wake from stop

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -213,11 +213,11 @@ heapless = "0.9.3"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-87c539515764df442bc50b6235bad891950ba3c4" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7a8bb7113f8548e09dca4ed214af3acb7925aa31" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-87c539515764df442bc50b6235bad891950ba3c4" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-7a8bb7113f8548e09dca4ed214af3acb7925aa31" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.107"
 quote = "1.0.47"

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -101,6 +101,10 @@ pub(crate) unsafe fn on_interrupt<T: Instance>() {
             // Error flags are to be read in the routines, so we also don't clear them here
             w.set_nackie(false);
             w.set_errie(false);
+
+            // WUPEN keep triggering ADDR interrupt, it seems to override ADDRIE
+            #[cfg(feature = "low-power")]
+            w.set_wupen(false);
         });
     });
 }
@@ -1977,6 +1981,39 @@ impl<'d> I2c<'d, Async, MultiMaster> {
                 trace!("ADDR triggered (address match)");
                 // we do not clear the address flag here as it will be cleared by the dma read/write
                 // if we clear it here the clock stretching will stop and the master will read in data before the slave is ready to send it
+                Poll::Ready(self.slave_command())
+            }
+        })
+        .await
+    }
+
+    /// Listen for incoming I2C messages in low power mode (STOP1 mode).
+    ///
+    /// The listen method is an asynchronous method but it does not require DMA to be asynchronous.
+    /// I2C clock should be set to appropriate clock so it can be awaken (e.g. HSI).
+    /// Some instances of I2C don't support this feature, refer to datasheet.
+    /// If unsupported instance is used, it will panic or never wake up.
+    #[cfg(feature = "low-power")]
+    pub async fn listen_low_power(&mut self) -> Result<SlaveCommand, Error> {
+        let state = self.state;
+        self.info.regs.cr1().modify(|reg| {
+            reg.set_wupen(true);
+            reg.set_addrie(true);
+            trace!("Enable WUPEN & ADDRIE");
+        });
+        debug_assert!(
+            // WUPEN of unsupported instance will read 0. or it was set to 0 by ISR.
+            self.info.regs.cr1().read().wupen() || self.info.regs.isr().read().addr(),
+            "this I2C instance does not support wakeup from Stop mode"
+        );
+
+        poll_fn(|cx| {
+            state.waker.register(cx.waker());
+            let isr = self.info.regs.isr().read();
+            if !isr.addr() {
+                Poll::Pending
+            } else {
+                trace!("ADDR triggered (address match)");
                 Poll::Ready(self.slave_command())
             }
         })

--- a/embassy-stm32/src/i2c/v2.rs
+++ b/embassy-stm32/src/i2c/v2.rs
@@ -1996,7 +1996,7 @@ impl<'d> I2c<'d, Async, MultiMaster> {
     #[cfg(feature = "low-power")]
     pub async fn listen_low_power(&mut self) -> Result<SlaveCommand, Error> {
         let state = self.state;
-        self.info.regs.cr1().modify(|reg| {
+        self.info.regs.cr1().set_bits(|reg| {
             reg.set_wupen(true);
             reg.set_addrie(true);
             trace!("Enable WUPEN & ADDRIE");

--- a/examples/stm32l0/src/bin/i2c_low_power.rs
+++ b/examples/stm32l0/src/bin/i2c_low_power.rs
@@ -1,0 +1,78 @@
+//! I2C slave wakeup-from-stop with the low-power executor.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, warn};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::i2c::{self, I2c, SendStatus, SlaveAddrConfig, SlaveCommandKind};
+use embassy_stm32::time::Hertz;
+use embassy_stm32::{self, bind_interrupts, dma, peripherals, rcc};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    I2C1 => i2c::EventInterruptHandler<peripherals::I2C1>, i2c::ErrorInterruptHandler<peripherals::I2C1>;
+    DMA1_CHANNEL2_3 => dma::InterruptHandler<peripherals::DMA1_CH2>, dma::InterruptHandler<peripherals::DMA1_CH3>;
+});
+
+#[embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init({
+        let mut cfg = embassy_stm32::Config::default();
+
+        // Use HSI
+        cfg.rcc = rcc::Config {
+            hsi: true,
+            msi: None,
+            sys: rcc::Sysclk::Hsi,
+            ..Default::default()
+        };
+
+        // I2C wakeup from Stop requires HSI16 as the I2C1 kernel clock.
+        cfg.rcc.mux.i2c1sel = rcc::mux::I2csel::Hsi;
+        cfg
+    });
+
+    // Wake from Stop defaults the system clock to MSI, change to HSI.
+    embassy_stm32::pac::RCC
+        .cfgr()
+        .modify(|w| w.set_stopwuck(embassy_stm32::pac::rcc::vals::Stopwuck::Hsi));
+
+    const I2C_ADDR: u8 = 0x20;
+
+    let mut i2c = {
+        let mut cfg = i2c::Config::default();
+        cfg.frequency = Hertz::khz(400);
+        I2c::new(p.I2C1, p.PB6, p.PB7, p.DMA1_CH2, p.DMA1_CH3, Irqs, cfg)
+            .into_slave_multimaster(SlaveAddrConfig::basic(I2C_ADDR))
+    };
+
+    let mut buffer = [0u8; 32];
+    let mut buffer_len = 0usize;
+
+    info!("i2c slave listening at address 0x{:02X}", I2C_ADDR);
+
+    loop {
+        // Change this to i2c.listen() to use SLEEP mode instead of STOP mode
+        match i2c.listen_low_power().await {
+            Ok(cmd) => match cmd.kind {
+                SlaveCommandKind::Write => match i2c.respond_to_write(&mut buffer).await {
+                    Ok(len) => {
+                        buffer_len = len;
+                        info!("i2c write: {} bytes: {:02X}", len, &buffer[..buffer_len]);
+                    }
+                    Err(e) => warn!("i2c write error: {:?}", e),
+                },
+                SlaveCommandKind::Read => match i2c.respond_to_read(&buffer[..buffer_len]).await {
+                    Ok(SendStatus::Done) => info!("i2c read: {} bytes", buffer_len),
+                    Ok(SendStatus::LeftoverBytes(n)) => {
+                        info!("i2c read: {} of {} bytes", buffer_len - n, buffer_len)
+                    }
+                    Err(e) => warn!("i2c read error: {:?}", e),
+                },
+            },
+            Err(e) => warn!("listen error: {:?}", e),
+        }
+    }
+}


### PR DESCRIPTION
Make STM32 I2C support STOP mode. Probably related to #4983.

The example has only been tested on the STM32L072.
Since I haven't seen much low-power API context here, I implemented this as a separate `listen_low_power()` function because it has minimal code size and runtime overhead.
This carries a safety risk if not used with appropriate clocking and the correct I2C instance, but I'm not sure how to cleanly prevent that.

Requires embassy-rs/stm32-data#892. I'm not sure how to make the CI use the new stm32-data.