### PR TITLE
stm32: reset only stop1 refcount

### DIFF
--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -175,9 +175,16 @@ pub fn get_stop_mode(_cs: CriticalSection) -> Option<StopMode> {
 
 #[cfg(feature = "low-power")]
 #[allow(dead_code)]
-pub(crate) unsafe fn reset_stop_refcount(_cs: CriticalSection) {
-    REFCOUNT_STOP2 = 0;
-    REFCOUNT_STOP1 = 0;
+pub(crate) unsafe fn reset_stop_refcount(_cs: CriticalSection, stop_mode: StopMode) {
+    match stop_mode {
+        StopMode::Standby | StopMode::Stop2 => {
+            REFCOUNT_STOP2 = 0;
+            REFCOUNT_STOP1 = 0;
+        }
+        StopMode::Stop1 => {
+            REFCOUNT_STOP1 = 0;
+        }
+    }
 }
 
 #[cfg(feature = "low-power")]

--- a/embassy-stm32/src/time_driver/gp16.rs
+++ b/embassy-stm32/src/time_driver/gp16.rs
@@ -154,7 +154,7 @@ impl RtcDriver {
             <T as CoreInstance>::UpdateInterrupt::enable();
 
             #[cfg(feature = "low-power")]
-            crate::rcc::reset_stop_refcount(cs);
+            crate::rcc::reset_stop_refcount(cs, crate::rcc::StopMode::Stop1);
         }
     }
 

--- a/embassy-stm32/src/timer/complementary_pwm.rs
+++ b/embassy-stm32/src/timer/complementary_pwm.rs
@@ -16,6 +16,7 @@ pub use crate::pac::timer::vals::{Bkbid as BreakBidirectionalMode, Bkdsrm as Bre
 pub use crate::pac::timer::vals::{
     Bkinp as BreakComparatorPolarity, Bkp as BreakInputPolarity, Ccds, Ckd, Mms2, Ossi, Ossr,
 };
+use crate::rcc::WakeGuard;
 use crate::time::Hertz;
 use crate::timer::TimerChannel;
 #[cfg(timer_v2)]
@@ -78,6 +79,7 @@ pub struct ComplementaryPwm<'d, T: AdvancedInstance4Channel> {
     _ch3n: Option<Flex<'d>>,
     _ch4: Option<Flex<'d>>,
     _ch4n: Option<Flex<'d>>,
+    _wake_guard: WakeGuard,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -143,6 +145,7 @@ impl<'d, T: AdvancedInstance4Channel> ComplementaryPwm<'d, T> {
             _ch3n,
             _ch4,
             _ch4n,
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_counting_mode(counting_mode);

--- a/embassy-stm32/src/timer/input_capture.rs
+++ b/embassy-stm32/src/timer/input_capture.rs
@@ -11,6 +11,7 @@ use super::{CaptureCompareInterruptHandler, Channel, GeneralInstance4Channel, Ti
 pub use super::{Ch1, Ch2, Ch3, Ch4};
 use crate::gpio::{AfType, Flex, Pull};
 use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::rcc::WakeGuard;
 use crate::time::Hertz;
 use crate::timer::{TimerChannel, TimerInputTrigger};
 use crate::{Peri, dma};
@@ -71,6 +72,7 @@ pub struct InputCapture<'d, T: GeneralInstance4Channel> {
     _ch2: Option<InputType<'d>>,
     _ch3: Option<InputType<'d>>,
     _ch4: Option<InputType<'d>>,
+    _wake_guard: WakeGuard,
 }
 
 impl<'d, T: GeneralInstance4Channel> InputCapture<'d, T> {
@@ -112,6 +114,7 @@ impl<'d, T: GeneralInstance4Channel> InputCapture<'d, T> {
             _ch2,
             _ch3,
             _ch4,
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_counting_mode(counting_mode);

--- a/embassy-stm32/src/timer/one_pulse.rs
+++ b/embassy-stm32/src/timer/one_pulse.rs
@@ -15,6 +15,7 @@ use crate::Peri;
 use crate::gpio::{AfType, Flex, Pull};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::pac::timer::vals::Etp;
+use crate::rcc::WakeGuard;
 use crate::time::Hertz;
 use crate::timer::TimerChannel;
 
@@ -88,6 +89,7 @@ impl<'d, T: GeneralInstance4Channel> TriggerPin<'d, T, Ext> {
 pub struct OnePulse<'d, T: GeneralInstance4Channel> {
     inner: Timer<'d, T>,
     _pin: Flex<'d>,
+    _wake_guard: WakeGuard,
 }
 
 impl<'d, T: GeneralInstance4Channel> OnePulse<'d, T> {
@@ -107,6 +109,7 @@ impl<'d, T: GeneralInstance4Channel> OnePulse<'d, T> {
         let mut this = Self {
             inner: Timer::new(tim),
             _pin: pin.pin,
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_trigger_source(Ts::Ti1fEd);
@@ -134,6 +137,7 @@ impl<'d, T: GeneralInstance4Channel> OnePulse<'d, T> {
         let mut this = Self {
             inner: Timer::new(tim),
             _pin: _pin.pin,
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_trigger_source(Ts::Ti1fp1);
@@ -162,6 +166,7 @@ impl<'d, T: GeneralInstance4Channel> OnePulse<'d, T> {
         let mut this = Self {
             inner: Timer::new(tim),
             _pin: _pin.pin,
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_trigger_source(Ts::Ti2fp2);
@@ -189,6 +194,7 @@ impl<'d, T: GeneralInstance4Channel> OnePulse<'d, T> {
         let mut this = Self {
             inner: Timer::new(tim),
             _pin: _pin.pin,
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.regs_gp16().smcr().modify(|r| {

--- a/embassy-stm32/src/timer/pwm_input.rs
+++ b/embassy-stm32/src/timer/pwm_input.rs
@@ -9,6 +9,7 @@ use super::{CaptureCompareInterruptHandler, Ch1, Ch2, Channel, GeneralInstance4C
 use crate::Peri;
 use crate::gpio::{AfType, Pull};
 use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::rcc::WakeGuard;
 use crate::time::Hertz;
 
 /// PWM Input driver.
@@ -19,6 +20,7 @@ use crate::time::Hertz;
 pub struct PwmInput<'d, T: GeneralInstance4Channel> {
     channel: Channel,
     inner: Timer<'d, T>,
+    _wake_guard: WakeGuard,
 }
 
 impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {
@@ -80,7 +82,11 @@ impl<'d, T: GeneralInstance4Channel> PwmInput<'d, T> {
         T::CaptureCompareInterrupt::unpend();
         unsafe { T::CaptureCompareInterrupt::enable() };
 
-        Self { channel: ch1, inner }
+        Self {
+            channel: ch1,
+            inner,
+            _wake_guard: T::RCC_INFO.wake_guard(),
+        }
     }
 
     /// Enable the given channel.

--- a/embassy-stm32/src/timer/qei.rs
+++ b/embassy-stm32/src/timer/qei.rs
@@ -8,6 +8,7 @@ use super::{GeneralInstance4Channel, TimerPin};
 use crate::Peri;
 use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, Pull};
+use crate::rcc::WakeGuard;
 use crate::timer::{CoreInstance, TimerChannel};
 
 /// Qei driver config.
@@ -138,6 +139,7 @@ pub struct Qei<'d, T: GeneralInstance4Channel> {
     inner: Timer<'d, T>,
     _ch1: Flex<'d>,
     _ch2: Flex<'d>,
+    _wake_guard: WakeGuard,
 }
 
 impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
@@ -207,6 +209,7 @@ impl<'d, T: GeneralInstance4Channel> Qei<'d, T> {
             inner,
             _ch1: new_pin!(ch1, AfType::input(config.base.ch1_pull)).unwrap(),
             _ch2: new_pin!(ch2, AfType::input(config.base.ch2_pull)).unwrap(),
+            _wake_guard: T::RCC_INFO.wake_guard(),
         }
     }
 

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -223,7 +223,7 @@ pub struct SimplePwm<'d, T: GeneralInstance4Channel> {
     ch2: Option<Flex<'d>>,
     ch3: Option<Flex<'d>>,
     ch4: Option<Flex<'d>>,
-    wake_guard: WakeGuard,
+    _wake_guard: WakeGuard,
 }
 
 impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
@@ -264,7 +264,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
             ch2,
             ch3,
             ch4,
-            wake_guard: T::RCC_INFO.wake_guard(),
+            _wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_counting_mode(counting_mode);

--- a/embassy-stm32/src/timer/simple_pwm.rs
+++ b/embassy-stm32/src/timer/simple_pwm.rs
@@ -12,6 +12,7 @@ use crate::dma::word::Word;
 use crate::gpio::Pull;
 use crate::gpio::{AfType, Flex, OutputType, Speed};
 use crate::pac::timer::vals::Ccds;
+use crate::rcc::WakeGuard;
 use crate::time::Hertz;
 #[cfg(timer_v2)]
 use crate::timer::low_level::DitheringConfig;
@@ -222,6 +223,7 @@ pub struct SimplePwm<'d, T: GeneralInstance4Channel> {
     ch2: Option<Flex<'d>>,
     ch3: Option<Flex<'d>>,
     ch4: Option<Flex<'d>>,
+    wake_guard: WakeGuard,
 }
 
 impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
@@ -262,6 +264,7 @@ impl<'d, T: GeneralInstance4Channel> SimplePwm<'d, T> {
             ch2,
             ch3,
             ch4,
+            wake_guard: T::RCC_INFO.wake_guard(),
         };
 
         this.inner.set_counting_mode(counting_mode);

--- a/examples/stm32wba6-lp/src/bin/pwm_reborrow.rs
+++ b/examples/stm32wba6-lp/src/bin/pwm_reborrow.rs
@@ -16,10 +16,9 @@ use embassy_time::Timer;
 use panic_probe as _;
 
 use embassy_stm32::gpio::{Flex, Input, Level, Output, OutputType, Pull, Speed};
-use embassy_stm32::rcc::{StopMode, WakeGuard};
 use embassy_stm32::time;
 use embassy_stm32::time::Hertz;
-use embassy_stm32::timer::low_level::{CountingMode, OutputPolarity};
+use embassy_stm32::timer::low_level::CountingMode;
 use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
 
 const DEBUG_DURING_SLEEP: bool = false;
@@ -76,16 +75,16 @@ async fn main(_spawner: Spawner) {
     let mut p = embassy_stm32::init(config);
 
     info!("initializing unused GPIOs for minimum current draw ...");
-    let gpio_pd5 = Output::new(p.PD5, Level::Low, Speed::Low);
-    let gpio_pb10 = Output::new(p.PB10, Level::High, Speed::Low);
-    let gpio_pa6 = Input::new(p.PA6, Pull::Up);
-    let gpio_pe1 = Output::new(p.PE1, Level::High, Speed::VeryHigh);
-    let gpio_pe3 = Output::new(p.PE3, Level::High, Speed::VeryHigh);
-    let gpio_pe0 = Output::new(p.PE0, Level::Low, Speed::VeryHigh);
-    let gpio_pd14 = Output::new(p.PD14, Level::Low, Speed::VeryHigh);
+    let _gpio_pd5 = Output::new(p.PD5, Level::Low, Speed::Low);
+    let _gpio_pb10 = Output::new(p.PB10, Level::High, Speed::Low);
+    let _gpio_pa6 = Input::new(p.PA6, Pull::Up);
+    let _gpio_pe1 = Output::new(p.PE1, Level::High, Speed::VeryHigh);
+    let _gpio_pe3 = Output::new(p.PE3, Level::High, Speed::VeryHigh);
+    let _gpio_pe0 = Output::new(p.PE0, Level::Low, Speed::VeryHigh);
+    let _gpio_pd14 = Output::new(p.PD14, Level::Low, Speed::VeryHigh);
     let mut flex_pd8 = Flex::new(p.PD8);
     flex_pd8.set_as_analog();
-    let gpio_ph3 = Output::new(p.PH3, Level::Low, Speed::Low);
+    let _gpio_ph3 = Output::new(p.PH3, Level::Low, Speed::Low);
 
     info!("initializing simplePwm and power rail");
     let mut power_rail = Output::new(p.PB15, Level::Low, Speed::Low);

--- a/examples/stm32wba6-lp/src/bin/pwm_reborrow.rs
+++ b/examples/stm32wba6-lp/src/bin/pwm_reborrow.rs
@@ -1,0 +1,131 @@
+//! SimplePWM example with STOP mode using SimplePwm and a
+//! Advance Control timer.
+//!
+//! The MCU enters STOP2 mode between LED toggles (5 s intervals).
+//! My board draws about 160µA while sleeping, which is due to hardware
+//! limitations. Actual MCU current will be measure once i test on
+//! NUCLEO board.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_time::Timer;
+use panic_probe as _;
+
+use embassy_stm32::gpio::{Flex, Input, Level, Output, OutputType, Pull, Speed};
+use embassy_stm32::rcc::{StopMode, WakeGuard};
+use embassy_stm32::time;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::timer::low_level::{CountingMode, OutputPolarity};
+use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
+
+const DEBUG_DURING_SLEEP: bool = false;
+
+#[embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    info!("Hello from STM32WBA6 (65RI) low-power example using simplePwm!");
+
+    let mut config = embassy_stm32::Config::default();
+    {
+        use embassy_stm32::rcc::*;
+
+        // Enable HSE (32 MHz external crystal) - REQUIRED for BLE radio
+        config.rcc.hse = Some(Hse {
+            prescaler: HsePrescaler::Div1,
+            trim: Some(0x0C),
+        });
+        // Enable LSE (32.768 kHz external crystal) - REQUIRED for BLE radio sleep timer
+        config.rcc.ls = LsConfig {
+            rtc: RtcClockSource::Lse,
+            lsi: false,
+            lse: Some(LseConfig {
+                frequency: Hertz(32_768),
+                mode: LseMode::Oscillator(LseDrive::MediumLow),
+                peripherals_clocked: true,
+            }),
+        };
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div1,   // PLLM = 1 → HSI / 1 = 16 MHz
+            mul: PllMul::Mul30,        // PLLN = 30 → 16 MHz * 30 = 480 MHz VCO
+            divr: Some(PllDiv::Div5),  // PLLR = 5 → 96 MHz (Sysclk)
+            divq: Some(PllDiv::Div10), // PLLQ = 10 → 48 MHz
+            divp: Some(PllDiv::Div30), // PLLP = 30 → 16 MHz (USB_OTG_HS)
+            frac: Some(0),             // Fractional part (disabled)
+        });
+
+        config.rcc.ahb_pre = AHBPrescaler::Div1;
+        config.rcc.apb1_pre = APBPrescaler::Div1;
+        config.rcc.apb2_pre = APBPrescaler::Div1;
+        config.rcc.apb7_pre = APBPrescaler::Div1;
+        config.rcc.ahb5_pre = AHB5Prescaler::Div4;
+
+        config.rcc.voltage_scale = VoltageScale::Range1;
+        config.rcc.mux.otghssel = mux::Otghssel::Pll1P;
+        config.rcc.mux.lptim2sel = mux::Lptim2sel::Hsi;
+        config.rcc.mux.rngsel = mux::Rngsel::Hsi;
+        config.rcc.sys = Sysclk::Pll1R;
+
+        config.enable_debug_during_sleep = DEBUG_DURING_SLEEP;
+        config.min_stop_pause = embassy_time::Duration::from_millis(10);
+    }
+
+    let mut p = embassy_stm32::init(config);
+
+    info!("initializing unused GPIOs for minimum current draw ...");
+    let gpio_pd5 = Output::new(p.PD5, Level::Low, Speed::Low);
+    let gpio_pb10 = Output::new(p.PB10, Level::High, Speed::Low);
+    let gpio_pa6 = Input::new(p.PA6, Pull::Up);
+    let gpio_pe1 = Output::new(p.PE1, Level::High, Speed::VeryHigh);
+    let gpio_pe3 = Output::new(p.PE3, Level::High, Speed::VeryHigh);
+    let gpio_pe0 = Output::new(p.PE0, Level::Low, Speed::VeryHigh);
+    let gpio_pd14 = Output::new(p.PD14, Level::Low, Speed::VeryHigh);
+    let mut flex_pd8 = Flex::new(p.PD8);
+    flex_pd8.set_as_analog();
+    let gpio_ph3 = Output::new(p.PH3, Level::Low, Speed::Low);
+
+    info!("initializing simplePwm and power rail");
+    let mut power_rail = Output::new(p.PB15, Level::Low, Speed::Low);
+
+    // STM32WBA65 has 3 types of timers:
+    //  - General Purpose(TIM2/3/4/16/17)
+    //  - AdvancedControl(TIM1)
+    //  - LowPower(LPTIM1/2)
+
+    loop {
+        {
+            info!("begin");
+            info!("initializing SimplePwm with timer TIM1");
+            let led_pwm_pin = PwmPin::new(p.PB8.reborrow(), OutputType::PushPull);
+            let mut led_pwm = SimplePwm::new(
+                p.TIM1.reborrow(),
+                Some(led_pwm_pin),
+                None,
+                None,
+                None,
+                time::khz(100),
+                CountingMode::EdgeAlignedUp,
+            );
+            // blocking STOP mode entry ... why is this needed?
+            // let _stay_awake = WakeGuard::new(StopMode::Stop1);
+
+            power_rail.set_high();
+            led_pwm.ch1().enable();
+            led_pwm.ch1().set_duty_cycle_percent(30);
+            info!("led on — staying awake so PWM keeps toggling");
+
+            Timer::after_millis(2000).await;
+
+            info!("led off — sleeping 5 s");
+            led_pwm.ch1().disable();
+            led_pwm.ch1().set_duty_cycle_percent(0);
+            drop(led_pwm);
+            power_rail.set_low();
+            info!("end");
+        }
+        Timer::after_millis(2000).await; // MCU enters STOP here
+    }
+}

--- a/examples/stm32wba6-lp/src/bin/pwm_reborrow.rs
+++ b/examples/stm32wba6-lp/src/bin/pwm_reborrow.rs
@@ -12,14 +12,13 @@
 use defmt::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
-use embassy_time::Timer;
-use panic_probe as _;
-
 use embassy_stm32::gpio::{Flex, Input, Level, Output, OutputType, Pull, Speed};
 use embassy_stm32::time;
 use embassy_stm32::time::Hertz;
 use embassy_stm32::timer::low_level::CountingMode;
 use embassy_stm32::timer::simple_pwm::{PwmPin, SimplePwm};
+use embassy_time::Timer;
+use panic_probe as _;
 
 const DEBUG_DURING_SLEEP: bool = false;
 


### PR DESCRIPTION
don't reset the stop2 refcount because this may be called after exiting stop1 when the stop2 refcount was nonzero.