### PR TITLE
feat(embassy-usb-host): added midi class

### DIFF
--- a/embassy-usb-host/src/class/midi/descriptors.rs
+++ b/embassy-usb-host/src/class/midi/descriptors.rs
@@ -1,0 +1,495 @@
+//! USB-MIDI 1.0 class-specific descriptor parsing.
+
+use embassy_usb_driver::EndpointType;
+use heapless::Vec;
+
+use super::{USB_CLASS_AUDIO, USB_MIDI_1_PROTOCOL, USB_SUBCLASS_MIDI_STREAMING};
+use crate::descriptor::descriptor_type::{CS_ENDPOINT, CS_INTERFACE, ENDPOINT};
+use crate::descriptor::{
+    ConfigurationDescriptorChain, EndpointDescriptor, InterfaceDescriptorChain, RawDescriptorIterator, USBDescriptor,
+};
+
+const MS_HEADER: u8 = 0x01;
+const MIDI_IN_JACK: u8 = 0x02;
+const MIDI_OUT_JACK: u8 = 0x03;
+const MS_GENERAL: u8 = 0x01;
+
+/// Maximum MIDIStreaming interfaces described by one configuration.
+pub const MAX_MIDI_INTERFACES: usize = 8;
+/// Maximum jacks or cables described by one MIDIStreaming interface.
+pub const MAX_MIDI_JACKS: usize = 16;
+/// Maximum physical bulk endpoints described by one MIDIStreaming interface.
+pub const MAX_MIDI_ENDPOINTS: usize = 4;
+/// Maximum input pins feeding one MIDI OUT jack.
+pub const MAX_MIDI_JACK_SOURCES: usize = 16;
+
+/// USB-MIDI class-specific descriptor parsing error.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MidiDescriptorError {
+    /// A descriptor is truncated, inconsistent, or has an unexpected type.
+    InvalidDescriptor,
+    /// A configuration exceeds one of this driver's fixed capacities.
+    Capacity,
+}
+
+/// Class-specific MIDIStreaming header descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiStreamingHeader {
+    /// USB-MIDI class specification release in binary-coded decimal.
+    pub midi_version: u16,
+    /// Total size of the class-specific MIDIStreaming descriptors.
+    pub total_length: u16,
+}
+
+impl MidiStreamingHeader {
+    /// Parse a class-specific MIDIStreaming header descriptor.
+    pub fn try_from_bytes(raw: &[u8]) -> Result<Self, MidiDescriptorError> {
+        check_descriptor_exact(raw, CS_INTERFACE, MS_HEADER, 7)?;
+        Ok(Self {
+            midi_version: u16::from_le_bytes([raw[3], raw[4]]),
+            total_length: u16::from_le_bytes([raw[5], raw[6]]),
+        })
+    }
+}
+
+/// Whether a MIDI jack is inside the USB device or connected externally.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MidiJackType {
+    /// Jack connected to a USB endpoint.
+    Embedded,
+    /// Jack representing a physical or otherwise external MIDI connection.
+    External,
+}
+
+impl MidiJackType {
+    fn try_from_byte(value: u8) -> Result<Self, MidiDescriptorError> {
+        match value {
+            0x01 => Ok(Self::Embedded),
+            0x02 => Ok(Self::External),
+            _ => Err(MidiDescriptorError::InvalidDescriptor),
+        }
+    }
+}
+
+/// MIDI IN jack descriptor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiInJack {
+    /// Embedded or external jack.
+    pub jack_type: MidiJackType,
+    /// Jack identifier referenced by other class-specific descriptors.
+    pub jack_id: u8,
+    /// String descriptor index, or zero when absent.
+    pub string_index: u8,
+}
+
+impl MidiInJack {
+    /// Parse a class-specific MIDI IN jack descriptor.
+    pub fn try_from_bytes(raw: &[u8]) -> Result<Self, MidiDescriptorError> {
+        check_descriptor_exact(raw, CS_INTERFACE, MIDI_IN_JACK, 6)?;
+        Ok(Self {
+            jack_type: MidiJackType::try_from_byte(raw[3])?,
+            jack_id: raw[4],
+            string_index: raw[5],
+        })
+    }
+}
+
+/// Source pin feeding a MIDI OUT jack.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiJackSource {
+    /// Identifier of the source entity or jack.
+    pub jack_id: u8,
+    /// One-based output pin on the source entity.
+    pub pin: u8,
+}
+
+/// MIDI OUT jack descriptor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiOutJack {
+    /// Embedded or external jack.
+    pub jack_type: MidiJackType,
+    /// Jack identifier referenced by other class-specific descriptors.
+    pub jack_id: u8,
+    /// Source pins feeding this jack.
+    pub sources: Vec<MidiJackSource, MAX_MIDI_JACK_SOURCES>,
+    /// String descriptor index, or zero when absent.
+    pub string_index: u8,
+}
+
+impl MidiOutJack {
+    /// Parse a class-specific MIDI OUT jack descriptor.
+    pub fn try_from_bytes(raw: &[u8]) -> Result<Self, MidiDescriptorError> {
+        check_descriptor(raw, CS_INTERFACE, MIDI_OUT_JACK, 7)?;
+        let source_count = raw[5] as usize;
+        let expected_len = 7usize
+            .checked_add(
+                source_count
+                    .checked_mul(2)
+                    .ok_or(MidiDescriptorError::InvalidDescriptor)?,
+            )
+            .ok_or(MidiDescriptorError::InvalidDescriptor)?;
+        if raw.len() != expected_len {
+            return Err(MidiDescriptorError::InvalidDescriptor);
+        }
+
+        let mut sources = Vec::new();
+        for source in raw[6..6 + source_count * 2].chunks_exact(2) {
+            sources
+                .push(MidiJackSource {
+                    jack_id: source[0],
+                    pin: source[1],
+                })
+                .map_err(|_| MidiDescriptorError::Capacity)?;
+        }
+
+        Ok(Self {
+            jack_type: MidiJackType::try_from_byte(raw[3])?,
+            jack_id: raw[4],
+            sources,
+            string_index: raw[expected_len - 1],
+        })
+    }
+}
+
+/// Jack IDs associated with a class-specific MIDIStreaming endpoint descriptor.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiEndpointJackAssociations {
+    /// Embedded jack IDs ordered by USB-MIDI cable number.
+    pub jack_ids: Vec<u8, MAX_MIDI_JACKS>,
+}
+
+impl MidiEndpointJackAssociations {
+    /// Parse a class-specific MIDIStreaming endpoint descriptor.
+    pub fn try_from_bytes(raw: &[u8]) -> Result<Self, MidiDescriptorError> {
+        check_descriptor(raw, CS_ENDPOINT, MS_GENERAL, 4)?;
+        let expected_len = 4usize
+            .checked_add(raw[3] as usize)
+            .ok_or(MidiDescriptorError::InvalidDescriptor)?;
+        if raw.len() != expected_len {
+            return Err(MidiDescriptorError::InvalidDescriptor);
+        }
+        Ok(Self {
+            jack_ids: Vec::from_slice(&raw[4..]).map_err(|_| MidiDescriptorError::Capacity)?,
+        })
+    }
+}
+
+/// A recognized descriptor within one USB-MIDI 1.0 streaming interface.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MidiDescriptor {
+    /// Class-specific MIDIStreaming header.
+    Header(MidiStreamingHeader),
+    /// MIDI IN jack.
+    InJack(MidiInJack),
+    /// MIDI OUT jack.
+    OutJack(MidiOutJack),
+    /// Standard USB endpoint.
+    Endpoint(EndpointDescriptor),
+    /// Jack associations for the preceding standard endpoint.
+    EndpointJackAssociations(MidiEndpointJackAssociations),
+}
+
+/// Iterator over recognized descriptors in one USB-MIDI 1.0 interface.
+pub struct MidiDescriptorIterator<'a> {
+    descriptors: RawDescriptorIterator<'a>,
+}
+
+impl<'a> MidiDescriptorIterator<'a> {
+    /// Create an iterator when `interface` is a USB-MIDI 1.0 streaming interface.
+    pub fn new(interface: &'a InterfaceDescriptorChain<'a>) -> Option<Self> {
+        is_midi_streaming_interface(interface).then(|| Self {
+            descriptors: interface.iter_descriptors(),
+        })
+    }
+}
+
+impl Iterator for MidiDescriptorIterator<'_> {
+    type Item = Result<MidiDescriptor, MidiDescriptorError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (_, raw) in self.descriptors.by_ref() {
+            if raw.len() < 2 {
+                return Some(Err(MidiDescriptorError::InvalidDescriptor));
+            }
+            let descriptor = match (raw[1], raw.get(2).copied()) {
+                (CS_INTERFACE, Some(MS_HEADER)) => MidiStreamingHeader::try_from_bytes(raw).map(MidiDescriptor::Header),
+                (CS_INTERFACE, Some(MIDI_IN_JACK)) => MidiInJack::try_from_bytes(raw).map(MidiDescriptor::InJack),
+                (CS_INTERFACE, Some(MIDI_OUT_JACK)) => MidiOutJack::try_from_bytes(raw).map(MidiDescriptor::OutJack),
+                (ENDPOINT, _) => EndpointDescriptor::try_from_bytes(raw)
+                    .map(MidiDescriptor::Endpoint)
+                    .map_err(|_| MidiDescriptorError::InvalidDescriptor),
+                (CS_ENDPOINT, Some(MS_GENERAL)) => {
+                    MidiEndpointJackAssociations::try_from_bytes(raw).map(MidiDescriptor::EndpointJackAssociations)
+                }
+                _ => continue,
+            };
+            return Some(descriptor);
+        }
+        None
+    }
+}
+
+/// One physical USB bulk endpoint and its ordered virtual-cable jack IDs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiEndpointDescriptor {
+    /// USB endpoint address, including its direction bit.
+    pub address: u8,
+    /// Maximum USB packet size.
+    pub max_packet_size: u16,
+    /// Associated embedded jack IDs. Their positions are USB-MIDI cable numbers.
+    pub jack_ids: Vec<u8, MAX_MIDI_JACKS>,
+}
+
+impl MidiEndpointDescriptor {
+    /// Whether this endpoint transfers data from the device to the host.
+    pub const fn is_in(&self) -> bool {
+        self.address & 0x80 != 0
+    }
+}
+
+/// Parsed USB-MIDI 1.0 streaming interface and its jack topology.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiStreamingInterface {
+    /// Standard USB interface number.
+    pub interface_number: u8,
+    /// Standard USB alternate-setting number.
+    pub alternate_setting: u8,
+    /// Class-specific streaming header, when supplied by the device.
+    pub header: Option<MidiStreamingHeader>,
+    /// MIDI IN jacks declared by this interface.
+    pub in_jacks: Vec<MidiInJack, MAX_MIDI_JACKS>,
+    /// MIDI OUT jacks declared by this interface.
+    pub out_jacks: Vec<MidiOutJack, MAX_MIDI_JACKS>,
+    /// Physical bulk endpoints and their ordered cable associations.
+    pub endpoints: Vec<MidiEndpointDescriptor, MAX_MIDI_ENDPOINTS>,
+}
+
+impl MidiStreamingInterface {
+    /// Parse one MIDIStreaming interface and associate each endpoint with its jacks.
+    pub fn try_from_interface(interface: &InterfaceDescriptorChain<'_>) -> Result<Self, MidiDescriptorError> {
+        let descriptors = MidiDescriptorIterator::new(interface).ok_or(MidiDescriptorError::InvalidDescriptor)?;
+        let mut result = Self {
+            interface_number: interface.interface_number,
+            alternate_setting: interface.alternate_setting,
+            header: None,
+            in_jacks: Vec::new(),
+            out_jacks: Vec::new(),
+            endpoints: Vec::new(),
+        };
+        let mut current_endpoint = None;
+
+        for descriptor in descriptors {
+            match descriptor? {
+                MidiDescriptor::Header(header) => result.header = Some(header),
+                MidiDescriptor::InJack(jack) => {
+                    result.in_jacks.push(jack).map_err(|_| MidiDescriptorError::Capacity)?
+                }
+                MidiDescriptor::OutJack(jack) => {
+                    result.out_jacks.push(jack).map_err(|_| MidiDescriptorError::Capacity)?
+                }
+                MidiDescriptor::Endpoint(endpoint) => {
+                    current_endpoint = None;
+                    if endpoint.ep_type() == EndpointType::Bulk {
+                        result
+                            .endpoints
+                            .push(MidiEndpointDescriptor {
+                                address: endpoint.endpoint_address,
+                                max_packet_size: endpoint.max_packet_size,
+                                jack_ids: Vec::new(),
+                            })
+                            .map_err(|_| MidiDescriptorError::Capacity)?;
+                        current_endpoint = Some(result.endpoints.len() - 1);
+                    }
+                }
+                MidiDescriptor::EndpointJackAssociations(associations) => {
+                    let endpoint = current_endpoint.ok_or(MidiDescriptorError::InvalidDescriptor)?;
+                    result.endpoints[endpoint].jack_ids = associations.jack_ids;
+                }
+            }
+        }
+        Ok(result)
+    }
+}
+
+/// Parse all USB-MIDI 1.0 streaming interfaces in a configuration descriptor.
+pub fn parse_midi_interfaces(
+    config_desc: &[u8],
+) -> Result<Vec<MidiStreamingInterface, MAX_MIDI_INTERFACES>, MidiDescriptorError> {
+    let config = ConfigurationDescriptorChain::try_from_slice(config_desc)
+        .map_err(|_| MidiDescriptorError::InvalidDescriptor)?;
+    let mut result = Vec::new();
+    for interface in config.iter_interface().filter(is_midi_streaming_interface) {
+        result
+            .push(MidiStreamingInterface::try_from_interface(&interface)?)
+            .map_err(|_| MidiDescriptorError::Capacity)?;
+    }
+    Ok(result)
+}
+
+fn is_midi_streaming_interface(interface: &InterfaceDescriptorChain<'_>) -> bool {
+    interface.interface_class == USB_CLASS_AUDIO
+        && interface.interface_subclass == USB_SUBCLASS_MIDI_STREAMING
+        && interface.interface_protocol == USB_MIDI_1_PROTOCOL
+}
+
+fn check_descriptor(raw: &[u8], descriptor_type: u8, subtype: u8, min_len: usize) -> Result<(), MidiDescriptorError> {
+    if raw.len() < min_len || raw[0] as usize != raw.len() || raw[1] != descriptor_type || raw[2] != subtype {
+        return Err(MidiDescriptorError::InvalidDescriptor);
+    }
+    Ok(())
+}
+
+fn check_descriptor_exact(
+    raw: &[u8],
+    descriptor_type: u8,
+    subtype: u8,
+    expected_len: usize,
+) -> Result<(), MidiDescriptorError> {
+    check_descriptor(raw, descriptor_type, subtype, expected_len)?;
+    if raw.len() != expected_len {
+        return Err(MidiDescriptorError::InvalidDescriptor);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic minimal configuration used to exercise interface and endpoint discovery.
+    const MINIMAL_MIDI_CONFIG: &[u8] = &[
+        9, 2, 32, 0, 1, 1, 0, 0x80, 50, 9, 4, 1, 0, 2, 1, 3, 0, 0, 7, 5, 0x81, 2, 64, 0, 0, 7, 5, 0x02, 2, 64, 0, 0,
+    ];
+
+    /// Yamaha DGX205 MIDI keyboard configuration descriptor.
+    ///
+    /// Copied from Cotton's `cotton-usb-host/src/tests/wire.rs`. Its endpoint
+    /// descriptors are deliberately oversized at nine bytes.
+    #[rustfmt::skip]
+    const YAMAHA_DGX205_CONFIG: &[u8] = &[
+        9, 2, 101, 0, 2, 1, 0, 128, 50, 9, 4, 0, 0, 0, 1, 1, 0, 0, 9, 36, 1, 0, 1, 9, 0, 1, 1, 9, 4, 1, 0, 2, 1, 3, 0,
+        0, 7, 36, 1, 0, 1, 65, 0, 6, 36, 2, 1, 1, 0, 6, 36, 2, 2, 2, 0, 9, 36, 3, 1, 3, 1, 2, 1, 0, 9, 36, 3, 2, 4, 1,
+        1, 1, 0, 9, 5, 2, 2, 32, 0, 0, 0, 0, 5, 37, 1, 1, 1, 9, 5, 129, 2, 32, 0, 0, 0, 0, 5, 37, 1, 1, 3,
+    ];
+
+    #[test]
+    fn finds_midi_streaming_bulk_endpoints() {
+        let interfaces = parse_midi_interfaces(MINIMAL_MIDI_CONFIG).unwrap();
+        assert_eq!(interfaces.len(), 1);
+        assert_eq!(interfaces[0].interface_number, 1);
+        assert_eq!(interfaces[0].endpoints[0].address, 0x81);
+        assert_eq!(interfaces[0].endpoints[1].address, 0x02);
+    }
+
+    #[test]
+    fn rejects_non_midi_1_interface() {
+        let mut config = MINIMAL_MIDI_CONFIG.to_vec();
+        config[16] = 0x02;
+        assert!(parse_midi_interfaces(&config).unwrap().is_empty());
+    }
+
+    #[test]
+    fn parses_midi_jacks_and_endpoint_associations() {
+        let interfaces = parse_midi_interfaces(YAMAHA_DGX205_CONFIG).unwrap();
+        assert_eq!(interfaces.len(), 1);
+
+        let midi = &interfaces[0];
+        assert_eq!(midi.interface_number, 1);
+        assert_eq!(
+            midi.header,
+            Some(MidiStreamingHeader {
+                midi_version: 0x0100,
+                total_length: 65
+            })
+        );
+        assert_eq!(midi.in_jacks.len(), 2);
+        assert_eq!(midi.in_jacks[0].jack_type, MidiJackType::Embedded);
+        assert_eq!(midi.in_jacks[0].jack_id, 1);
+        assert_eq!(midi.in_jacks[1].jack_type, MidiJackType::External);
+        assert_eq!(midi.in_jacks[1].jack_id, 2);
+        assert_eq!(midi.out_jacks.len(), 2);
+        assert_eq!(midi.out_jacks[0].jack_id, 3);
+        assert_eq!(
+            midi.out_jacks[0].sources.as_slice(),
+            &[MidiJackSource { jack_id: 2, pin: 1 }]
+        );
+        assert_eq!(midi.endpoints.len(), 2);
+        assert_eq!(midi.endpoints[0].address, 0x02);
+        assert_eq!(midi.endpoints[0].jack_ids.as_slice(), &[1]);
+        assert_eq!(midi.endpoints[1].address, 0x81);
+        assert_eq!(midi.endpoints[1].jack_ids.as_slice(), &[3]);
+    }
+
+    #[test]
+    fn iterates_typed_midi_descriptors_in_wire_order() {
+        let config = ConfigurationDescriptorChain::try_from_slice(YAMAHA_DGX205_CONFIG).unwrap();
+        let interface = config.iter_interface().nth(1).unwrap();
+        let descriptors: heapless::Vec<_, 9> = MidiDescriptorIterator::new(&interface)
+            .unwrap()
+            .map(Result::unwrap)
+            .collect();
+
+        assert!(matches!(descriptors[0], MidiDescriptor::Header(_)));
+        assert!(matches!(descriptors[1], MidiDescriptor::InJack(_)));
+        assert!(matches!(descriptors[2], MidiDescriptor::InJack(_)));
+        assert!(matches!(descriptors[3], MidiDescriptor::OutJack(_)));
+        assert!(matches!(descriptors[4], MidiDescriptor::OutJack(_)));
+        assert!(matches!(descriptors[5], MidiDescriptor::Endpoint(_)));
+        assert!(matches!(descriptors[6], MidiDescriptor::EndpointJackAssociations(_)));
+        assert!(matches!(descriptors[7], MidiDescriptor::Endpoint(_)));
+        assert!(matches!(descriptors[8], MidiDescriptor::EndpointJackAssociations(_)));
+    }
+
+    #[test]
+    fn rejects_inconsistent_class_specific_lengths() {
+        assert_eq!(
+            MidiStreamingHeader::try_from_bytes(&[6, 36, 1, 0, 1, 7]),
+            Err(MidiDescriptorError::InvalidDescriptor)
+        );
+        assert_eq!(
+            MidiOutJack::try_from_bytes(&[9, 36, 3, 1, 3, 2, 1, 1, 0]),
+            Err(MidiDescriptorError::InvalidDescriptor)
+        );
+        assert_eq!(
+            MidiEndpointJackAssociations::try_from_bytes(&[5, 37, 1, 2, 1]),
+            Err(MidiDescriptorError::InvalidDescriptor)
+        );
+        assert_eq!(
+            parse_midi_interfaces(&MINIMAL_MIDI_CONFIG[..MINIMAL_MIDI_CONFIG.len() - 1]),
+            Err(MidiDescriptorError::InvalidDescriptor)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_jack_types_and_excessive_associations() {
+        assert_eq!(
+            MidiInJack::try_from_bytes(&[6, 36, 2, 3, 1, 0]),
+            Err(MidiDescriptorError::InvalidDescriptor)
+        );
+
+        let raw = [21, 37, 1, 17, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17];
+        assert_eq!(
+            MidiEndpointJackAssociations::try_from_bytes(&raw),
+            Err(MidiDescriptorError::Capacity)
+        );
+    }
+
+    #[test]
+    fn rejects_endpoint_associations_without_a_bulk_endpoint() {
+        let config = [9, 2, 23, 0, 1, 1, 0, 128, 50, 9, 4, 1, 0, 0, 1, 3, 0, 0, 5, 37, 1, 1, 1];
+        assert_eq!(
+            parse_midi_interfaces(&config),
+            Err(MidiDescriptorError::InvalidDescriptor)
+        );
+    }
+}

--- a/embassy-usb-host/src/class/midi/descriptors.rs
+++ b/embassy-usb-host/src/class/midi/descriptors.rs
@@ -6,7 +6,8 @@ use heapless::Vec;
 use super::{USB_CLASS_AUDIO, USB_MIDI_1_PROTOCOL, USB_SUBCLASS_MIDI_STREAMING};
 use crate::descriptor::descriptor_type::{CS_ENDPOINT, CS_INTERFACE, ENDPOINT};
 use crate::descriptor::{
-    ConfigurationDescriptorChain, EndpointDescriptor, InterfaceDescriptorChain, RawDescriptorIterator, USBDescriptor,
+    ConfigurationDescriptorChain, DeviceDescriptor, EndpointDescriptor, InterfaceDescriptorChain,
+    RawDescriptorIterator, USBDescriptor,
 };
 
 const MS_HEADER: u8 = 0x01;
@@ -209,6 +210,12 @@ impl<'a> MidiDescriptorIterator<'a> {
             descriptors: interface.iter_descriptors(),
         })
     }
+
+    fn new_unchecked(interface: &'a InterfaceDescriptorChain<'a>) -> Self {
+        Self {
+            descriptors: interface.iter_descriptors(),
+        }
+    }
 }
 
 impl Iterator for MidiDescriptorIterator<'_> {
@@ -277,7 +284,14 @@ pub struct MidiStreamingInterface {
 impl MidiStreamingInterface {
     /// Parse one MIDIStreaming interface and associate each endpoint with its jacks.
     pub fn try_from_interface(interface: &InterfaceDescriptorChain<'_>) -> Result<Self, MidiDescriptorError> {
-        let descriptors = MidiDescriptorIterator::new(interface).ok_or(MidiDescriptorError::InvalidDescriptor)?;
+        if !is_midi_streaming_interface(interface) {
+            return Err(MidiDescriptorError::InvalidDescriptor);
+        }
+        Self::try_from_interface_unchecked(interface)
+    }
+
+    fn try_from_interface_unchecked(interface: &InterfaceDescriptorChain<'_>) -> Result<Self, MidiDescriptorError> {
+        let descriptors = MidiDescriptorIterator::new_unchecked(interface);
         let mut result = Self {
             interface_number: interface.interface_number,
             alternate_setting: interface.alternate_setting,
@@ -336,10 +350,40 @@ pub fn parse_midi_interfaces(
     Ok(result)
 }
 
+/// Parse USB-MIDI interfaces, including recognized vendor-specific device layouts.
+pub fn parse_midi_interfaces_for_device(
+    device: &DeviceDescriptor,
+    config_desc: &[u8],
+) -> Result<Vec<MidiStreamingInterface, MAX_MIDI_INTERFACES>, MidiDescriptorError> {
+    let config = ConfigurationDescriptorChain::try_from_slice(config_desc)
+        .map_err(|_| MidiDescriptorError::InvalidDescriptor)?;
+    let mut result = Vec::new();
+    for interface in config.iter_interface() {
+        if is_midi_streaming_interface(&interface) {
+            result
+                .push(MidiStreamingInterface::try_from_interface(&interface)?)
+                .map_err(|_| MidiDescriptorError::Capacity)?;
+        } else if is_legacy_yamaha_midi_interface(device, &interface) {
+            let parsed = MidiStreamingInterface::try_from_interface_unchecked(&interface)?;
+            if parsed.header.is_some() && !parsed.endpoints.is_empty() {
+                result.push(parsed).map_err(|_| MidiDescriptorError::Capacity)?;
+            }
+        }
+    }
+    Ok(result)
+}
+
 fn is_midi_streaming_interface(interface: &InterfaceDescriptorChain<'_>) -> bool {
     interface.interface_class == USB_CLASS_AUDIO
         && interface.interface_subclass == USB_SUBCLASS_MIDI_STREAMING
         && interface.interface_protocol == USB_MIDI_1_PROTOCOL
+}
+
+fn is_legacy_yamaha_midi_interface(device: &DeviceDescriptor, interface: &InterfaceDescriptorChain<'_>) -> bool {
+    device.vendor_id == 0x0499
+        && interface.interface_class == 0xff
+        && interface.interface_subclass == 0x00
+        && interface.interface_protocol == 0xff
 }
 
 fn check_descriptor(raw: &[u8], descriptor_type: u8, subtype: u8, min_len: usize) -> Result<(), MidiDescriptorError> {
@@ -381,6 +425,30 @@ mod tests {
         0, 7, 36, 1, 0, 1, 65, 0, 6, 36, 2, 1, 1, 0, 6, 36, 2, 2, 2, 0, 9, 36, 3, 1, 3, 1, 2, 1, 0, 9, 36, 3, 2, 4, 1,
         1, 1, 0, 9, 5, 2, 2, 32, 0, 0, 0, 0, 5, 37, 1, 1, 1, 9, 5, 129, 2, 32, 0, 0, 0, 0, 5, 37, 1, 1, 3,
     ];
+
+    #[rustfmt::skip]
+    const YAMAHA_DGX205_LEGACY_CONFIG: &[u8] = &[
+        9, 2, 0x36, 0, 1, 1, 0, 0xc0, 0, 9, 4, 0, 0, 2, 0xff, 0, 0xff, 0,
+        7, 0x24, 1, 0, 1, 0x24, 0, 6, 0x24, 2, 2, 1, 0, 9, 0x24, 3, 2, 1, 1, 1, 1, 0,
+        7, 5, 1, 2, 0x40, 0, 1, 7, 5, 0x82, 2, 0x40, 0, 1,
+    ];
+
+    fn device(vendor_id: u16) -> DeviceDescriptor {
+        DeviceDescriptor {
+            bcd_usb: 0x0110,
+            device_class: 0,
+            device_subclass: 0,
+            device_protocol: 0,
+            max_packet_size0: 8,
+            vendor_id,
+            product_id: 0x1031,
+            bcd_device: 0x0110,
+            manufacturer: 1,
+            product: 2,
+            serial_number: 0,
+            num_configurations: 1,
+        }
+    }
 
     #[test]
     fn finds_midi_streaming_bulk_endpoints() {
@@ -428,6 +496,33 @@ mod tests {
         assert_eq!(midi.endpoints[0].jack_ids.as_slice(), &[1]);
         assert_eq!(midi.endpoints[1].address, 0x81);
         assert_eq!(midi.endpoints[1].jack_ids.as_slice(), &[3]);
+    }
+
+    #[test]
+    fn parses_legacy_yamaha_vendor_interface() {
+        assert!(parse_midi_interfaces(YAMAHA_DGX205_LEGACY_CONFIG).unwrap().is_empty());
+
+        let interfaces = parse_midi_interfaces_for_device(&device(0x0499), YAMAHA_DGX205_LEGACY_CONFIG).unwrap();
+        assert_eq!(interfaces.len(), 1);
+        assert_eq!(interfaces[0].interface_number, 0);
+        assert_eq!(interfaces[0].endpoints.len(), 2);
+        assert_eq!(interfaces[0].endpoints[0].address, 0x01);
+        assert_eq!(interfaces[0].endpoints[1].address, 0x82);
+        assert!(
+            interfaces[0]
+                .endpoints
+                .iter()
+                .all(|endpoint| endpoint.jack_ids.is_empty())
+        );
+    }
+
+    #[test]
+    fn does_not_claim_other_vendors_legacy_interface() {
+        assert!(
+            parse_midi_interfaces_for_device(&device(0x1234), YAMAHA_DGX205_LEGACY_CONFIG)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/embassy-usb-host/src/class/midi/mod.rs
+++ b/embassy-usb-host/src/class/midi/mod.rs
@@ -1,0 +1,769 @@
+//! USB MIDI 1.0 host class driver.
+//!
+//! USB MIDI 1.0 transports one or more virtual MIDI cables over bulk
+//! endpoints. Each transfer consists of four-byte USB-MIDI event packets.
+
+use core::slice::ChunksExact;
+
+use embassy_usb_driver::host::{PipeError, UsbHostAllocator};
+use heapless::Vec;
+
+use crate::handler::EnumerationInfo;
+
+mod descriptors;
+mod transport;
+
+use descriptors::{
+    MAX_MIDI_JACKS, MidiDescriptorError, MidiEndpointDescriptor, MidiStreamingInterface, parse_midi_interfaces,
+};
+
+/// Advanced descriptor and endpoint-level USB-MIDI APIs.
+pub mod raw {
+    pub use super::descriptors::*;
+    pub use super::transport::{MidiInputPipe, MidiOutputPipe};
+    pub use super::{UsbMidiEventPacket, event_packets};
+}
+
+pub(crate) const USB_CLASS_AUDIO: u8 = 0x01;
+pub(crate) const USB_SUBCLASS_MIDI_STREAMING: u8 = 0x03;
+pub(crate) const USB_MIDI_1_PROTOCOL: u8 = 0x00;
+
+/// USB-MIDI event packet size.
+pub const EVENT_PACKET_SIZE: usize = 4;
+
+/// One USB-MIDI 1.0 event packet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct UsbMidiEventPacket([u8; EVENT_PACKET_SIZE]);
+
+/// Error constructing a USB-MIDI 1.0 event packet from MIDI bytes.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MidiPacketError {
+    /// USB-MIDI 1.0 cable numbers are limited to 0 through 15.
+    InvalidCable,
+    /// The status byte is unsupported or reserved.
+    InvalidStatus,
+    /// The byte count does not match the MIDI status.
+    InvalidLength,
+    /// A MIDI data byte has its status bit set.
+    InvalidData,
+}
+
+impl UsbMidiEventPacket {
+    /// Create an event packet from its wire representation.
+    pub const fn new(bytes: [u8; EVENT_PACKET_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    /// Encode one complete non-SysEx MIDI 1.0 message for a virtual cable.
+    pub fn from_midi_bytes(cable: u8, data: &[u8]) -> Result<Self, MidiPacketError> {
+        if cable > 0x0f {
+            return Err(MidiPacketError::InvalidCable);
+        }
+        let status = *data.first().ok_or(MidiPacketError::InvalidLength)?;
+        let (cin, expected_len) = match status {
+            0x80..=0xef => {
+                let cin = status >> 4;
+                let len = if matches!(cin, 0x0c | 0x0d) { 2 } else { 3 };
+                (cin, len)
+            }
+            0xf1 | 0xf3 => (0x02, 2),
+            0xf2 => (0x03, 3),
+            0xf6 | 0xf7 => (0x05, 1),
+            0xf8 | 0xfa..=0xfc | 0xfe | 0xff => (0x0f, 1),
+            _ => return Err(MidiPacketError::InvalidStatus),
+        };
+        if data.len() != expected_len {
+            return Err(MidiPacketError::InvalidLength);
+        }
+        if data[1..].iter().any(|byte| byte & 0x80 != 0) {
+            return Err(MidiPacketError::InvalidData);
+        }
+
+        let mut packet = [0; EVENT_PACKET_SIZE];
+        packet[0] = cable << 4 | cin;
+        packet[1..1 + expected_len].copy_from_slice(data);
+        Ok(Self(packet))
+    }
+
+    /// Virtual cable number carried by this packet.
+    pub const fn cable(&self) -> u8 {
+        self.0[0] >> 4
+    }
+
+    /// Code Index Number describing the MIDI message carried by this packet.
+    pub const fn cin(&self) -> u8 {
+        self.0[0] & 0x0f
+    }
+
+    /// Number of valid MIDI bytes, or `None` for a reserved CIN.
+    pub const fn message_len(&self) -> Option<usize> {
+        match self.cin() {
+            0x2 | 0x6 | 0xc | 0xd => Some(2),
+            0x3 | 0x4 | 0x7 | 0x8..=0xb | 0xe => Some(3),
+            0x5 | 0xf => Some(1),
+            _ => None,
+        }
+    }
+
+    /// Valid MIDI bytes, or `None` for a reserved CIN.
+    pub fn data(&self) -> Option<&[u8]> {
+        self.message_len().map(|len| &self.0[1..1 + len])
+    }
+
+    /// Four-byte USB-MIDI wire representation.
+    pub const fn as_bytes(&self) -> &[u8; EVENT_PACKET_SIZE] {
+        &self.0
+    }
+}
+
+impl From<[u8; EVENT_PACKET_SIZE]> for UsbMidiEventPacket {
+    fn from(bytes: [u8; EVENT_PACKET_SIZE]) -> Self {
+        Self::new(bytes)
+    }
+}
+
+/// Iterate over complete USB-MIDI event packets in a transfer.
+pub fn event_packets(data: &[u8]) -> Result<impl Iterator<Item = UsbMidiEventPacket> + '_, MidiError> {
+    if data.is_empty() || !data.len().is_multiple_of(EVENT_PACKET_SIZE) {
+        return Err(MidiError::InvalidPacketLength);
+    }
+
+    Ok(data
+        .chunks_exact(EVENT_PACKET_SIZE)
+        .map(|chunk| UsbMidiEventPacket::new([chunk[0], chunk[1], chunk[2], chunk[3]])))
+}
+
+/// USB MIDI host error.
+#[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum MidiError {
+    /// A USB transfer failed.
+    Transfer(PipeError),
+    /// No MIDIStreaming interface was found.
+    NoInterface,
+    /// The requested transfer direction is not exposed by the interface.
+    NoEndpoint,
+    /// An endpoint was opened using the wrong transfer direction.
+    WrongDirection,
+    /// The controller could not allocate an endpoint pipe.
+    NoPipe,
+    /// The MIDI descriptors are malformed or exceed a fixed capacity.
+    Descriptor(MidiDescriptorError),
+    /// The device uses a topology unsupported by the friendly host API.
+    UnsupportedTopology,
+    /// A port does not belong to this MIDI device direction.
+    InvalidPort,
+    /// A MIDI message could not be encoded as an event packet.
+    InvalidMessage(MidiPacketError),
+    /// USB-MIDI transfers must contain complete four-byte event packets.
+    InvalidPacketLength,
+}
+
+impl From<PipeError> for MidiError {
+    fn from(error: PipeError) -> Self {
+        Self::Transfer(error)
+    }
+}
+
+impl From<MidiDescriptorError> for MidiError {
+    fn from(error: MidiDescriptorError) -> Self {
+        Self::Descriptor(error)
+    }
+}
+
+impl From<MidiPacketError> for MidiError {
+    fn from(error: MidiPacketError) -> Self {
+        Self::InvalidMessage(error)
+    }
+}
+
+impl core::fmt::Display for MidiError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Transfer(_) => write!(f, "USB MIDI transfer failed"),
+            Self::NoInterface => write!(f, "no USB MIDIStreaming interface found"),
+            Self::NoEndpoint => write!(f, "USB MIDI endpoint direction unavailable"),
+            Self::WrongDirection => write!(f, "USB MIDI endpoint has the wrong direction"),
+            Self::NoPipe => write!(f, "no free USB host pipe"),
+            Self::Descriptor(_) => write!(f, "invalid USB MIDI descriptors"),
+            Self::UnsupportedTopology => write!(f, "unsupported USB MIDI topology"),
+            Self::InvalidPort => write!(f, "USB MIDI port does not belong to this device direction"),
+            Self::InvalidMessage(_) => write!(f, "invalid MIDI message"),
+            Self::InvalidPacketLength => write!(f, "USB MIDI data is not a multiple of four bytes"),
+        }
+    }
+}
+
+impl core::error::Error for MidiError {}
+
+/// A logical device-to-host MIDI port discovered from a USB cable association.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiInputPort {
+    device_address: u8,
+    interface_number: u8,
+    endpoint_address: u8,
+    cable: u8,
+    jack_id: u8,
+}
+
+impl MidiInputPort {
+    /// One-based port number suitable for display.
+    pub const fn number(&self) -> u8 {
+        self.cable + 1
+    }
+
+    /// Zero-based USB-MIDI virtual cable number.
+    pub const fn cable(&self) -> u8 {
+        self.cable
+    }
+
+    /// Associated embedded jack identifier.
+    pub const fn jack_id(&self) -> u8 {
+        self.jack_id
+    }
+
+    /// MIDIStreaming interface number.
+    pub const fn interface_number(&self) -> u8 {
+        self.interface_number
+    }
+}
+
+/// A logical host-to-device MIDI port discovered from a USB cable association.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct MidiOutputPort {
+    device_address: u8,
+    interface_number: u8,
+    endpoint_address: u8,
+    cable: u8,
+    jack_id: u8,
+}
+
+impl MidiOutputPort {
+    /// One-based port number suitable for display.
+    pub const fn number(&self) -> u8 {
+        self.cable + 1
+    }
+
+    /// Zero-based USB-MIDI virtual cable number.
+    pub const fn cable(&self) -> u8 {
+        self.cable
+    }
+
+    /// Associated embedded jack identifier.
+    pub const fn jack_id(&self) -> u8 {
+        self.jack_id
+    }
+
+    /// MIDIStreaming interface number.
+    pub const fn interface_number(&self) -> u8 {
+        self.interface_number
+    }
+}
+
+/// Friendly host driver for one USB MIDI 1.0 streaming interface.
+///
+/// Input-only and output-only devices are represented by an empty port slice
+/// on the unsupported direction.
+///
+/// This convenience API supports one alternate-setting-zero MIDIStreaming
+/// interface with at most one bulk endpoint per direction. Use [`raw`] for
+/// devices with multiple streaming interfaces or same-direction endpoints.
+pub struct MidiHost<'d, A: UsbHostAllocator<'d>> {
+    sender: Sender<'d, A>,
+    receiver: Receiver<'d, A>,
+}
+
+impl<'d, A: UsbHostAllocator<'d>> MidiHost<'d, A> {
+    /// Discover the MIDI ports and allocate the available bulk pipes.
+    pub fn new(alloc: &A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, MidiError> {
+        let interfaces = parse_midi_interfaces(config_desc)?;
+        let (interface, input_endpoint, output_endpoint) = select_streaming_interface(&interfaces)?;
+
+        let receiver = Receiver::open(alloc, interface, input_endpoint, enum_info)?;
+        let sender = Sender::open(alloc, interface, output_endpoint, enum_info)?;
+        Ok(Self { sender, receiver })
+    }
+
+    /// Logical device-to-host MIDI ports.
+    pub fn input_ports(&self) -> &[MidiInputPort] {
+        self.receiver.ports()
+    }
+
+    /// Logical host-to-device MIDI ports.
+    pub fn output_ports(&self) -> &[MidiOutputPort] {
+        self.sender.ports()
+    }
+
+    /// Receive one bulk transfer containing USB-MIDI event packets.
+    pub async fn read_transfer(&mut self, buf: &mut [u8]) -> Result<usize, MidiError> {
+        self.receiver.read_transfer(buf).await
+    }
+
+    /// Send one or more complete USB-MIDI event packets.
+    pub async fn write_packet(&mut self, packets: &[u8]) -> Result<(), MidiError> {
+        self.sender.write_packet(packets).await
+    }
+
+    /// Encode and send one complete non-SysEx MIDI message to a logical port.
+    pub async fn send(&mut self, port: MidiOutputPort, message: &[u8]) -> Result<(), MidiError> {
+        self.sender.send(port, message).await
+    }
+
+    /// Split the class into independently owned sender and receiver halves.
+    ///
+    /// This allows sending and receiving from separate tasks.
+    pub fn split(self) -> (Sender<'d, A>, Receiver<'d, A>) {
+        (self.sender, self.receiver)
+    }
+}
+
+fn select_streaming_interface(
+    interfaces: &[MidiStreamingInterface],
+) -> Result<
+    (
+        &MidiStreamingInterface,
+        Option<&MidiEndpointDescriptor>,
+        Option<&MidiEndpointDescriptor>,
+    ),
+    MidiError,
+> {
+    let mut matching = interfaces
+        .iter()
+        .filter(|interface| interface.alternate_setting == 0 && !interface.endpoints.is_empty());
+    let interface = matching.next().ok_or(MidiError::NoInterface)?;
+    if matching.next().is_some() {
+        return Err(MidiError::UnsupportedTopology);
+    }
+
+    let mut input_endpoint = None;
+    let mut output_endpoint = None;
+    for endpoint in &interface.endpoints {
+        let slot = if endpoint.is_in() {
+            &mut input_endpoint
+        } else {
+            &mut output_endpoint
+        };
+        if slot.replace(endpoint).is_some() {
+            return Err(MidiError::UnsupportedTopology);
+        }
+    }
+
+    Ok((interface, input_endpoint, output_endpoint))
+}
+
+/// USB-MIDI host-to-device packet sender.
+pub struct Sender<'d, A: UsbHostAllocator<'d>> {
+    pipe: Option<transport::MidiOutputPipe<'d, A>>,
+    ports: Vec<MidiOutputPort, MAX_MIDI_JACKS>,
+}
+
+impl<'d, A: UsbHostAllocator<'d>> Sender<'d, A> {
+    fn open(
+        alloc: &A,
+        interface: &MidiStreamingInterface,
+        endpoint: Option<&MidiEndpointDescriptor>,
+        enum_info: &EnumerationInfo,
+    ) -> Result<Self, MidiError> {
+        let Some(endpoint) = endpoint else {
+            return Ok(Self {
+                pipe: None,
+                ports: Vec::new(),
+            });
+        };
+        let ports = output_ports(interface.interface_number, endpoint, enum_info.device_address)?;
+        let pipe = transport::MidiOutputPipe::open(alloc, endpoint, enum_info)?;
+        Ok(Self {
+            pipe: Some(pipe),
+            ports,
+        })
+    }
+
+    /// Logical ports that can receive MIDI from the host.
+    pub fn ports(&self) -> &[MidiOutputPort] {
+        &self.ports
+    }
+
+    /// Send one or more complete USB-MIDI event packets.
+    pub async fn write_packet(&mut self, packets: &[u8]) -> Result<(), MidiError> {
+        self.pipe.as_mut().ok_or(MidiError::NoEndpoint)?.write(packets).await
+    }
+
+    /// Encode and send one complete non-SysEx MIDI message to a logical port.
+    pub async fn send(&mut self, port: MidiOutputPort, message: &[u8]) -> Result<(), MidiError> {
+        if !self.ports.contains(&port) {
+            return Err(MidiError::InvalidPort);
+        }
+        let packet = UsbMidiEventPacket::from_midi_bytes(port.cable, message)?;
+        self.write_packet(packet.as_bytes()).await
+    }
+}
+
+/// USB-MIDI device-to-host packet receiver.
+pub struct Receiver<'d, A: UsbHostAllocator<'d>> {
+    pipe: Option<transport::MidiInputPipe<'d, A>>,
+    ports: Vec<MidiInputPort, MAX_MIDI_JACKS>,
+}
+
+impl<'d, A: UsbHostAllocator<'d>> Receiver<'d, A> {
+    fn open(
+        alloc: &A,
+        interface: &MidiStreamingInterface,
+        endpoint: Option<&MidiEndpointDescriptor>,
+        enum_info: &EnumerationInfo,
+    ) -> Result<Self, MidiError> {
+        let Some(endpoint) = endpoint else {
+            return Ok(Self {
+                pipe: None,
+                ports: Vec::new(),
+            });
+        };
+        let ports = input_ports(interface.interface_number, endpoint, enum_info.device_address)?;
+        let pipe = transport::MidiInputPipe::open(alloc, endpoint, enum_info)?;
+        Ok(Self {
+            pipe: Some(pipe),
+            ports,
+        })
+    }
+
+    /// Logical ports that can send MIDI to the host.
+    pub fn ports(&self) -> &[MidiInputPort] {
+        &self.ports
+    }
+
+    /// Receive one bulk transfer containing complete USB-MIDI event packets.
+    pub async fn read_transfer(&mut self, buf: &mut [u8]) -> Result<usize, MidiError> {
+        self.pipe.as_mut().ok_or(MidiError::NoEndpoint)?.read(buf).await
+    }
+
+    /// Receive one transfer and map each event packet to its logical input port.
+    pub async fn receive<'a>(&'a mut self, buffer: &'a mut [u8]) -> Result<ReceivedMidiPackets<'a>, MidiError> {
+        let length = self.read_transfer(buffer).await?;
+        for chunk in buffer[..length].chunks_exact(EVENT_PACKET_SIZE) {
+            let cable = chunk[0] >> 4;
+            if !self.ports.iter().any(|port| port.cable == cable) {
+                return Err(MidiError::InvalidPort);
+            }
+        }
+        Ok(ReceivedMidiPackets {
+            chunks: buffer[..length].chunks_exact(EVENT_PACKET_SIZE),
+            ports: &self.ports,
+        })
+    }
+}
+
+/// One received USB-MIDI event packet and its logical input port.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ReceivedMidiPacket {
+    port: MidiInputPort,
+    packet: UsbMidiEventPacket,
+}
+
+impl ReceivedMidiPacket {
+    /// Logical input port selected by the packet's virtual cable number.
+    pub const fn port(&self) -> MidiInputPort {
+        self.port
+    }
+
+    /// USB-MIDI event packet.
+    pub const fn packet(&self) -> UsbMidiEventPacket {
+        self.packet
+    }
+
+    /// Valid MIDI bytes, or `None` for a reserved CIN.
+    pub fn data(&self) -> Option<&[u8]> {
+        self.packet.data()
+    }
+}
+
+/// Iterator over the logical MIDI packets in one received USB transfer.
+pub struct ReceivedMidiPackets<'a> {
+    chunks: ChunksExact<'a, u8>,
+    ports: &'a [MidiInputPort],
+}
+
+impl Iterator for ReceivedMidiPackets<'_> {
+    type Item = ReceivedMidiPacket;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let chunk = self.chunks.next()?;
+        let packet = UsbMidiEventPacket::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let port = self.ports.iter().find(|port| port.cable == packet.cable()).copied()?;
+        Some(ReceivedMidiPacket { port, packet })
+    }
+}
+
+fn input_ports(
+    interface_number: u8,
+    endpoint: &MidiEndpointDescriptor,
+    device_address: u8,
+) -> Result<Vec<MidiInputPort, MAX_MIDI_JACKS>, MidiError> {
+    let mut ports = Vec::new();
+    for (cable, &jack_id) in cable_jacks(endpoint).enumerate() {
+        ports
+            .push(MidiInputPort {
+                device_address,
+                interface_number,
+                endpoint_address: endpoint.address,
+                cable: cable as u8,
+                jack_id,
+            })
+            .map_err(|_| MidiDescriptorError::Capacity)?;
+    }
+    Ok(ports)
+}
+
+fn output_ports(
+    interface_number: u8,
+    endpoint: &MidiEndpointDescriptor,
+    device_address: u8,
+) -> Result<Vec<MidiOutputPort, MAX_MIDI_JACKS>, MidiError> {
+    let mut ports = Vec::new();
+    for (cable, &jack_id) in cable_jacks(endpoint).enumerate() {
+        ports
+            .push(MidiOutputPort {
+                device_address,
+                interface_number,
+                endpoint_address: endpoint.address,
+                cable: cable as u8,
+                jack_id,
+            })
+            .map_err(|_| MidiDescriptorError::Capacity)?;
+    }
+    Ok(ports)
+}
+
+fn cable_jacks(endpoint: &MidiEndpointDescriptor) -> impl Iterator<Item = &u8> {
+    static IMPLICIT_CABLE: [u8; 1] = [0];
+    if endpoint.jack_ids.is_empty() {
+        IMPLICIT_CABLE.iter()
+    } else {
+        endpoint.jack_ids.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_event_packet_fields_and_lengths() {
+        let note_on = UsbMidiEventPacket::new([0x39, 0x90, 60, 100]);
+        assert_eq!(note_on.cable(), 3);
+        assert_eq!(note_on.cin(), 9);
+        assert_eq!(note_on.data(), Some(&[0x90, 60, 100][..]));
+
+        let program_change = UsbMidiEventPacket::new([0x0c, 0xc0, 12, 0]);
+        assert_eq!(program_change.data(), Some(&[0xc0, 12][..]));
+
+        let clock = UsbMidiEventPacket::new([0x0f, 0xf8, 0, 0]);
+        assert_eq!(clock.data(), Some(&[0xf8][..]));
+
+        let reserved = UsbMidiEventPacket::new([0x00, 0, 0, 0]);
+        assert_eq!(reserved.data(), None);
+    }
+
+    #[test]
+    fn iterates_complete_event_packets() {
+        let data = [0x09, 0x90, 60, 100, 0x08, 0x80, 60, 0];
+        let packets: heapless::Vec<_, 2> = event_packets(&data).unwrap().collect();
+        assert_eq!(packets.len(), 2);
+        assert_eq!(packets[0].data(), Some(&[0x90, 60, 100][..]));
+        assert_eq!(packets[1].data(), Some(&[0x80, 60, 0][..]));
+        assert!(event_packets(&data[..7]).is_err());
+        assert!(event_packets(&[]).is_err());
+    }
+
+    #[test]
+    fn encodes_channel_voice_event_packets() {
+        let messages: &[(&[u8], u8)] = &[
+            (&[0x80, 60, 0], 0x08),
+            (&[0x90, 60, 100], 0x09),
+            (&[0xa0, 60, 50], 0x0a),
+            (&[0xb0, 74, 90], 0x0b),
+            (&[0xc0, 12], 0x0c),
+            (&[0xd0, 77], 0x0d),
+            (&[0xe0, 0, 64], 0x0e),
+        ];
+        for &(message, cin) in messages {
+            let packet = UsbMidiEventPacket::from_midi_bytes(3, message).unwrap();
+            assert_eq!(packet.cable(), 3);
+            assert_eq!(packet.cin(), cin);
+            assert_eq!(packet.data(), Some(message));
+        }
+    }
+
+    #[test]
+    fn encodes_system_common_and_realtime_event_packets() {
+        let messages: &[(&[u8], u8)] = &[
+            (&[0xf1, 1], 0x02),
+            (&[0xf2, 1, 2], 0x03),
+            (&[0xf3, 3], 0x02),
+            (&[0xf6], 0x05),
+            (&[0xf7], 0x05),
+            (&[0xf8], 0x0f),
+            (&[0xfa], 0x0f),
+            (&[0xfb], 0x0f),
+            (&[0xfc], 0x0f),
+            (&[0xfe], 0x0f),
+            (&[0xff], 0x0f),
+        ];
+        for &(message, cin) in messages {
+            let packet = UsbMidiEventPacket::from_midi_bytes(15, message).unwrap();
+            assert_eq!(packet.cin(), cin);
+            assert_eq!(packet.data(), Some(message));
+            for &padding in &packet.as_bytes()[1 + message.len()..] {
+                assert_eq!(padding, 0);
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_invalid_midi_event_packet_inputs() {
+        assert_eq!(
+            UsbMidiEventPacket::from_midi_bytes(16, &[0x90, 60, 100]),
+            Err(MidiPacketError::InvalidCable)
+        );
+        for status in [0x00, 0x7f, 0xf0, 0xf4, 0xf5, 0xf9, 0xfd] {
+            assert_eq!(
+                UsbMidiEventPacket::from_midi_bytes(0, &[status]),
+                Err(MidiPacketError::InvalidStatus)
+            );
+        }
+        for message in [&[][..], &[0x90, 60][..], &[0xc0, 12, 0][..], &[0xf8, 0][..]] {
+            assert_eq!(
+                UsbMidiEventPacket::from_midi_bytes(0, message),
+                Err(MidiPacketError::InvalidLength)
+            );
+        }
+        assert_eq!(
+            UsbMidiEventPacket::from_midi_bytes(0, &[0x90, 0x80, 0]),
+            Err(MidiPacketError::InvalidData)
+        );
+    }
+
+    #[test]
+    fn maps_endpoint_cables_to_typed_logical_ports() {
+        let endpoint = MidiEndpointDescriptor {
+            address: 0x81,
+            max_packet_size: 64,
+            jack_ids: Vec::from_slice(&[3, 7]).unwrap(),
+        };
+        let ports = input_ports(2, &endpoint, 5).unwrap();
+
+        assert_eq!(ports.len(), 2);
+        assert_eq!(ports[0].number(), 1);
+        assert_eq!(ports[0].cable(), 0);
+        assert_eq!(ports[0].jack_id(), 3);
+        assert_eq!(ports[1].number(), 2);
+        assert_eq!(ports[1].cable(), 1);
+        assert_eq!(ports[1].jack_id(), 7);
+        assert_eq!(ports[1].interface_number(), 2);
+    }
+
+    #[test]
+    fn maps_received_cables_to_input_ports() {
+        let endpoint = MidiEndpointDescriptor {
+            address: 0x81,
+            max_packet_size: 64,
+            jack_ids: Vec::from_slice(&[3, 7]).unwrap(),
+        };
+        let ports = input_ports(2, &endpoint, 5).unwrap();
+        let transfer = [0x19, 0x90, 60, 100];
+        let mut packets = ReceivedMidiPackets {
+            chunks: transfer.chunks_exact(EVENT_PACKET_SIZE),
+            ports: &ports,
+        };
+
+        let received = packets.next().unwrap();
+        assert_eq!(received.port(), ports[1]);
+        assert_eq!(received.data(), Some(&[0x90, 60, 100][..]));
+        assert!(packets.next().is_none());
+    }
+
+    #[test]
+    fn supplies_one_implicit_port_without_jack_associations() {
+        let endpoint = MidiEndpointDescriptor {
+            address: 0x02,
+            max_packet_size: 64,
+            jack_ids: Vec::new(),
+        };
+        let ports = output_ports(1, &endpoint, 4).unwrap();
+
+        assert_eq!(ports.len(), 1);
+        assert_eq!(ports[0].cable(), 0);
+        assert_eq!(ports[0].jack_id(), 0);
+    }
+
+    fn interface(alternate_setting: u8, endpoints: &[MidiEndpointDescriptor]) -> MidiStreamingInterface {
+        MidiStreamingInterface {
+            interface_number: 1,
+            alternate_setting,
+            header: None,
+            in_jacks: Vec::new(),
+            out_jacks: Vec::new(),
+            endpoints: Vec::from_slice(endpoints).unwrap(),
+        }
+    }
+
+    fn endpoint(address: u8) -> MidiEndpointDescriptor {
+        MidiEndpointDescriptor {
+            address,
+            max_packet_size: 64,
+            jack_ids: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn selects_input_output_and_duplex_topologies() {
+        let input = endpoint(0x81);
+        let output = endpoint(0x02);
+
+        let interfaces = [interface(0, core::slice::from_ref(&input))];
+        let (_, selected_input, selected_output) = select_streaming_interface(&interfaces).unwrap();
+        assert_eq!(selected_input.unwrap().address, input.address);
+        assert!(selected_output.is_none());
+
+        let interfaces = [interface(0, core::slice::from_ref(&output))];
+        let (_, selected_input, selected_output) = select_streaming_interface(&interfaces).unwrap();
+        assert!(selected_input.is_none());
+        assert_eq!(selected_output.unwrap().address, output.address);
+
+        let interfaces = [interface(0, &[input.clone(), output.clone()])];
+        let (_, selected_input, selected_output) = select_streaming_interface(&interfaces).unwrap();
+        assert_eq!(selected_input.unwrap().address, input.address);
+        assert_eq!(selected_output.unwrap().address, output.address);
+    }
+
+    #[test]
+    fn rejects_missing_and_ambiguous_topologies() {
+        assert!(matches!(select_streaming_interface(&[]), Err(MidiError::NoInterface)));
+
+        let input = endpoint(0x81);
+        let output = endpoint(0x02);
+        let interfaces = [interface(1, core::slice::from_ref(&input))];
+        assert!(matches!(
+            select_streaming_interface(&interfaces),
+            Err(MidiError::NoInterface)
+        ));
+
+        let interfaces = [
+            interface(0, core::slice::from_ref(&input)),
+            interface(0, core::slice::from_ref(&output)),
+        ];
+        assert!(matches!(
+            select_streaming_interface(&interfaces),
+            Err(MidiError::UnsupportedTopology)
+        ));
+
+        let interfaces = [interface(0, &[input.clone(), input])];
+        assert!(matches!(
+            select_streaming_interface(&interfaces),
+            Err(MidiError::UnsupportedTopology)
+        ));
+    }
+}

--- a/embassy-usb-host/src/class/midi/mod.rs
+++ b/embassy-usb-host/src/class/midi/mod.rs
@@ -14,7 +14,8 @@ mod descriptors;
 mod transport;
 
 use descriptors::{
-    MAX_MIDI_JACKS, MidiDescriptorError, MidiEndpointDescriptor, MidiStreamingInterface, parse_midi_interfaces,
+    MAX_MIDI_JACKS, MidiDescriptorError, MidiEndpointDescriptor, MidiStreamingInterface,
+    parse_midi_interfaces_for_device,
 };
 
 /// Advanced descriptor and endpoint-level USB-MIDI APIs.
@@ -280,7 +281,7 @@ pub struct MidiHost<'d, A: UsbHostAllocator<'d>> {
 impl<'d, A: UsbHostAllocator<'d>> MidiHost<'d, A> {
     /// Discover the MIDI ports and allocate the available bulk pipes.
     pub fn new(alloc: &A, config_desc: &[u8], enum_info: &EnumerationInfo) -> Result<Self, MidiError> {
-        let interfaces = parse_midi_interfaces(config_desc)?;
+        let interfaces = parse_midi_interfaces_for_device(&enum_info.device_desc, config_desc)?;
         let (interface, input_endpoint, output_endpoint) = select_streaming_interface(&interfaces)?;
 
         let receiver = Receiver::open(alloc, interface, input_endpoint, enum_info)?;

--- a/embassy-usb-host/src/class/midi/mod.rs
+++ b/embassy-usb-host/src/class/midi/mod.rs
@@ -490,10 +490,15 @@ impl Iterator for ReceivedMidiPackets<'_> {
     type Item = ReceivedMidiPacket;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let chunk = self.chunks.next()?;
-        let packet = UsbMidiEventPacket::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
-        let port = self.ports.iter().find(|port| port.cable == packet.cable()).copied()?;
-        Some(ReceivedMidiPacket { port, packet })
+        loop {
+            let chunk = self.chunks.next()?;
+            let packet = UsbMidiEventPacket::new([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            if packet.data().is_none() {
+                continue;
+            }
+            let port = self.ports.iter().find(|port| port.cable == packet.cable()).copied()?;
+            return Some(ReceivedMidiPacket { port, packet });
+        }
     }
 }
 
@@ -673,7 +678,7 @@ mod tests {
             jack_ids: Vec::from_slice(&[3, 7]).unwrap(),
         };
         let ports = input_ports(2, &endpoint, 5).unwrap();
-        let transfer = [0x19, 0x90, 60, 100];
+        let transfer = [0, 0, 0, 0, 0x19, 0x90, 60, 100, 0, 0, 0, 0];
         let mut packets = ReceivedMidiPackets {
             chunks: transfer.chunks_exact(EVENT_PACKET_SIZE),
             ports: &ports,

--- a/embassy-usb-host/src/class/midi/transport.rs
+++ b/embassy-usb-host/src/class/midi/transport.rs
@@ -1,0 +1,106 @@
+//! Low-level USB-MIDI bulk endpoint transports.
+
+use embassy_usb_driver::host::{UsbHostAllocator, UsbPipe, pipe};
+use embassy_usb_driver::{EndpointAddress, EndpointInfo, EndpointType};
+
+use super::{EVENT_PACKET_SIZE, MidiEndpointDescriptor, MidiError};
+use crate::handler::EnumerationInfo;
+
+/// Device-to-host USB-MIDI bulk transport.
+pub struct MidiInputPipe<'d, A: UsbHostAllocator<'d>> {
+    pipe: A::Pipe<pipe::Bulk, pipe::In>,
+}
+
+impl<'d, A: UsbHostAllocator<'d>> MidiInputPipe<'d, A> {
+    /// Allocate a pipe for a device-to-host MIDI endpoint.
+    pub fn open(alloc: &A, endpoint: &MidiEndpointDescriptor, enum_info: &EnumerationInfo) -> Result<Self, MidiError> {
+        if !endpoint.is_in() {
+            return Err(MidiError::WrongDirection);
+        }
+        let endpoint = EndpointInfo {
+            addr: EndpointAddress::from(endpoint.address),
+            ep_type: EndpointType::Bulk,
+            max_packet_size: endpoint.max_packet_size,
+            interval_ms: 0,
+        };
+        let pipe = alloc
+            .alloc_pipe::<pipe::Bulk, pipe::In>(enum_info.device_address, &endpoint, enum_info.split())
+            .map_err(|_| MidiError::NoPipe)?;
+        Ok(Self { pipe })
+    }
+
+    /// Receive one USB bulk transfer containing complete event packets.
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<usize, MidiError> {
+        check_transfer_buffer(buffer)?;
+        let length = self.pipe.request_in(buffer).await?;
+        if length % EVENT_PACKET_SIZE != 0 {
+            return Err(MidiError::InvalidPacketLength);
+        }
+        Ok(length)
+    }
+}
+
+/// Host-to-device USB-MIDI bulk transport.
+pub struct MidiOutputPipe<'d, A: UsbHostAllocator<'d>> {
+    pipe: A::Pipe<pipe::Bulk, pipe::Out>,
+}
+
+impl<'d, A: UsbHostAllocator<'d>> MidiOutputPipe<'d, A> {
+    /// Allocate a pipe for a host-to-device MIDI endpoint.
+    pub fn open(alloc: &A, endpoint: &MidiEndpointDescriptor, enum_info: &EnumerationInfo) -> Result<Self, MidiError> {
+        if endpoint.is_in() {
+            return Err(MidiError::WrongDirection);
+        }
+        let endpoint = EndpointInfo {
+            addr: EndpointAddress::from(endpoint.address),
+            ep_type: EndpointType::Bulk,
+            max_packet_size: endpoint.max_packet_size,
+            interval_ms: 0,
+        };
+        let pipe = alloc
+            .alloc_pipe::<pipe::Bulk, pipe::Out>(enum_info.device_address, &endpoint, enum_info.split())
+            .map_err(|_| MidiError::NoPipe)?;
+        Ok(Self { pipe })
+    }
+
+    /// Send one USB bulk transfer containing complete event packets.
+    pub async fn write(&mut self, packets: &[u8]) -> Result<(), MidiError> {
+        check_transfer_buffer(packets)?;
+        self.pipe.request_out(packets, false).await?;
+        Ok(())
+    }
+}
+
+fn check_transfer_buffer(buffer: &[u8]) -> Result<(), MidiError> {
+    if buffer.is_empty() || !buffer.len().is_multiple_of(EVENT_PACKET_SIZE) {
+        return Err(MidiError::InvalidPacketLength);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_one_or_more_complete_event_packets() {
+        assert!(check_transfer_buffer(&[0; EVENT_PACKET_SIZE]).is_ok());
+        assert!(check_transfer_buffer(&[0; EVENT_PACKET_SIZE * 4]).is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_and_partial_event_packets() {
+        assert!(matches!(
+            check_transfer_buffer(&[]),
+            Err(MidiError::InvalidPacketLength)
+        ));
+        assert!(matches!(
+            check_transfer_buffer(&[0; EVENT_PACKET_SIZE - 1]),
+            Err(MidiError::InvalidPacketLength)
+        ));
+        assert!(matches!(
+            check_transfer_buffer(&[0; EVENT_PACKET_SIZE + 1]),
+            Err(MidiError::InvalidPacketLength)
+        ));
+    }
+}

--- a/embassy-usb-host/src/class/mod.rs
+++ b/embassy-usb-host/src/class/mod.rs
@@ -6,6 +6,7 @@ pub mod hid;
 pub mod hid_report;
 pub mod hub;
 pub mod kbd;
+pub mod midi;
 pub mod msc;
 pub mod uac;
 pub mod vcp;


### PR DESCRIPTION
Two layer host USB midi class - coded with assistance from Claude.
* Low-level config parser `parse_midi_interfaces`, in/out Pipes and midi event packet parser and iterator
* High-level `MidiHost` abstraction with `Sender` and `Receiver` splitter and a preparsed vecs of in/out ports (Jacks).

## Low level enumeration and use
```
let interfaces = parse_midi_interfaces(config_bytes)?;
  let interface = &interfaces[0];

  let input_ep = interface.endpoints.iter().find(|ep| ep.is_in()).unwrap();
  let output_ep = interface.endpoints.iter().find(|ep| !ep.is_in()).unwrap();

  let mut input = MidiInputPipe::open(&usb_host, input_ep, &enumeration)?;
  let mut output = MidiOutputPipe::open(&usb_host, output_ep, &enumeration)?;

  let note = UsbMidiEventPacket::from_midi_bytes(0, &[0x90, 60, 100])?;
  output.write(note.as_bytes()).await?;

  let length = input.read(&mut buffer).await?;
  for packet in event_packets(&buffer[..length])? {
      process(packet.cable(), packet.data());
  }
```

## High level use
```
  let midi = MidiHost::new(&usb_host, config_bytes, &enumeration)?;
  let (mut sender, mut receiver) = midi.split();

  if let Some(&port) = sender.ports().first() {
      sender.send(port, &[0x90, 60, 100]).await?;
  }

  for received in receiver.receive(&mut buffer).await? {
      process(received.port(), received.data());
  }
```


