### PR TITLE
stm32/rcc/l: set max flash latency before raising the MSI range

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -67,6 +67,7 @@ RCC:
 - feat: stm32/rcc/c0: add `Config::sys_div` to configure the SYSDIV divider on chips that have it (C051, C071, C091/C092). It was previously never programmed and not accounted for in the reported SYSCLK
 - change: stm32/rcc/c0: rename `Hsi::sys_div` to `Hsi::div` and `HsiSysDiv` to `HsiDiv` (breaking change). The field sets HSIDIV, not SYSDIV; the old name suggested otherwise
 - fix: stm32/rcc/c0: raise the flash read access latency before anything that can raise the core frequency, so a configuration handed over from a bootloader without a reset cannot run above 24 MHz with too few wait states
+- fix: stm32/rcc/l: set the maximum flash latency before raising the MSI range, so MSI above the reset wait-state limit (e.g. 48 MHz) as sysclk no longer hardfaults in `init()` on L4, L5, WB and U0 (extends the WL-only fix from #2786; L0/L1 are unaffected, their MSI tops out at 4.194 MHz)
 
 SPI:
 - change default NSS configuration from active-high to active-low

--- a/embassy-stm32/src/rcc/l.rs
+++ b/embassy-stm32/src/rcc/l.rs
@@ -188,10 +188,23 @@ pub(crate) unsafe fn init(config: Config) {
         while RCC.cfgr().read().sws() != Sysclk::Msi {}
     }
 
-    #[cfg(stm32wl)]
+    // Set the maximum flash wait states now: `config.msi` below may raise the
+    // MSI frequency (up to 48 MHz) while MSI is the active sysclk, before the
+    // computed latency is written. Raising latency is always safe; the exact
+    // value for the target clocks is set later. stm32l0/l1 are not affected:
+    // their MSI tops out at 4.194 MHz, within zero wait states at every
+    // voltage range.
+    #[cfg(any(stm32l4, stm32l5, stm32wb, stm32wl, stm32u0))]
     {
-        // Set max latency
-        FLASH.acr().modify(|w| w.set_latency(2));
+        #[cfg(any(stm32l4, stm32wb))]
+        const MAX_LATENCY: u8 = 4;
+        #[cfg(stm32l5)]
+        const MAX_LATENCY: u8 = 5;
+        #[cfg(any(stm32wl, stm32u0))]
+        const MAX_LATENCY: u8 = 2;
+
+        FLASH.acr().modify(|w| w.set_latency(MAX_LATENCY));
+        while FLASH.acr().read().latency() != MAX_LATENCY {}
     }
 
     // Set voltage scale


### PR DESCRIPTION
`rcc/l.rs` raises the MSI range while MSI is the active sysclk, but writes the computed flash latency only much later. So with a config like `msi = Range48m, sys = Msi`, the core briefly runs at 48 MHz from flash still at 0 wait states (only valid up to 16 MHz on L4), and it hardfaults inside `init()` before the latency write is ever reached. Repro on an STM32L476RG (0.6.0 and current main; the core locks up before the first defmt line):

```rust
let mut config = embassy_stm32::Config::default();
config.rcc.msi = Some(MSIRange::Range48m); // anything above 16 MHz
config.rcc.sys = Sysclk::Msi;
let p = embassy_stm32::init(config);
```

The default config (MSI 4 MHz) works, and getting 48 MHz from the PLL works; only "MSI above the reset wait-state limit as sysclk" falls in the gap, because the HSI/HSE/PLL paths keep the core on slow MSI until the final sysclk switch, which happens after the latency write.

#2786 fixed this for stm32wl only. This extends the same conservative pre-set to the other affected families in the file: l4, l5, wb, u0. The values are each family's maximum from the latency tables further down in `init()`; the exact latency for the configured clocks is still applied later as before (raising latency is always safe, lowering needs the final value). Unlike the original #2786 block this also waits for the latency readback, matching what the later write does.

l0/l1 are left out on purpose: their MSI tops out at 4.194 MHz, within 0 wait states at every voltage range, so they cannot reach the bug.

Validation:

- NUCLEO-L476RG (l4): MSI `Range48m` as sysclk locks up without this change, boots with it.
- NUCLEO-WL55JC (wl): regression control, still boots with MSI at 48 MHz.
- l5, wb, u0, l0, l1: `cargo check` per family (no hardware here for those; wb/u0 are the same ordering by inspection).
- Changelog entry added.
