### PR TITLE
stm32/usart: Add support for synchronous USART communication

### DIFF
--- a/embassy-stm32/src/usart/buffered.rs
+++ b/embassy-stm32/src/usart/buffered.rs
@@ -532,7 +532,18 @@ impl<'d> BufferedUart<'d> {
                 .min(config.rx_fifo_threshold),
             );
         });
-        configure(info, self.rx.kernel_clock, &config, true, true)?;
+
+        // TODO support synchronous USART
+        configure(
+            info,
+            self.rx.kernel_clock,
+            &config,
+            false,
+            true,
+            true,
+            #[cfg(usart_v4)]
+            false,
+        )?;
 
         info.regs.cr1().modify(|w| {
             w.set_rxneie(cfg!(not(usart_v4)));

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -11,6 +11,7 @@ use embassy_embedded_hal::SetConfig;
 use embassy_hal_internal::PeripheralType;
 use embassy_hal_internal::drop::OnDrop;
 use embassy_sync::waitqueue::AtomicWaker;
+pub use embedded_hal_02::spi::{Phase, Polarity};
 use futures_util::future::{Either, select};
 
 use crate::Peri;
@@ -19,7 +20,7 @@ use crate::dma::ChannelAndRequest;
 use crate::gpio::{AfType, Flex, OutputType, Pull, Speed};
 use crate::interrupt::typelevel::Interrupt as _;
 use crate::interrupt::{self, Interrupt, InterruptExt};
-use crate::mode::{Async, Blocking, Mode};
+use crate::mode::{Async, Blocking, Mode as PeriMode};
 #[cfg(not(any(usart_v1, usart_v2)))]
 use crate::pac::usart::Lpuart as Regs;
 #[cfg(any(usart_v1, usart_v2))]
@@ -183,6 +184,17 @@ impl Duplex {
     }
 }
 
+/// USART synchronous mode
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Mode {
+    /// Clock polarity
+    pub polarity: Polarity,
+    /// Clock phase
+    pub phase: Phase,
+    /// Output a clock pulse on the last bit if this flag is set to `true`
+    pub last_bit: bool,
+}
+
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
@@ -207,7 +219,7 @@ pub enum ConfigError {
 }
 
 #[non_exhaustive]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 /// Config
 pub struct Config {
     /// Baud rate
@@ -218,6 +230,9 @@ pub struct Config {
     pub stop_bits: StopBits,
     /// Parity type
     pub parity: Parity,
+
+    /// Clock mode (when the USART is used in synchronous mode)
+    pub mode: Mode,
 
     /// If true: on a read-like method, if there is a latent error pending,
     /// the read will abort and the error will be reported and cleared
@@ -261,11 +276,18 @@ pub struct Config {
     /// Set this to true to enable the IrDA mode register
     pub irda_enable: bool,
 
+    /// Set the pull configuration for the CK pin (if in synchronous slave mode).
+    #[cfg(usart_v4)]
+    pub ck_pull: Pull,
+
     /// Set the pull configuration for the RX pin.
     pub rx_pull: Pull,
 
     /// Set the pull configuration for the CTS pin.
     pub cts_pull: Pull,
+
+    /// Set the pin configuration for the CK pin (if in synchronous master mode).
+    pub ck_config: OutputConfig,
 
     /// Set the pin configuration for the TX pin.
     pub tx_config: OutputConfig,
@@ -312,6 +334,20 @@ impl Config {
         };
         AfType::input(self.rx_pull)
     }
+
+    fn raw_polarity(&self) -> vals::Cpol {
+        match self.mode.polarity {
+            Polarity::IdleHigh => vals::Cpol::High,
+            Polarity::IdleLow => vals::Cpol::Low,
+        }
+    }
+
+    fn raw_phase(&self) -> vals::Cpha {
+        match self.mode.phase {
+            Phase::CaptureOnSecondTransition => vals::Cpha::Second,
+            Phase::CaptureOnFirstTransition => vals::Cpha::First,
+        }
+    }
 }
 
 impl Default for Config {
@@ -321,6 +357,11 @@ impl Default for Config {
             data_bits: DataBits::DataBits8,
             stop_bits: StopBits::STOP1,
             parity: Parity::ParityNone,
+            mode: Mode {
+                polarity: Polarity::IdleLow,
+                phase: Phase::CaptureOnFirstTransition,
+                last_bit: false,
+            },
             // historical behavior
             detect_previous_overrun: false,
             eager_reads: None,
@@ -333,8 +374,11 @@ impl Default for Config {
             #[cfg(any(usart_v3, usart_v4))]
             invert_rx: false,
             irda_enable: false,
+            #[cfg(usart_v4)]
+            ck_pull: Pull::None,
             rx_pull: Pull::None,
             cts_pull: Pull::None,
+            ck_config: OutputConfig::PushPull,
             tx_config: OutputConfig::PushPull,
             rts_config: OutputConfig::PushPull,
             de_config: OutputConfig::PushPull,
@@ -399,12 +443,13 @@ enum ReadCompletionEvent {
 ///
 /// See [`UartRx`] for more details, and see [`BufferedUart`] and [`RingBufferedUartRx`]
 /// as alternatives that do provide the necessary guarantees for `embedded_io::Read`.
-pub struct Uart<'d, M: Mode> {
+#[doc(alias = "USART")]
+pub struct Uart<'d, M: PeriMode> {
     tx: UartTx<'d, M>,
     rx: UartRx<'d, M>,
 }
 
-impl<'d, M: Mode> SetConfig for Uart<'d, M> {
+impl<'d, M: PeriMode> SetConfig for Uart<'d, M> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -418,10 +463,11 @@ impl<'d, M: Mode> SetConfig for Uart<'d, M> {
 ///
 /// Can be obtained from [`Uart::split`], or can be constructed independently,
 /// if you do not need the receiving half of the driver.
-pub struct UartTx<'d, M: Mode> {
+pub struct UartTx<'d, M: PeriMode> {
     info: &'static Info,
     state: &'static State,
     kernel_clock: Hertz,
+    _ck: Option<Flex<'d>>,
     _tx: Option<Flex<'d>>,
     cts: Option<Flex<'d>>,
     _de: Option<Flex<'d>>,
@@ -430,7 +476,7 @@ pub struct UartTx<'d, M: Mode> {
     _marker: PhantomData<M>,
 }
 
-impl<'d, M: Mode> SetConfig for UartTx<'d, M> {
+impl<'d, M: PeriMode> SetConfig for UartTx<'d, M> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -468,10 +514,11 @@ impl<'d, M: Mode> SetConfig for UartTx<'d, M> {
 /// store data received between calls.
 ///
 /// Also see [this github comment](https://github.com/embassy-rs/embassy/pull/2185#issuecomment-1810047043).
-pub struct UartRx<'d, M: Mode> {
+pub struct UartRx<'d, M: PeriMode> {
     info: &'static Info,
     state: &'static State,
     kernel_clock: Hertz,
+    _ck: Option<Flex<'d>>,
     rx: Option<Flex<'d>>,
     rts: Option<Flex<'d>>,
     rx_dma: Option<ChannelAndRequest<'d>>,
@@ -481,7 +528,7 @@ pub struct UartRx<'d, M: Mode> {
     _marker: PhantomData<M>,
 }
 
-impl<'d, M: Mode> SetConfig for UartRx<'d, M> {
+impl<'d, M: PeriMode> SetConfig for UartRx<'d, M> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -499,7 +546,16 @@ impl<'d> UartTx<'d, Async> {
         _irq: impl interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(peri, new_pin!(tx, config.tx_af()), None, new_dma!(tx_dma, _irq), config)
+        Self::new_inner(
+            peri,
+            None,
+            new_pin!(tx, config.tx_af()),
+            None,
+            new_dma!(tx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
     }
 
     /// Create a new tx-only UART with a clear-to-send pin
@@ -513,10 +569,56 @@ impl<'d> UartTx<'d, Async> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(tx, config.tx_af()),
             new_pin!(cts, AfType::input(config.cts_pull)),
             new_dma!(tx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new tx-only USART in synchronous master mode.
+    pub fn new_master<T: Instance, D: TxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        tx_dma: Peri<'d, D>,
+        _irq: impl interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            new_dma!(tx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new tx-only USART with a clear-to-send pin in synchronous master mode.
+    pub fn new_master_with_cts<T: Instance, D: TxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        cts: Peri<'d, if_afio!(impl CtsPin<T, A>)>,
+        tx_dma: Peri<'d, D>,
+        _irq: impl interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>> + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
+            new_dma!(tx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -583,7 +685,16 @@ impl<'d> UartTx<'d, Blocking> {
         tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(peri, new_pin!(tx, config.tx_af()), None, None, config)
+        Self::new_inner(
+            peri,
+            None,
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
     }
 
     /// Create a new blocking tx-only UART with a clear-to-send pin
@@ -595,26 +706,71 @@ impl<'d> UartTx<'d, Blocking> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(tx, config.tx_af()),
             new_pin!(cts, AfType::input(config.cts_pull)),
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new blocking tx-only USART in synchronous master mode.
+    pub fn new_blocking_master<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.tx_config.af_type()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new blocking tx-only USART with a clear-to-send pin in synchronous master mode.
+    pub fn new_blocking_master_with_cts<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        cts: Peri<'d, if_afio!(impl CtsPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.tx_config.af_type()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 }
 
-impl<'d, M: Mode> UartTx<'d, M> {
+impl<'d, M: PeriMode> UartTx<'d, M> {
     fn new_inner<T: Instance>(
         _peri: Peri<'d, T>,
+        ck: Option<Flex<'d>>,
         tx: Option<Flex<'d>>,
         cts: Option<Flex<'d>>,
         tx_dma: Option<ChannelAndRequest<'d>>,
         config: Config,
+        #[cfg(usart_v4)] slave: bool,
     ) -> Result<Self, ConfigError> {
         let mut this = Self {
             info: T::info(),
             state: T::state(),
             kernel_clock: T::frequency(),
+            _ck: ck,
             _tx: tx,
             cts,
             _de: None,
@@ -622,11 +778,15 @@ impl<'d, M: Mode> UartTx<'d, M> {
             duplex: config.duplex,
             _marker: PhantomData,
         };
-        this.enable_and_configure(&config)?;
+        this.enable_and_configure(
+            &config,
+            #[cfg(usart_v4)]
+            slave,
+        )?;
         Ok(this)
     }
 
-    fn enable_and_configure(&mut self, config: &Config) -> Result<(), ConfigError> {
+    fn enable_and_configure(&mut self, config: &Config, #[cfg(usart_v4)] slave: bool) -> Result<(), ConfigError> {
         let info = self.info;
         let state = self.state;
         state.tx_rx_refcount.store(1, Ordering::Relaxed);
@@ -636,7 +796,16 @@ impl<'d, M: Mode> UartTx<'d, M> {
         info.regs.cr3().modify(|w| {
             w.set_ctse(self.cts.is_some());
         });
-        configure(info, self.kernel_clock, config, false, true)?;
+        configure(
+            info,
+            self.kernel_clock,
+            config,
+            self._ck.is_some(),
+            false,
+            true,
+            #[cfg(usart_v4)]
+            slave,
+        )?;
 
         Ok(())
     }
@@ -782,7 +951,16 @@ impl<'d> UartRx<'d, Async> {
         + 'd,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(peri, new_pin!(rx, config.rx_af()), None, new_dma!(rx_dma, _irq), config)
+        Self::new_inner(
+            peri,
+            None,
+            new_pin!(rx, config.rx_af()),
+            None,
+            new_dma!(rx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
     }
 
     /// Create a new rx-only UART with a request-to-send pin
@@ -798,10 +976,60 @@ impl<'d> UartRx<'d, Async> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(rts, config.rts_config.af_type()),
             new_dma!(rx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new rx-only USART in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_slave<T: Instance, D: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        rx_dma: Peri<'d, D>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            None,
+            new_dma!(rx_dma, _irq),
+            config,
+            true,
+        )
+    }
+
+    /// Create a new rx-only USART with a request-to-send pin in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_slave_with_rts<T: Instance, D: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        rts: Peri<'d, if_afio!(impl RtsPin<T, A>)>,
+        rx_dma: Peri<'d, D>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D::Interrupt, crate::dma::InterruptHandler<D>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            new_dma!(rx_dma, _irq),
+            config,
+            true,
         )
     }
 
@@ -1044,7 +1272,16 @@ impl<'d> UartRx<'d, Blocking> {
         rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
         config: Config,
     ) -> Result<Self, ConfigError> {
-        Self::new_inner(peri, new_pin!(rx, config.rx_af()), None, None, config)
+        Self::new_inner(
+            peri,
+            None,
+            new_pin!(rx, config.rx_af()),
+            None,
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
     }
 
     /// Create a new rx-only UART with a request-to-send pin
@@ -1056,27 +1293,72 @@ impl<'d> UartRx<'d, Blocking> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(rts, config.rts_config.af_type()),
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new rx-only USART in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_blocking_slave<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            None,
+            None,
+            config,
+            true,
+        )
+    }
+
+    /// Create a new rx-only USART with a request-to-send pin in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_blocking_slave_with_rts<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        rts: Peri<'d, if_afio!(impl RtsPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            None,
+            config,
+            true,
         )
     }
 }
 
-impl<'d, M: Mode> UartRx<'d, M> {
+impl<'d, M: PeriMode> UartRx<'d, M> {
     fn new_inner<T: Instance>(
         _peri: Peri<'d, T>,
+        ck: Option<Flex<'d>>,
         rx: Option<Flex<'d>>,
         rts: Option<Flex<'d>>,
         rx_dma: Option<ChannelAndRequest<'d>>,
         config: Config,
+        #[cfg(usart_v4)] slave: bool,
     ) -> Result<Self, ConfigError> {
         let mut this = Self {
             _marker: PhantomData,
             info: T::info(),
             state: T::state(),
             kernel_clock: T::frequency(),
+            _ck: ck,
             rx,
             rts,
             rx_dma,
@@ -1084,11 +1366,15 @@ impl<'d, M: Mode> UartRx<'d, M> {
             #[cfg(any(usart_v1, usart_v2))]
             buffered_sr: regs::Sr(0),
         };
-        this.enable_and_configure(&config)?;
+        this.enable_and_configure(
+            &config,
+            #[cfg(usart_v4)]
+            slave,
+        )?;
         Ok(this)
     }
 
-    fn enable_and_configure(&mut self, config: &Config) -> Result<(), ConfigError> {
+    fn enable_and_configure(&mut self, config: &Config, #[cfg(usart_v4)] slave: bool) -> Result<(), ConfigError> {
         let info = self.info;
         let state = self.state;
         state.tx_rx_refcount.store(1, Ordering::Relaxed);
@@ -1101,7 +1387,17 @@ impl<'d, M: Mode> UartRx<'d, M> {
         info.regs.cr3().write(|w| {
             w.set_rtse(self.rts.is_some());
         });
-        configure(info, self.kernel_clock, &config, true, false)?;
+
+        configure(
+            info,
+            self.kernel_clock,
+            &config,
+            self._ck.is_some(),
+            true,
+            false,
+            #[cfg(usart_v4)]
+            slave,
+        )?;
 
         info.interrupt.unpend();
         unsafe { info.interrupt.enable() };
@@ -1212,13 +1508,13 @@ impl<'d, M: Mode> UartRx<'d, M> {
     }
 }
 
-impl<'d, M: Mode> Drop for UartTx<'d, M> {
+impl<'d, M: PeriMode> Drop for UartTx<'d, M> {
     fn drop(&mut self) {
         drop_tx_rx(self.info, self.state);
     }
 }
 
-impl<'d, M: Mode> Drop for UartRx<'d, M> {
+impl<'d, M: PeriMode> Drop for UartRx<'d, M> {
     fn drop(&mut self) {
         drop_tx_rx(self.info, self.state);
     }
@@ -1246,6 +1542,7 @@ impl<'d> Uart<'d, Async> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(tx, config.tx_af()),
             None,
@@ -1254,6 +1551,8 @@ impl<'d> Uart<'d, Async> {
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1274,6 +1573,7 @@ impl<'d> Uart<'d, Async> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(tx, config.tx_af()),
             new_pin!(rts, config.rts_config.af_type()),
@@ -1282,6 +1582,8 @@ impl<'d> Uart<'d, Async> {
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1302,6 +1604,7 @@ impl<'d> Uart<'d, Async> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(tx, config.tx_af()),
             None,
@@ -1310,6 +1613,8 @@ impl<'d> Uart<'d, Async> {
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1346,6 +1651,7 @@ impl<'d> Uart<'d, Async> {
         Self::new_inner(
             peri,
             None,
+            None,
             new_pin!(tx, config.tx_af()),
             None,
             None,
@@ -1353,6 +1659,8 @@ impl<'d> Uart<'d, Async> {
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1386,12 +1694,171 @@ impl<'d> Uart<'d, Async> {
             peri,
             None,
             None,
+            None,
             new_pin!(rx, config.rx_af()),
             None,
             None,
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new bidirectional USART in synchronous master mode
+    pub fn new_master<T: Instance, D1: TxDma<T>, D2: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        tx_dma: Peri<'d, D1>,
+        rx_dma: Peri<'d, D2>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
+        + interrupt::typelevel::Binding<D2::Interrupt, crate::dma::InterruptHandler<D2>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            None,
+            new_dma!(tx_dma, _irq),
+            new_dma!(rx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new bidirectional USART with request-to-send and clear-to-send pins in synchronous master mode
+    pub fn new_master_with_rtscts<T: Instance, D1: TxDma<T>, D2: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        rts: Peri<'d, if_afio!(impl RtsPin<T, A>)>,
+        cts: Peri<'d, if_afio!(impl CtsPin<T, A>)>,
+        tx_dma: Peri<'d, D1>,
+        rx_dma: Peri<'d, D2>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
+        + interrupt::typelevel::Binding<D2::Interrupt, crate::dma::InterruptHandler<D2>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
+            None,
+            new_dma!(tx_dma, _irq),
+            new_dma!(rx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    #[cfg(not(any(usart_v1, usart_v2)))]
+    /// Create a new bidirectional USART with a driver-enable pin in synchronous master mode
+    pub fn new_master_with_de<T: Instance, D1: TxDma<T>, D2: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        de: Peri<'d, if_afio!(impl DePin<T, A>)>,
+        tx_dma: Peri<'d, D1>,
+        rx_dma: Peri<'d, D2>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
+        + interrupt::typelevel::Binding<D2::Interrupt, crate::dma::InterruptHandler<D2>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            new_pin!(de, config.de_config.af_type()),
+            new_dma!(tx_dma, _irq),
+            new_dma!(rx_dma, _irq),
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new bidirectional USART in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_slave<T: Instance, D1: TxDma<T>, D2: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        tx_dma: Peri<'d, D1>,
+        rx_dma: Peri<'d, D2>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
+        + interrupt::typelevel::Binding<D2::Interrupt, crate::dma::InterruptHandler<D2>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            None,
+            new_dma!(tx_dma, _irq),
+            new_dma!(rx_dma, _irq),
+            config,
+            true,
+        )
+    }
+
+    /// Create a new bidirectional USART with request-to-send and clear-to-send pins in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_slave_with_rtscts<T: Instance, D1: TxDma<T>, D2: RxDma<T>, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        rts: Peri<'d, if_afio!(impl RtsPin<T, A>)>,
+        cts: Peri<'d, if_afio!(impl CtsPin<T, A>)>,
+        tx_dma: Peri<'d, D1>,
+        rx_dma: Peri<'d, D2>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>>
+        + interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
+        + interrupt::typelevel::Binding<D2::Interrupt, crate::dma::InterruptHandler<D2>>
+        + 'd,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
+            None,
+            new_dma!(tx_dma, _irq),
+            new_dma!(rx_dma, _irq),
+            config,
+            true,
         )
     }
 
@@ -1426,6 +1893,7 @@ impl<'d> Uart<'d, Blocking> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(tx, config.tx_af()),
             None,
@@ -1434,6 +1902,8 @@ impl<'d> Uart<'d, Blocking> {
             None,
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1448,6 +1918,7 @@ impl<'d> Uart<'d, Blocking> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(tx, config.tx_af()),
             new_pin!(rts, config.rts_config.af_type()),
@@ -1456,6 +1927,8 @@ impl<'d> Uart<'d, Blocking> {
             None,
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1470,6 +1943,7 @@ impl<'d> Uart<'d, Blocking> {
     ) -> Result<Self, ConfigError> {
         Self::new_inner(
             peri,
+            None,
             new_pin!(rx, config.rx_af()),
             new_pin!(tx, config.tx_af()),
             None,
@@ -1478,6 +1952,8 @@ impl<'d> Uart<'d, Blocking> {
             None,
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1507,6 +1983,7 @@ impl<'d> Uart<'d, Blocking> {
         Self::new_inner(
             peri,
             None,
+            None,
             new_pin!(tx, config.tx_af()),
             None,
             None,
@@ -1514,6 +1991,8 @@ impl<'d> Uart<'d, Blocking> {
             None,
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
         )
     }
 
@@ -1541,19 +2020,149 @@ impl<'d> Uart<'d, Blocking> {
             peri,
             None,
             None,
+            None,
             new_pin!(rx, config.rx_af()),
             None,
             None,
             None,
             None,
             config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new blocking bidirectional USART in synchronous master mode
+    pub fn new_blocking_master<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new bidirectional USART with request-to-send and clear-to-send pins in synchronous master mode
+    pub fn new_blocking_master_with_rtscts<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        rts: Peri<'d, if_afio!(impl RtsPin<T, A>)>,
+        cts: Peri<'d, if_afio!(impl CtsPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
+            None,
+            None,
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    #[cfg(not(any(usart_v1, usart_v2)))]
+    /// Create a new bidirectional USART with a driver-enable pin in synchronous master mode
+    pub fn new_blocking_master_with_de<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        de: Peri<'d, if_afio!(impl DePin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, config.ck_config.af_type()),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            new_pin!(de, config.de_config.af_type()),
+            None,
+            None,
+            config,
+            #[cfg(usart_v4)]
+            false,
+        )
+    }
+
+    /// Create a new blocking bidirectional USART in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_blocking_slave<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            config,
+            true,
+        )
+    }
+
+    /// Create a new bidirectional USART with request-to-send and clear-to-send pins in synchronous slave mode
+    #[cfg(usart_v4)]
+    pub fn new_blocking_slave_with_rtscts<T: Instance, #[cfg(afio)] A>(
+        peri: Peri<'d, T>,
+        ck: Peri<'d, if_afio!(impl CkPin<T, A>)>,
+        rx: Peri<'d, if_afio!(impl RxPin<T, A>)>,
+        tx: Peri<'d, if_afio!(impl TxPin<T, A>)>,
+        rts: Peri<'d, if_afio!(impl RtsPin<T, A>)>,
+        cts: Peri<'d, if_afio!(impl CtsPin<T, A>)>,
+        config: Config,
+    ) -> Result<Self, ConfigError> {
+        Self::new_inner(
+            peri,
+            new_pin!(ck, AfType::input(config.ck_pull)),
+            new_pin!(rx, config.rx_af()),
+            new_pin!(tx, config.tx_af()),
+            new_pin!(rts, config.rts_config.af_type()),
+            new_pin!(cts, AfType::input(config.cts_pull)),
+            None,
+            None,
+            None,
+            config,
+            true,
         )
     }
 }
 
-impl<'d, M: Mode> Uart<'d, M> {
+impl<'d, M: PeriMode> Uart<'d, M> {
     fn new_inner<T: Instance>(
         _peri: Peri<'d, T>,
+        ck: Option<Flex<'d>>,
         rx: Option<Flex<'d>>,
         tx: Option<Flex<'d>>,
         rts: Option<Flex<'d>>,
@@ -1562,6 +2171,7 @@ impl<'d, M: Mode> Uart<'d, M> {
         tx_dma: Option<ChannelAndRequest<'d>>,
         rx_dma: Option<ChannelAndRequest<'d>>,
         config: Config,
+        #[cfg(usart_v4)] slave: bool,
     ) -> Result<Self, ConfigError> {
         let info = T::info();
         let state = T::state();
@@ -1579,6 +2189,7 @@ impl<'d, M: Mode> Uart<'d, M> {
                 info,
                 state,
                 kernel_clock,
+                _ck: ck,
                 _tx: tx,
                 cts,
                 _de: de,
@@ -1590,6 +2201,7 @@ impl<'d, M: Mode> Uart<'d, M> {
                 info,
                 state,
                 kernel_clock,
+                _ck: None,
                 rx,
                 rts,
                 rx_dma,
@@ -1598,11 +2210,15 @@ impl<'d, M: Mode> Uart<'d, M> {
                 buffered_sr: regs::Sr(0),
             },
         };
-        this.enable_and_configure(&config)?;
+        this.enable_and_configure(
+            &config,
+            #[cfg(usart_v4)]
+            slave,
+        )?;
         Ok(this)
     }
 
-    fn enable_and_configure(&mut self, config: &Config) -> Result<(), ConfigError> {
+    fn enable_and_configure(&mut self, config: &Config, #[cfg(usart_v4)] slave: bool) -> Result<(), ConfigError> {
         let info = self.rx.info;
         let state = self.rx.state;
         state.tx_rx_refcount.store(2, Ordering::Relaxed);
@@ -1618,7 +2234,17 @@ impl<'d, M: Mode> Uart<'d, M> {
             #[cfg(not(any(usart_v1, usart_v2)))]
             w.set_dem(self.tx._de.is_some());
         });
-        configure(info, self.rx.kernel_clock, config, true, true)?;
+
+        configure(
+            info,
+            self.rx.kernel_clock,
+            config,
+            self.tx._ck.is_some(),
+            true,
+            true,
+            #[cfg(usart_v4)]
+            slave,
+        )?;
 
         info.interrupt.unpend();
         unsafe { info.interrupt.enable() };
@@ -1677,8 +2303,24 @@ fn reconfigure(info: &Info, kernel_clock: Hertz, config: &Config) -> Result<(), 
     info.interrupt.disable();
     let r = info.regs;
 
-    let cr = r.cr1().read();
-    configure(info, kernel_clock, config, cr.re(), cr.te())?;
+    let cr1 = r.cr1().read();
+    let cr2 = r.cr2().read();
+    #[cfg(not(usart_v4))]
+    let clken = cr2.clken();
+    #[cfg(usart_v4)]
+    let slave = cr2.slven();
+    #[cfg(usart_v4)]
+    let clken = slave || cr2.clken();
+    configure(
+        info,
+        kernel_clock,
+        config,
+        clken,
+        cr1.re(),
+        cr1.te(),
+        #[cfg(usart_v4)]
+        slave,
+    )?;
 
     info.interrupt.unpend();
     unsafe { info.interrupt.enable() };
@@ -1827,8 +2469,10 @@ fn configure(
     info: &Info,
     kernel_clock: Hertz,
     config: &Config,
+    enable_ck: bool,
     enable_rx: bool,
     enable_tx: bool,
+    #[cfg(usart_v4)] slave: bool,
 ) -> Result<(), ConfigError> {
     let r = info.regs;
     let kind = info.kind;
@@ -1880,6 +2524,16 @@ fn configure(
         if config.irda_enable {
             w.set_clken(false);
             w.set_linen(false);
+        } else if enable_ck {
+            w.set_clken(true);
+            w.set_cpol(config.raw_polarity());
+            w.set_cpha(config.raw_phase());
+            w.set_lbcl(config.mode.last_bit);
+            #[cfg(usart_v4)]
+            if slave {
+                w.set_clken(false);
+                w.set_slven(true);
+            }
         }
 
         #[cfg(any(usart_v3, usart_v4))]
@@ -2004,14 +2658,14 @@ fn configure(
     Ok(())
 }
 
-impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for UartRx<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_02::serial::Read<u8> for UartRx<'d, M> {
     type Error = Error;
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
         self.nb_read()
     }
 }
 
-impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M> {
     type Error = Error;
     fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
         self.blocking_write(buffer)
@@ -2021,14 +2675,14 @@ impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for UartTx<'d, M>
     }
 }
 
-impl<'d, M: Mode> embedded_hal_02::serial::Read<u8> for Uart<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_02::serial::Read<u8> for Uart<'d, M> {
     type Error = Error;
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
         self.nb_read()
     }
 }
 
-impl<'d, M: Mode> embedded_hal_02::blocking::serial::Write<u8> for Uart<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_02::blocking::serial::Write<u8> for Uart<'d, M> {
     type Error = Error;
     fn bwrite_all(&mut self, buffer: &[u8]) -> Result<(), Self::Error> {
         self.blocking_write(buffer)
@@ -2050,25 +2704,25 @@ impl embedded_hal_nb::serial::Error for Error {
     }
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::ErrorType for Uart<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::ErrorType for Uart<'d, M> {
     type Error = Error;
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::ErrorType for UartTx<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::ErrorType for UartTx<'d, M> {
     type Error = Error;
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::ErrorType for UartRx<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::ErrorType for UartRx<'d, M> {
     type Error = Error;
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::Read for UartRx<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::Read for UartRx<'d, M> {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.nb_read()
     }
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::Write for UartTx<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::Write for UartTx<'d, M> {
     fn write(&mut self, char: u8) -> nb::Result<(), Self::Error> {
         self.nb_write(char)
     }
@@ -2078,13 +2732,13 @@ impl<'d, M: Mode> embedded_hal_nb::serial::Write for UartTx<'d, M> {
     }
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::Read for Uart<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::Read for Uart<'d, M> {
     fn read(&mut self) -> Result<u8, nb::Error<Self::Error>> {
         self.nb_read()
     }
 }
 
-impl<'d, M: Mode> embedded_hal_nb::serial::Write for Uart<'d, M> {
+impl<'d, M: PeriMode> embedded_hal_nb::serial::Write for Uart<'d, M> {
     fn write(&mut self, char: u8) -> nb::Result<(), Self::Error> {
         self.blocking_write(&[char]).map_err(nb::Error::Other)
     }
@@ -2100,15 +2754,15 @@ impl embedded_io::Error for Error {
     }
 }
 
-impl<M: Mode> embedded_io::ErrorType for Uart<'_, M> {
+impl<M: PeriMode> embedded_io::ErrorType for Uart<'_, M> {
     type Error = Error;
 }
 
-impl<M: Mode> embedded_io::ErrorType for UartTx<'_, M> {
+impl<M: PeriMode> embedded_io::ErrorType for UartTx<'_, M> {
     type Error = Error;
 }
 
-impl<M: Mode> embedded_io::Write for Uart<'_, M> {
+impl<M: PeriMode> embedded_io::Write for Uart<'_, M> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.blocking_write(buf)?;
         Ok(buf.len())
@@ -2119,7 +2773,7 @@ impl<M: Mode> embedded_io::Write for Uart<'_, M> {
     }
 }
 
-impl<M: Mode> embedded_io::Write for UartTx<'_, M> {
+impl<M: PeriMode> embedded_io::Write for UartTx<'_, M> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
         self.blocking_write(buf)?;
         Ok(buf.len())

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -1042,7 +1042,10 @@ impl<'d> UartRx<'d, Async> {
         Ok(())
     }
 
-    /// Initiate an asynchronous read with idle line detection enabled
+    /// Initiate an asynchronous read with idle line detection enabled.
+    ///
+    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
+    /// as if you had called [`read(buffer)`](Self::read) instead!
     pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
@@ -1877,7 +1880,10 @@ impl<'d> Uart<'d, Async> {
         self.rx.read(buffer).await
     }
 
-    /// Perform an an asynchronous read with idle line detection enabled
+    /// Perform an an asynchronous read with idle line detection enabled.
+    ///
+    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
+    /// as if you had called [`read(buffer)`](Self::read) instead!
     pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
         self.rx.read_until_idle(buffer).await
     }

--- a/examples/stm32h723/src/bin/usart_synchronous.rs
+++ b/examples/stm32h723/src/bin/usart_synchronous.rs
@@ -1,0 +1,92 @@
+#![no_std]
+#![no_main]
+
+use defmt::{error, info, unwrap};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::usart::{self, UartRx, UartTx};
+use embassy_stm32::{Config, bind_interrupts, dma, mode, peripherals};
+use embassy_time::Timer;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    DMA1_STREAM1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_STREAM2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
+    USART2 => usart::InterruptHandler<peripherals::USART2>;
+});
+
+#[embassy_executor::task]
+async fn tx_task(mut usart: UartTx<'static, mode::Async>) {
+    #[unsafe(link_section = ".sram1")]
+    static GREETING: &str = "Hello Embassy World!\r\n";
+
+    loop {
+        match usart.write(GREETING.as_bytes()).await {
+            Ok(()) => {
+                info!("Sent: {:?}", GREETING);
+            }
+            Err(err) => {
+                error!("Error during send: {}", err);
+            }
+        }
+        Timer::after_secs(1).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn rx_task(mut usart: UartRx<'static, mode::Async>) {
+    #[unsafe(link_section = ".sram1")]
+    static mut RX_BUF: [u8; 64] = [0; 64];
+    let buf = unsafe { &mut RX_BUF[..] };
+
+    loop {
+        let len = match usart.read_until_idle(buf).await {
+            Ok(len) => len,
+            Err(err) => {
+                error!("Error during receive: {}", err);
+                continue;
+            }
+        };
+        let buf = &buf[..len];
+        match str::from_utf8(buf) {
+            Ok(str) => {
+                info!("Received: {:?}", str);
+            }
+            Err(_) => {
+                info!("Received: {:02X}", buf);
+            }
+        }
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hsi = Some(HSIPrescaler::Div1);
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div16,
+            mul: PllMul::Mul200,
+            divp: Some(PllDiv::Div2), // 400 MHz
+            divq: Some(PllDiv::Div8), // 100 MHz
+            divr: None,
+        });
+    }
+    let p = embassy_stm32::init(config);
+
+    let mut config = usart::Config::default();
+    config.invert_tx = true;
+    config.invert_rx = true;
+    // When using USART in slave mode, the master must send 8 clock pulses for 8 bits of data.
+    // Therefore, pick exactly one:
+    //  - Enable one parity bit for the master only
+    //  - Enable clock pulse on the last bit
+    config.mode.last_bit = true;
+    let usart_master = unwrap!(UartTx::new_master(p.USART3, p.PC12, p.PC10, p.DMA1_CH1, Irqs, config));
+    let usart_slave = unwrap!(UartRx::new_slave(p.USART2, p.PD7, p.PD6, p.DMA1_CH2, Irqs, config));
+
+    spawner.spawn(unwrap!(rx_task(usart_slave)));
+    spawner.spawn(unwrap!(tx_task(usart_master)));
+}

--- a/examples/stm32h723/src/bin/usart_synchronous.rs
+++ b/examples/stm32h723/src/bin/usart_synchronous.rs
@@ -15,11 +15,11 @@ bind_interrupts!(struct Irqs {
     USART2 => usart::InterruptHandler<peripherals::USART2>;
 });
 
+#[unsafe(link_section = ".sram1")]
+static GREETING: &str = "Hello Embassy World!\r\n";
+
 #[embassy_executor::task]
 async fn tx_task(mut usart: UartTx<'static, mode::Async>) {
-    #[unsafe(link_section = ".sram1")]
-    static GREETING: &str = "Hello Embassy World!\r\n";
-
     loop {
         match usart.write(GREETING.as_bytes()).await {
             Ok(()) => {
@@ -36,18 +36,14 @@ async fn tx_task(mut usart: UartTx<'static, mode::Async>) {
 #[embassy_executor::task]
 async fn rx_task(mut usart: UartRx<'static, mode::Async>) {
     #[unsafe(link_section = ".sram1")]
-    static mut RX_BUF: [u8; 64] = [0; 64];
+    static mut RX_BUF: [u8; GREETING.len()] = [0; GREETING.len()];
     let buf = unsafe { &mut RX_BUF[..] };
 
     loop {
-        let len = match usart.read_until_idle(buf).await {
-            Ok(len) => len,
-            Err(err) => {
-                error!("Error during receive: {}", err);
-                continue;
-            }
+        if let Err(err) = usart.read(buf).await {
+            error!("Error during receive: {}", err);
+            continue;
         };
-        let buf = &buf[..len];
         match str::from_utf8(buf) {
             Ok(str) => {
                 info!("Received: {:?}", str);

--- a/examples/stm32h723/src/bin/usart_synchronous_ringbuf.rs
+++ b/examples/stm32h723/src/bin/usart_synchronous_ringbuf.rs
@@ -1,0 +1,94 @@
+#![no_std]
+#![no_main]
+
+use defmt::{error, info, unwrap};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::usart::{self, UartRx, UartTx};
+use embassy_stm32::{Config, bind_interrupts, dma, mode, peripherals};
+use embassy_time::Timer;
+use embedded_io_async::Read;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    DMA1_STREAM1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+    DMA1_STREAM2 => dma::InterruptHandler<peripherals::DMA1_CH2>;
+    USART2 => usart::InterruptHandler<peripherals::USART2>;
+});
+
+#[unsafe(link_section = ".sram1")]
+static GREETING: &str = "Hello Embassy World!\r\n";
+
+#[embassy_executor::task]
+async fn tx_task(mut usart: UartTx<'static, mode::Async>) {
+    loop {
+        match usart.write(GREETING.as_bytes()).await {
+            Ok(()) => {
+                info!("Sent: {:?}", GREETING);
+            }
+            Err(err) => {
+                error!("Error during send: {}", err);
+            }
+        }
+        Timer::after_secs(1).await;
+    }
+}
+
+#[embassy_executor::task]
+async fn rx_task(usart: UartRx<'static, mode::Async>) {
+    #[unsafe(link_section = ".sram1")]
+    static mut RX_BUF: [u8; 256] = [0; 256];
+    let buf = unsafe { &mut RX_BUF[..] };
+    let mut usart = usart.into_ring_buffered(buf);
+
+    let mut buf = [0u8; GREETING.len()];
+    loop {
+        // Note: The way USART ring buffers currently work, this will not immediately
+        // return when at least buf.len() data is available, but rather wait until at
+        // least half the ringbuf is full.
+        if let Err(err) = usart.read_exact(&mut buf).await {
+            error!("Error during receive: {}", err);
+            continue;
+        };
+        match str::from_utf8(&buf) {
+            Ok(str) => {
+                info!("Received: {:?}", str);
+            }
+            Err(_) => {
+                info!("Received: {:02X}", buf);
+            }
+        }
+    }
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.hsi = Some(HSIPrescaler::Div1);
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div16,
+            mul: PllMul::Mul200,
+            divp: Some(PllDiv::Div2), // 400 MHz
+            divq: Some(PllDiv::Div8), // 100 MHz
+            divr: None,
+        });
+    }
+    let p = embassy_stm32::init(config);
+
+    let mut config = usart::Config::default();
+    config.invert_tx = true;
+    config.invert_rx = true;
+    // When using USART in slave mode, the master must send 8 clock pulses for 8 bits of data.
+    // Therefore, pick exactly one:
+    //  - Enable one parity bit for the master only
+    //  - Enable clock pulse on the last bit
+    config.mode.last_bit = true;
+    let usart_master = unwrap!(UartTx::new_master(p.USART3, p.PC12, p.PC10, p.DMA1_CH1, Irqs, config));
+    let usart_slave = unwrap!(UartRx::new_slave(p.USART2, p.PD7, p.PD6, p.DMA1_CH2, Irqs, config));
+
+    spawner.spawn(unwrap!(rx_task(usart_slave)));
+    spawner.spawn(unwrap!(tx_task(usart_master)));
+}


### PR DESCRIPTION
Alternative to #6730. Tested on an STM32H723ZG (nucleo) board communicating with itself.

I tried to make the API as similar to the SPI API as possible (i.e. clk pin is the first in the new function, and master/slave share the same API). That also means it shares the same problems and then some that the SPI slave currently has. It looks like idle line detection in slave mode is not working, and unlike SPI we have no CS/NSS pin, so there is no way to tell when a transaction is done.

Closes #6730.