### PR TITLE
stm32/usart: Don't drop the incorrect pin when Rx/Tx are swapped

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1567,6 +1567,12 @@ impl<'d, M: Mode> Uart<'d, M> {
         let state = T::state();
         let kernel_clock = T::frequency();
 
+        // Make sure we assign the correct pins to the correct instance.
+        // Otherwise, the USART stops working if we drop one half of the
+        // tuple returned by self.split().
+        #[cfg(any(usart_v3, usart_v4))]
+        let (rx, tx) = if config.swap_rx_tx { (tx, rx) } else { (rx, tx) };
+
         let mut this = Self {
             tx: UartTx {
                 _marker: PhantomData,


### PR DESCRIPTION
It turns out, when dropping the `UartRx` half, it drops the pin acting as Tx, which makes `UartTx` no longer work, which is bad.