### PR TITLE
build: fix formatting in xarxa dependency

### DIFF
--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -35,12 +35,7 @@ embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal" }
 embassy-net-driver-channel = { version = "0.4.0", path = "../embassy-net-driver-channel", optional=true}
 stm32-bindings = { version = "0.2.2", optional=true, default-features = false }
 
-xarxa = { 
-    git = "https://github.com/embassy-rs/xarxa",
-    rev = "1f332ac32cc33d86aefc8e1c1a9749b93234a6de",
-    optional = true,
-    default-features = false,
-}
+xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "1f332ac32cc33d86aefc8e1c1a9749b93234a6de", optional = true, default-features = false}
 
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.17", optional = true }


### PR DESCRIPTION
Without this change, his build error is thrown

```
error: newlines are unsupported in inline tables, expected nothing
  --> ../../open_source_projects/embassy-cesar/embassy-stm32-wpan/Cargo.toml:38:11
   |
38 |   xarxa = {
   |  __________^
39 | |     git = "https://github.com/embassy-rs/xarxa",
   | |^
error: failed to load manifest for workspace member /Users/ctamayo/Axon/cew/ion-c/lib/main_controller_application
referenced by workspace at /Users/ctamayo/Axon/cew/ion-c/Cargo.toml
Caused by:
  failed to load manifest for dependency embassy-stm32-wpan
```