### PR TITLE
Fix saadc pins on nRF54LM20

### DIFF
--- a/embassy-nrf/src/chips/nrf54lm20_app.rs
+++ b/embassy-nrf/src/chips/nrf54lm20_app.rs
@@ -789,14 +789,14 @@ impl_uarte!(SERIAL22, UARTE22, SERIAL22);
 impl_uarte!(SERIAL30, UARTE30, SERIAL30);
 
 // NB: SAADC uses "pin" abstraction, not "AIN"
-impl_saadc_input!(P1_04, 1, 4);
-impl_saadc_input!(P1_05, 1, 5);
-impl_saadc_input!(P1_06, 1, 6);
-impl_saadc_input!(P1_07, 1, 7);
-impl_saadc_input!(P1_11, 1, 11);
-impl_saadc_input!(P1_12, 1, 12);
-impl_saadc_input!(P1_13, 1, 13);
-impl_saadc_input!(P1_14, 1, 14);
+impl_saadc_input!(P1_00, 1, 0); // AIN0
+impl_saadc_input!(P1_31, 1, 31); // AIN1
+impl_saadc_input!(P1_30, 1, 30); // AIN2
+impl_saadc_input!(P1_29, 1, 29); // AIN3
+impl_saadc_input!(P1_06, 1, 6); // AIN4
+impl_saadc_input!(P1_05, 1, 5); // AIN5
+impl_saadc_input!(P1_04, 1, 4); // AIN6
+impl_saadc_input!(P1_03, 1, 3); // AIN7
 
 #[cfg(feature = "_s")]
 impl_cracen!(CRACEN, CRACEN, CRACEN);


### PR DESCRIPTION
Update nrf54lm20's AIN pins according to the datasheet