### PR TITLE
embassy_net: Add config query functions for IPv4 and IPv6

### DIFF
--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wire types (`Ipv4Address`, `IpCidr`, ...) moved to `embassy_net::wire`.
 - Implement `core::error::Error` for `dns::Error`, `tcp::AcceptError`, `udp::SendError` and `udp::RecvError`.
 - Prevent double DHCP DISCOVER on link state change.
+- Add functions to query the configuration state of IPv4 and IPv6 separately.
 
 ## 0.9.1 - 2026-04-16
 

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -148,4 +148,4 @@ embedded-io-async = { version = "0.7.0" }
 
 heapless = { version = "0.9", default-features = false }
 embedded-nal-async = "0.9.0"
-document-features = "0.2.7"
+document-features = "0.2.12"

--- a/embassy-net/src/iface/mod.rs
+++ b/embassy-net/src/iface/mod.rs
@@ -278,6 +278,18 @@ impl<'d> Iface<'d> {
         self.with(|i| is_config_up(i))
     }
 
+    /// Check whether the network stack has a valid IPv4 configuration.
+    #[cfg(feature = "ipv4")]
+    pub fn is_config_v4_up(&self) -> bool {
+        self.with(|i| crate::is_config_v4_up(i))
+    }
+
+    /// Check whether the network stack has a valid non link-local IPv6 configuration.
+    #[cfg(feature = "ipv6")]
+    pub fn is_config_v6_up(&self) -> bool {
+        self.with(|i| crate::is_config_v6_up(i))
+    }
+
     /// Wait for the network device to obtain a link signal.
     pub async fn wait_link_up(&self) {
         wait_iface(self.stack, self.handle, is_link_up).await
@@ -296,5 +308,33 @@ impl<'d> Iface<'d> {
     /// Wait for the interface to lose a valid IP configuration.
     pub async fn wait_config_down(&self) {
         wait_iface(self.stack, self.handle, |i| !is_config_up(i)).await
+    }
+
+    /// Wait for the interface to obtain a valid IPv4 configuration.
+    #[cfg(feature = "ipv4")]
+    pub async fn wait_config_v4_up(&self) {
+        wait_iface(self.stack, self.handle, |i| crate::is_config_v4_up(i)).await
+    }
+
+    /// Wait for the interface to lose a valid IPv4 configuration.
+    #[cfg(feature = "ipv4")]
+    pub async fn wait_config_v4_down(&self) {
+        wait_iface(self.stack, self.handle, |i| !crate::is_config_v4_up(i)).await
+    }
+
+    /// Wait for the interface to obtain a valid IPv6 configuration.
+    ///
+    /// This does not include link-local addresses.
+    #[cfg(feature = "ipv6")]
+    pub async fn wait_config_v6_up(&self) {
+        wait_iface(self.stack, self.handle, |i| crate::is_config_v6_up(i)).await
+    }
+
+    /// Wait for the interface to lose a valid IPv6 configuration.
+    ///
+    /// This does not include link-local addresses.
+    #[cfg(feature = "ipv6")]
+    pub async fn wait_config_v6_down(&self) {
+        wait_iface(self.stack, self.handle, |i| !crate::is_config_v6_up(i)).await
     }
 }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -544,6 +544,18 @@ pub(crate) fn is_config_up(iface: &xarxa::iface::Iface<'_, '_>) -> bool {
     iface.ip_addrs().iter().any(|a| !is_link_local(a))
 }
 
+#[cfg(feature = "ipv4")]
+/// Check if any IPv4 address is configured.
+pub(crate) fn is_config_v4_up(iface: &xarxa::iface::Iface<'_, '_>) -> bool {
+    iface.ip_addrs().iter().any(|a| a.cidr.is_ipv4())
+}
+
+#[cfg(feature = "ipv6")]
+/// Check if any non link-local IPv6 address is configured.
+pub(crate) fn is_config_v6_up(iface: &xarxa::iface::Iface<'_, '_>) -> bool {
+    iface.ip_addrs().iter().any(|a| a.cidr.is_ipv6() && !is_link_local(a))
+}
+
 /// Whether an interface's link is up.
 pub(crate) fn is_link_up(iface: &mut xarxa::iface::Iface<'_, '_>) -> bool {
     iface.link_state() == LinkState::Up


### PR DESCRIPTION
This allows querying either the IPv4 or IPv6 configuration state, as well as waiting on changes to both the IPv4 and IPv6 configs.

Tested with Ferris-on-Air.