### PR TITLE
nrf/cracen: program the RNG health-test cut-offs on nRF54LM20A

### DIFF
--- a/embassy-nrf/src/cracen.rs
+++ b/embassy-nrf/src/cracen.rs
@@ -7,6 +7,21 @@ use core::marker::PhantomData;
 use crate::mode::{Blocking, Mode};
 use crate::{Peri, interrupt, pac, peripherals};
 
+/// TRNG health-test cut-offs for CRACEN Lite, from NCS `RNG_REPEATTHRESHOLD_VAL` and
+/// `RNG_PROPTESTCUTOFF_VAL`.
+///
+/// These registers reset to 4 and 13, which a working noise source fails, and they revert
+/// whenever CRACEN is powered down — which `stop_rng` does after every call. NCS programs
+/// them on every power-up in `cracen_acquire`, calling it a workaround for incorrect
+/// hardware defaults on CRACEN Lite.
+///
+/// Only CRACEN Lite is affected, hence the cfg: nRF54L15/L10/L05 reset the same registers
+/// to 41 and 793, which are sane, and NCS does not apply the workaround to them either.
+#[cfg(feature = "_nrf54lm20")]
+const RNG_REPEATTHRESHOLD_VAL: u8 = 21;
+#[cfg(feature = "_nrf54lm20")]
+const RNG_PROPTESTCUTOFF_VAL: u16 = 311;
+
 /// A wrapper around an nRF54 CRACEN peripheral.
 ///
 /// It has a blocking api through `rand`.
@@ -31,11 +46,26 @@ impl<'d, M: Mode> Cracen<'d, M> {
         pac::CRACENCORE
     }
 
+    /// Program the health-test cut-offs. Must happen after every power-up, since the
+    /// registers revert with the block.
+    #[cfg(feature = "_nrf54lm20")]
+    fn configure_health_tests() {
+        let r = Self::core().rngcontrol();
+        r.repeatthreshold()
+            .write(|w| w.set_repeatthreshold(RNG_REPEATTHRESHOLD_VAL));
+        r.proptestcutoff()
+            .write(|w| w.set_proptestcutoff(RNG_PROPTESTCUTOFF_VAL));
+    }
+
     fn start_rng(&self) {
         let r = Self::regs();
         r.enable().write(|w| {
             w.set_rng(true);
         });
+
+        // Before the RNG is started, and after the power-up that cleared them.
+        #[cfg(feature = "_nrf54lm20")]
+        Self::configure_health_tests();
 
         let r = Self::core();
 
@@ -44,7 +74,9 @@ impl<'d, M: Mode> Cracen<'d, M> {
             w.set_cooldownperiod(0);
         });
 
-        r.rngcontrol().control().write(|w| {
+        // Modify, not write: NB128BITBLOCKS defaults to 4 and zero is not a legal
+        // value, so the other fields have to survive the start.
+        r.rngcontrol().control().modify(|w| {
             w.set_enable(true);
         });
 
@@ -80,8 +112,29 @@ impl<'d, M: Mode> Cracen<'d, M> {
 
         let r = Self::core();
         for chunk in dest.chunks_mut(4) {
-            while r.rngcontrol().fifolevel().read() == 0 {}
-            let word = r.rngcontrol().fifo(0).read().to_ne_bytes();
+            // A failed health test parks the FSM in `Error`, where the FIFO never fills
+            // again — so without this check the poll never returns, and being a blocking
+            // loop in a sync fn it takes the whole executor with it. There is nothing to
+            // do but fail loudly: measured on an nRF54LM20A, neither a SoftRst nor
+            // reprogramming the cut-offs revives a TRNG that has already reached `Error`,
+            // only a reset of the part does, and an infallible API cannot report. The
+            // cut-offs programmed in `start_rng` are what keeps this unreached.
+            let word = loop {
+                if r.rngcontrol().fifolevel().read() != 0 {
+                    break r.rngcontrol().fifo(0).read();
+                }
+                let status = r.rngcontrol().status().read();
+                if status.state() == pac::cracencore::vals::State::Error {
+                    panic!(
+                        "CRACEN RNG health test failed (rep={} prop={} startup={}); it needs a reset to produce entropy again",
+                        status.repfail(),
+                        status.propfail(),
+                        status.startupfail()
+                    );
+                }
+            };
+
+            let word = word.to_ne_bytes();
             let to_copy = word.len().min(chunk.len());
             chunk[..to_copy].copy_from_slice(&word[..to_copy]);
         }


### PR DESCRIPTION
`blocking_fill_bytes` polls `while fifolevel == 0 {}` with no error check. On nRF54LM20A the RNG reliably stops producing entropy after a few tens of thousands of draws, at which point that loop never returns — and being a blocking loop in a sync fn, it takes the whole executor with it. A node using it stops answering entirely, with no diagnostic.

The cause is that this part's health-test cut-offs come up wrong. `RNGCONTROL.REPEATTHRESHOLD` and `PROPTESTCUTOFF` reset to **4** and **13**; the adaptive proportion test fails against a cut-off of 13, the control FSM parks in `Error`, and the FIFO never fills again. They revert on every CRACEN power-down, which `stop_rng` does after every call, so nothing keeps them right.

The nRF Connect SDK programs 21 and 311 on every CRACEN power-up and calls it a workaround for incorrect hardware defaults on CRACEN Lite (all links pinned to `v3.4.0`):

- [`cracen/Kconfig#L13-L14`](https://github.com/nrfconnect/sdk-nrf/blob/v3.4.0/subsys/nrf_security/src/drivers/cracen/Kconfig#L13-L14) — `CRACEN_HW_VERSION_LITE` is `def_bool SOC_NRF54LM20A || SOC_NRF54LM20B || ...`
- [`sxsymcrypt/src/trng.c#L30-L39`](https://github.com/nrfconnect/sdk-nrf/blob/v3.4.0/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/trng.c#L30-L39) — the two values and `sx_trng_configure_cracen_lite_workaround()`
- [`common/src/cracen/hardware/hardware.c#L63-L72`](https://github.com/nrfconnect/sdk-nrf/blob/v3.4.0/subsys/nrf_security/src/drivers/cracen/common/src/cracen/hardware/hardware.c#L63-L72) — called from `cracen_acquire()`, with the comment that the registers "reset to incorrect default values when CRACEN is powered down" and must be reconfigured on every power-up "to prevent entropy errors"
- [`sxsymcrypt/include/sxsymcrypt/trng.h#L211-L222`](https://github.com/nrfconnect/sdk-nrf/blob/v3.4.0/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/include/sxsymcrypt/trng.h#L211-L222) — the same, in the API documentation

This is CRACEN Lite only, and that is from the datasheets rather than only from NCS's Kconfig — nRF54L15/L10/L05 reset the same two registers to 41 and 793, which are sane, and NCS does not apply the workaround to them:

| Register (offset) | nRF54L15/L10/L05 | nRF54LM20A | NCS Lite |
|---|---|---|---|
| `REPEATTHRESHOLD` (0x1024) | 41 | 4 | 21 |
| `PROPTHRESHOLD`/`PROPTESTCUTOFF` (0x1028) | 793 | 13 | 311 |

Measured on hardware, running this driver's exact sequence — power up, enable, read one word, power down — as fast as the part allows:

```
unpatched                       fails at cycle 9472 and 38396 in two runs,
                                and then on every cycle after that (32.6M in a row)
cut-offs programmed             8.6M cycles, no failures
cut-offs programmed after
it has already failed           20.6M cycles, every one still failing
```

So this prevents the failure and cannot cure it. A retry loop would be useless: neither a `SoftRst` pulse nor reprogramming the cut-offs revives a TRNG that has already reached `Error` — only a reset of the part does. The poll therefore gains a check that panics rather than spinning, since an infallible API has no way to report and a silent executor-wide hang is the worst of the options. That follows `embassy-stm32`'s RNG, which panics when its resets are exhausted.

Also switch the enable in `start_rng` from `write` to `modify`. `NB128BITBLOCKS` resets to 4 and the datasheet says zero is not a legal value, but a plain write zeroes it along with the rest of the register; NCS writes the field explicitly ([`trng.c#L135-L137`](https://github.com/nrfconnect/sdk-nrf/blob/v3.4.0/subsys/nrf_security/src/drivers/cracen/sxsymcrypt/src/trng.c#L135-L137)).

Related: #6756 reports the same failure mode on RP2350, where the blocking TRNG API stops making progress after health checks fail.

Builds for `nrf54lm20-app-s`, `nrf54l15-app-s`, `nrf54l10-app-s` and `nrf54l05-app-s`, with `defmt`, with `log`, and with neither.
