### PR TITLE
usb-host: match high-speed hubs, not just full-speed ones

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -69,7 +69,21 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
                     InterfaceDescriptor {
                         interface_class: 0x09,
                         interface_subclass: 0x0,
-                        interface_protocol: 0x0,
+                        // Match a protocol of either 0x00 or 0x01. Per USB 2.0
+                        // §11.23.1 a full-speed hub and a high-speed hub with a
+                        // single transaction translator both report 0x00 here,
+                        // while a hub with multiple TTs instead exposes two
+                        // alternate settings: 0x01 for single-TT operation on
+                        // alt 0, and 0x02 for multi-TT operation on alt 1. So
+                        // accepting 0x00 alone rejects every multi-TT hub.
+                        //
+                        // 0x02 is deliberately not matched. Alt 0 is the setting
+                        // the hub is already in, as this driver issues no
+                        // SET_INTERFACE, so matching 0x02 would take endpoints
+                        // from a setting the device is not using. Driving a
+                        // multi-TT hub in multi-TT mode, for more full/low-speed
+                        // bandwidth across its ports, would need that request.
+                        interface_protocol: 0x00 | 0x01,
                         ..
                     }
                 )


### PR DESCRIPTION
The hub class driver matched a hub interface on `bInterfaceProtocol == 0x00`. Per USB 2.0 §11.23.1 that value means a *full-speed* hub; a high-speed hub reports 0x01 (single transaction translator) or 0x02 (multiple TTs). So `HubHandler::try_register` returned `NoSupportedInterface` for every high-speed hub, and no device behind one could be reached.

Match 0x01 as well. 0x02 is deliberately left out: a multi-TT hub reports 0x01 on alternate setting 0 and 0x02 on alternate setting 1, so it is still matched here by its 0x01 setting — the one already active, since this driver issues no SET_INTERFACE. Matching 0x02 would risk selecting a descriptor for a setting the device is not in.

Found on a Raspberry Pi 3, whose on-board SMSC LAN9514 hub carries every port including the Ethernet function, so nothing enumerated at all.

---

Tested on Raspberry Pi 3 via https://github.com/joeferner/rpi-hal-embassy and https://github.com/joeferner/rpi-hal