### PR TITLE
fix(embassy-rp): Transform pre_init rust to asm ..

### DIFF
--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -643,7 +643,7 @@ pub fn init(config: config::Config) -> Peripherals {
 // #[pre_init] code converted to ASM
 //
 // As per [https://docs.rs/cortex-m-rt/0.7.5/cortex_m_rt/#features] - a #[pre_init] macro is also
-// provided to run a function before RAM initialisation, but its use is deprecated as it is not 
+// provided to run a function before RAM initialisation, but its use is deprecated as it is not
 // defined behaviour to execute Rust code before initialisation.
 // It is still possible to create a custom pre_init function using assembly.
 //

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -640,8 +640,12 @@ pub fn init(config: config::Config) -> Peripherals {
     peripherals
 }
 
-// `cortex-m-rt` calls `__pre_init` before it initializes RAM, so this must be assembly rather than
-// a Rust function.
+// #[pre_init] code converted to ASM
+//
+// As per [https://docs.rs/cortex-m-rt/0.7.5/cortex_m_rt/#features] - a #[pre_init] macro is also
+// provided to run a function before RAM initialisation, but its use is deprecated as it is not 
+// defined behaviour to execute Rust code before initialisation.
+// It is still possible to create a custom pre_init function using assembly.
 //
 // SIO does not get reset when core0 is reset with either `scb::sys_reset()` or with SWD.
 // Since we're using SIO spinlock 31 for the critical-section impl, this causes random

--- a/embassy-rp/src/lib.rs
+++ b/embassy-rp/src/lib.rs
@@ -640,71 +640,140 @@ pub fn init(config: config::Config) -> Peripherals {
     peripherals
 }
 
-// TODO: change pre_init to ASM.
-// we're using export_name manually to workaround cortex-m-rt deprecating it.
+// `cortex-m-rt` calls `__pre_init` before it initializes RAM, so this must be assembly rather than
+// a Rust function.
+//
+// SIO does not get reset when core0 is reset with either `scb::sys_reset()` or with SWD.
+// Since we're using SIO spinlock 31 for the critical-section impl, this causes random
+// hangs if we reset in the middle of a CS, because the next boot sees the spinlock
+// as locked and waits forever.
+//
+// See https://github.com/embassy-rs/embassy/issues/1736
+// and https://github.com/rp-rs/rp-hal/issues/292
+// and https://matrix.to/#/!vhKMWjizPZBgKeknOo:matrix.org/$VfOkQgyf1PjmaXZbtycFzrCje1RorAXd8BQFHTl4d5M
+//
+// According to Raspberry Pi, this is considered Working As Intended, and not an errata,
+// even though this behavior is different from every other ARM chip (sys_reset usually resets
+// the *system* as its name implies, not just the current core).
+//
+// To fix this, reset SIO on boot. We must do this in pre_init because it's unsound to do it
+// in `embassy_rp::init`, since the user could've acquired a CS by then. pre_init is guaranteed
+// to run before any user code.
+//
+// A similar thing could happen with PROC1. It is unclear whether it's possible for PROC1
+// to stay unreset through a PROC0 reset, so we reset it anyway just in case.
+//
+// Important info from PSM logic (from Luke Wren in above Matrix thread)
+//
+//     The logic is, each PSM stage is reset if either of the following is true:
+//     - The previous stage is in reset and FRCE_ON is false
+//     - FRCE_OFF is true
+//
+// The PSM order is SIO -> PROC0 -> PROC1.
+// So, we have to force-on PROC0 to prevent it from getting reset when resetting SIO.
 #[cfg(feature = "rt")]
-#[unsafe(export_name = "__pre_init")]
-unsafe fn pre_init() {
-    // SIO does not get reset when core0 is reset with either `scb::sys_reset()` or with SWD.
-    // Since we're using SIO spinlock 31 for the critical-section impl, this causes random
-    // hangs if we reset in the middle of a CS, because the next boot sees the spinlock
-    // as locked and waits forever.
-    //
-    // See https://github.com/embassy-rs/embassy/issues/1736
-    // and https://github.com/rp-rs/rp-hal/issues/292
-    // and https://matrix.to/#/!vhKMWjizPZBgKeknOo:matrix.org/$VfOkQgyf1PjmaXZbtycFzrCje1RorAXd8BQFHTl4d5M
-    //
-    // According to Raspberry Pi, this is considered Working As Intended, and not an errata,
-    // even though this behavior is different from every other ARM chip (sys_reset usually resets
-    // the *system* as its name implies, not just the current core).
-    //
-    // To fix this, reset SIO on boot. We must do this in pre_init because it's unsound to do it
-    // in `embassy_rp::init`, since the user could've acquired a CS by then. pre_init is guaranteed
-    // to run before any user code.
-    //
-    // A similar thing could happen with PROC1. It is unclear whether it's possible for PROC1
-    // to stay unreset through a PROC0 reset, so we reset it anyway just in case.
-    //
-    // Important info from PSM logic (from Luke Wren in above Matrix thread)
-    //
-    //     The logic is, each PSM stage is reset if either of the following is true:
-    //     - The previous stage is in reset and FRCE_ON is false
-    //     - FRCE_OFF is true
-    //
-    // The PSM order is SIO -> PROC0 -> PROC1.
-    // So, we have to force-on PROC0 to prevent it from getting reset when resetting SIO.
-    #[cfg(feature = "rp2040")]
-    {
-        pac::PSM.frce_on().write_and_wait(|w| {
-            w.set_proc0(true);
-        });
-        // Then reset SIO and PROC1.
-        pac::PSM.frce_off().write_and_wait(|w| {
-            w.set_sio(true);
-            w.set_proc1(true);
-        });
-        // clear force_off first, force_on second. The other way around would reset PROC0.
-        pac::PSM.frce_off().write_and_wait(|_| {});
-        pac::PSM.frce_on().write_and_wait(|_| {});
-    }
+#[cfg(feature = "rp2040")]
+core::arch::global_asm!(
+    r#"
+    .syntax unified
+    .section .text.__pre_init, "ax"
+    .global __pre_init
+    .type __pre_init, %function
+    .thumb_func
+__pre_init:
+    // pac::PSM.frce_on().write_and_wait(|w| w.set_proc0(true));
+    movs r1, #1
+    lsls r1, r1, #15
+    ldr r0, =0x40010000
+    str r1, [r0]
+.Lrp2040_wait_frce_on_set:
+    ldr r2, [r0]
+    cmp r2, r1
+    bne .Lrp2040_wait_frce_on_set
 
-    #[cfg(feature = "_rp235x")]
-    {
-        // on RP235x, datasheet says "The FRCE_ON register is a development feature that does nothing in production devices."
-        // No idea why they removed it. Removing it means we can't use PSM to reset SIO, because it comes before
-        // PROC0, so we'd need FRCE_ON to prevent resetting ourselves.
-        //
-        // So we just unlock the spinlock manually.
-        pac::SIO.spinlock(31).write_value(1);
+    // pac::PSM.frce_off().write_and_wait(|w| {{
+    //     w.set_sio(true);
+    //     w.set_proc1(true);
+    // }});
+    movs r1, #5
+    lsls r1, r1, #14
+    str r1, [r0, #4]
+.Lrp2040_wait_frce_off_set:
+    ldr r2, [r0, #4]
+    cmp r2, r1
+    bne .Lrp2040_wait_frce_off_set
 
-        // We can still use PSM to reset PROC1 since it comes after PROC0 in the state machine.
-        pac::PSM.frce_off().write_and_wait(|w| w.set_proc1(true));
-        pac::PSM.frce_off().write_and_wait(|_| {});
+    // pac::PSM.frce_off().write_and_wait(|_| {{}});
+    movs r1, #0
+    str r1, [r0, #4]
+.Lrp2040_wait_frce_off_clear:
+    ldr r2, [r0, #4]
+    cmp r2, r1
+    bne .Lrp2040_wait_frce_off_clear
 
-        // Make atomics work between cores.
-        enable_actlr_extexclall();
-    }
-}
+    // pac::PSM.frce_on().write_and_wait(|_| {{}});
+    str r1, [r0]
+.Lrp2040_wait_frce_on_clear:
+    ldr r2, [r0]
+    cmp r2, r1
+    bne .Lrp2040_wait_frce_on_clear
+
+    bx lr
+    .size __pre_init, . - __pre_init
+"#
+);
+
+// On RP235x, datasheet says "The FRCE_ON register is a development feature that does nothing in production devices."
+// No idea why they removed it. Removing it means we can't use PSM to reset SIO, because it comes before
+// PROC0, so we'd need FRCE_ON to prevent resetting ourselves.
+//
+// So we just unlock the spinlock manually.
+//
+// We can still use PSM to reset PROC1 since it comes after PROC0 in the state machine.
+#[cfg(feature = "rt")]
+#[cfg(feature = "_rp235x")]
+core::arch::global_asm!(
+    r#"
+    .syntax unified
+    .section .text.__pre_init, "ax"
+    .global __pre_init
+    .type __pre_init, %function
+    .thumb_func
+__pre_init:
+    // pac::SIO.spinlock(31).write_value(1);
+    ldr r0, =0xd000017c
+    movs r1, #1
+    str r1, [r0]
+
+    // pac::PSM.frce_off().write_and_wait(|w| w.set_proc1(true));
+    ldr r0, =0x40018004
+    lsls r1, r1, #24
+    str r1, [r0]
+.Lrp235x_wait_frce_off_set:
+    ldr r2, [r0]
+    cmp r2, r1
+    bne .Lrp235x_wait_frce_off_set
+
+    // pac::PSM.frce_off().write_and_wait(|_| {{}});
+    movs r1, #0
+    str r1, [r0]
+.Lrp235x_wait_frce_off_clear:
+    ldr r2, [r0]
+    cmp r2, r1
+    bne .Lrp235x_wait_frce_off_clear
+
+    // (&*cortex_m::peripheral::ICB::PTR).actlr.modify(|w| w | (1 << 29));
+    ldr r0, =0xe000e008
+    ldr r1, [r0]
+    movs r2, #1
+    lsls r2, r2, #29
+    orrs r1, r2
+    str r1, [r0]
+
+    bx lr
+    .size __pre_init, . - __pre_init
+"#
+);
 
 /// Set the EXTEXCLALL bit in ACTLR.
 ///
@@ -715,7 +784,8 @@ unsafe fn pre_init() {
 /// TODO: does this interfere somehow if the user wants to use a custom MPU configuration?
 /// maybe we need to add a way to disable this?
 ///
-/// This must be done FOR EACH CORE.
+/// This must be done FOR EACH CORE. Core 0 does this in `__pre_init`; this function is
+/// called after runtime initialization for core 1.
 #[cfg(feature = "_rp235x")]
 unsafe fn enable_actlr_extexclall() {
     (&*cortex_m::peripheral::ICB::PTR).actlr.modify(|w| w | (1 << 29));
@@ -728,9 +798,6 @@ trait RegExt<T: Copy> {
     fn write_xor<R>(&self, f: impl FnOnce(&mut T) -> R) -> R;
     fn write_set<R>(&self, f: impl FnOnce(&mut T) -> R) -> R;
     fn write_clear<R>(&self, f: impl FnOnce(&mut T) -> R) -> R;
-    fn write_and_wait<R>(&self, f: impl FnOnce(&mut T) -> R) -> R
-    where
-        T: PartialEq;
 }
 
 impl<T: Default + Copy, A: pac::common::Write> RegExt<T> for pac::common::Reg<T, A> {
@@ -760,19 +827,6 @@ impl<T: Default + Copy, A: pac::common::Write> RegExt<T> for pac::common::Reg<T,
         unsafe {
             let ptr = (self.as_ptr() as *mut u8).add(0x3000) as *mut T;
             ptr.write_volatile(val);
-        }
-        res
-    }
-
-    fn write_and_wait<R>(&self, f: impl FnOnce(&mut T) -> R) -> R
-    where
-        T: PartialEq,
-    {
-        let mut val = Default::default();
-        let res = f(&mut val);
-        unsafe {
-            self.as_ptr().write_volatile(val);
-            while self.as_ptr().read_volatile() != val {}
         }
         res
     }


### PR DESCRIPTION
`cortex-m-rt` 0.7.6 deprecated the `#[pre_init]` macro. It still exists but emits a deprecation warning, which becomes a CI failure under -D warnings.

Disassembled the rust code, for `rp2040` and `rp235xb`, and grafted it onto `lib.rs` .. interjecting rust+asm for validation purposes.

## RP2040 
cargo +1.97.1 objdump --release --bin pio_irq --target thumbv6m-none-eabi --no-default-features --features rp2040 -d --disassemble-symbols=__pre_init

20001558 <__pre_init>:
20001558: b580          push    {r7, lr}
2000155a: af00          add     r7, sp, #0x0

; pac::PSM.frce_on().write_and_wait(|w| {
;     w.set_proc0(true);
; });
2000155c: 2001          movs    r0, #0x1
2000155e: 03c1          lsls    r1, r0, #0xf
20001560: 480a          ldr     r0, [pc, #0x28]  ; 0x40010000
20001562: 6001          str     r1, [r0]
20001564: 6802          ldr     r2, [r0]
20001566: 428a          cmp     r2, r1
20001568: d1fc          bne     0x20001564

; pac::PSM.frce_off().write_and_wait(|w| {
;     w.set_sio(true);
;     w.set_proc1(true);
; });
2000156a: 2105          movs    r1, #0x5
2000156c: 0389          lsls    r1, r1, #0xe
2000156e: 6041          str     r1, [r0, #0x4]
20001570: 6842          ldr     r2, [r0, #0x4]
20001572: 428a          cmp     r2, r1
20001574: d1fc          bne     0x20001570

; pac::PSM.frce_off().write_and_wait(|_| {});
20001576: 2100          movs    r1, #0x0
20001578: 6041          str     r1, [r0, #0x4]
2000157a: 6842          ldr     r2, [r0, #0x4]
2000157c: 2a00          cmp     r2, #0x0
2000157e: d1fc          bne     0x2000157a

; pac::PSM.frce_on().write_and_wait(|_| {});
20001580: 6001          str     r1, [r0]
20001582: 6801          ldr     r1, [r0]
20001584: 2900          cmp     r1, #0x0
20001586: d1fc          bne     0x20001582

20001588: bd80          pop     {r7, pc}
2000158a: 46c0          mov     r8, r8

## RP235xb
-- cargo +1.97.1 build --release --bin pio_irq --target thumbv6m-none-eabi --no-default-features --features rp235xb -d --disassemble-symbols=__pre_init

20001798 <__pre_init>:
20001798: b580          push    {r7, lr}
2000179a: 466f          mov     r7, sp

; pac::SIO.spinlock(31).write_value(1);
2000179c: f240 107c     movw    r0, #0x17c
200017a0: 2101          movs    r1, #0x1
200017a2: f2cd 0000     movt    r0, #0xd000
200017a6: 6001          str     r1, [r0]

; pac::PSM.frce_off().write_and_wait(|w| w.set_proc1(true));
200017a8: f248 0004     movw    r0, #0x8004
200017ac: f2c4 0001     movt    r0, #0x4001
200017b0: f04f 7180     mov.w   r1, #0x1000000
200017b4: 6001          str     r1, [r0]
200017b6: 6801          ldr     r1, [r0]
200017b8: f1b1 7f80     cmp.w   r1, #0x1000000
200017bc: d1fb          bne     0x200017b6

; pac::PSM.frce_off().write_and_wait(|_| {});
200017be: 2100          movs    r1, #0x0
200017c0: 6001          str     r1, [r0]
200017c2: 6801          ldr     r1, [r0]
200017c4: 2900          cmp     r1, #0x0
200017c6: d1fc          bne     0x200017c2

; enable_actlr_extexclall();
; ACTLR |= 1 << 29
200017c8: f24e 0008     movw    r0, #0xe008
200017cc: f2ce 0000     movt    r0, #0xe000
200017d0: 6801          ldr     r1, [r0]
200017d2: f041 5100     orr     r1, r1, #0x20000000
200017d6: 6001          str     r1, [r0]

200017d8: bd80          pop     {r7, pc}

Work done with assistance of Codex.
