### PR TITLE
usb-host: free the device address on every enumeration failure

### DIFF
--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -149,6 +149,54 @@ impl Default for BusState {
     }
 }
 
+/// Holds a device address for the duration of an enumeration, releasing
+/// it again unless the enumeration succeeds.
+///
+/// `enumerate` can fail at a dozen points, and every one of them has to
+/// hand the address back or the bus leaks addresses until it runs out of
+/// them at 127. Doing that at each `return` is a standing invitation to
+/// miss one — several were missed — so ownership expresses it instead:
+/// the address is freed on drop, and only a successful enumeration takes
+/// it back out with [`AddressGuard::release`].
+struct AddressGuard<'a> {
+    state: &'a BusState,
+    addr: u8,
+    /// Whether dropping still frees the address. Cleared by
+    /// [`AddressGuard::release`], which consumes the guard, so this
+    /// cannot be observed false through a live one.
+    armed: bool,
+}
+
+impl<'a> AddressGuard<'a> {
+    fn new(state: &'a BusState, addr: u8) -> Self {
+        Self {
+            state,
+            addr,
+            armed: true,
+        }
+    }
+
+    /// The address this guard is holding.
+    fn addr(&self) -> u8 {
+        self.addr
+    }
+
+    /// Gives up ownership: the device now holds this address, so it must
+    /// not be returned to the pool.
+    fn release(mut self) -> u8 {
+        self.armed = false;
+        self.addr
+    }
+}
+
+impl Drop for AddressGuard<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.state.free_address(self.addr);
+        }
+    }
+}
+
 /// Bus-level controller for a single root USB controller.
 ///
 /// Owns the [`UsbHostController`] implementation and exposes the
@@ -272,7 +320,7 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
         // the same bus: the default (address 0) state is bus-global.
         let _enum_guard = self.state.enum_lock.lock().await;
 
-        let addr = self.state.alloc_address().ok_or(EnumerationError::NoPipe)?;
+        let addr = AddressGuard::new(self.state, self.state.alloc_address().ok_or(EnumerationError::NoPipe)?);
 
         // use smallest size "8", since some devices use lower than default for given speed.
         const DEFAULT_MAX_PACKET_SIZE: u16 = 8;
@@ -287,10 +335,7 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
         let mut ch = self
             .alloc
             .alloc_pipe::<pipe::Control, pipe::InOut>(0, &ep0_info, route.split())
-            .map_err(|_| {
-                self.state.free_address(addr);
-                EnumerationError::NoPipe
-            })?;
+            .map_err(|_| EnumerationError::NoPipe)?;
 
         trace!("[enum] Getting max_packet_size for new device");
         let max_packet_size0 = {
@@ -308,7 +353,6 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
                             Timer::after_millis(1).await;
                             continue;
                         } else {
-                            self.state.free_address(addr);
                             return Err(e.into());
                         }
                     }
@@ -317,11 +361,10 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
         };
         // USB 2.0 §9.6.1: legal EP0 max packet sizes are 8, 16, 32, 64.
         if !matches!(max_packet_size0, 8 | 16 | 32 | 64) {
-            self.state.free_address(addr);
             return Err(EnumerationError::InvalidDescriptor);
         }
 
-        ch.device_set_address(addr).await?;
+        ch.device_set_address(addr.addr()).await?;
         // USB 2.0 §9.2.6.3: allow the device a 2ms recovery interval after SET_ADDRESS.
         Timer::after_millis(2).await;
 
@@ -337,11 +380,8 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         let mut ch = self
             .alloc
-            .alloc_pipe::<pipe::Control, pipe::InOut>(addr, &ep0_info, route.split())
-            .map_err(|_| {
-                self.state.free_address(addr);
-                EnumerationError::NoPipe
-            })?;
+            .alloc_pipe::<pipe::Control, pipe::InOut>(addr.addr(), &ep0_info, route.split())
+            .map_err(|_| EnumerationError::NoPipe)?;
 
         let retries = 5;
         let dev_desc = async {
@@ -368,13 +408,9 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         // Step 4: Get configuration descriptor header (9 bytes).
         let setup = SetupPacket::get_config_descriptor(0, 9);
-        let n = ch
-            .control_in(&setup.to_bytes(), &mut config_buf[..9])
-            .await
-            .inspect_err(|_| self.state.free_address(addr))?;
+        let n = ch.control_in(&setup.to_bytes(), &mut config_buf[..9]).await?;
 
         if n < 9 {
-            self.state.free_address(addr);
             return Err(EnumerationError::InvalidDescriptor);
         }
 
@@ -383,7 +419,6 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
         let total_len = config_header.total_len as usize;
 
         if total_len > config_buf.len() {
-            self.state.free_address(addr);
             return Err(EnumerationError::ConfigBufferTooSmall(total_len));
         }
 
@@ -393,7 +428,6 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         // USB 2.0 §9.4.3: the device must return exactly total_len bytes for a full config descriptor.
         if n != total_len {
-            self.state.free_address(addr);
             return Err(EnumerationError::InvalidDescriptor);
         }
 
@@ -401,9 +435,7 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         // Step 5: SET_CONFIGURATION.
         let setup = SetupPacket::set_configuration(config_header.configuration_value);
-        ch.control_out(&setup.to_bytes(), &[])
-            .await
-            .inspect_err(|_| self.state.free_address(addr))?;
+        ch.control_out(&setup.to_bytes(), &[]).await?;
 
         info!("Device configured (config={})", config_header.configuration_value);
 
@@ -412,7 +444,7 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         Ok((
             EnumerationInfo {
-                device_address: addr,
+                device_address: addr.release(),
                 route,
                 device_desc: dev_desc,
             },


### PR DESCRIPTION
`BusHandle::enumerate` allocates a device address up front and releases it on failure — but three of its error paths use a bare `?` and return without doing so:

  - SET_ADDRESS
  - the device descriptor read
  - the full configuration descriptor read

Every other failure path in the same function frees it, so this is an inconsistency rather than a deliberate choice. A device that fails repeatedly at one of those three steps consumes a fresh address each attempt and walks the bus toward the 127-address ceiling, after which enumeration fails for everything with `NoPipe`.

Visible symptom on a bus with a device that intermittently fails to enumerate: the *other* devices' addresses creep upward across retries.

---

Tested on Raspberry Pi 3 via https://github.com/joeferner/rpi-hal-embassy and https://github.com/joeferner/rpi-hal