### PR TITLE
usb-host: retry every descriptor read, not just the device descriptor

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -108,9 +108,12 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
             enum_info.split(),
         )?;
 
-        let desc = control_channel
-            .request_descriptor::<HubDescriptor, { HubDescriptor::BUF_SIZE }>(0, true)
-            .await?;
+        let desc = crate::handler::retry_descriptor(async || {
+            control_channel
+                .request_descriptor::<HubDescriptor, { HubDescriptor::BUF_SIZE }>(0, true)
+                .await
+        })
+        .await?;
 
         let mut hub = HubHandler {
             bus: bus.clone(),

--- a/embassy-usb-host/src/control.rs
+++ b/embassy-usb-host/src/control.rs
@@ -388,7 +388,17 @@ pub trait ControlPipeExt<D: pipe::Direction>: UsbPipe<pipe::Control, D> {
     {
         let setup = SetupPacket::get_configuration();
         let mut buf = [0u8; 1];
-        self.control_in(&setup.to_bytes(), &mut buf).await?;
+        // Retried on the same grounds as a descriptor read, and for the
+        // same devices: GET_CONFIGURATION is an idempotent read, and a
+        // control transfer restarts from its SETUP, which clears a
+        // control endpoint's protocol stall (USB 2.0 §8.5.3.4).
+        //
+        // Without this a device flaky enough to STALL one read is
+        // reported by every class driver as an outright registration
+        // failure — `RegisterError::HostError(PipeError(Stall))` where
+        // the honest answer is usually `NoSupportedInterface`, since
+        // registration never got far enough to look at an interface.
+        crate::handler::retry_descriptor(async || self.control_in(&setup.to_bytes(), &mut buf).await).await?;
         Ok(NonZeroU8::new(buf[0]))
     }
 

--- a/embassy-usb-host/src/handler.rs
+++ b/embassy-usb-host/src/handler.rs
@@ -1,12 +1,53 @@
 //! USB host device enumeration helpers.
 #![allow(missing_docs)]
 
+use embassy_time::Timer;
 use embassy_usb_driver::Speed;
 use embassy_usb_driver::host::pipe::{self, IsIn, IsOut};
 use embassy_usb_driver::host::{HostError, SplitInfo, SplitSpeed, UsbPipe};
 
 use crate::control::ControlPipeExt;
 use crate::descriptor::{ConfigurationDescriptor, ConfigurationDescriptorChain, DeviceDescriptor, USBDescriptor};
+
+/// How many times a descriptor read is re-attempted before its failure is
+/// taken as the answer.
+pub(crate) const DESCRIPTOR_RETRIES: u32 = 3;
+
+/// Milliseconds between those attempts.
+pub(crate) const DESCRIPTOR_RETRY_MS: u64 = 5;
+
+/// Runs a descriptor read, re-attempting it a few times before taking a
+/// failure as the answer.
+///
+/// Some devices STALL a descriptor read once and answer the identical
+/// request milliseconds later — nothing about the request differs between
+/// the two. Observed here on a USB gamepad (0428:4001), which refuses the
+/// first configuration-descriptor read issued after it is addressed.
+/// Linux's usbcore makes the same allowance for every descriptor read in
+/// `usb_get_descriptor`, commented "some devices are flakey".
+///
+/// Safe in a way it would not be for a state-changing request: a
+/// descriptor read is idempotent, and a control transfer restarts from
+/// its SETUP, which clears a control endpoint's protocol stall (USB 2.0
+/// §8.5.3.4) — so there is nothing left over from the failed attempt to
+/// undo first. `SET_ADDRESS` and `SET_CONFIGURATION` deliberately do not
+/// go through here: repeating one of those is not the same as issuing it
+/// once.
+pub(crate) async fn retry_descriptor<T, E>(mut read: impl AsyncFnMut() -> Result<T, E>) -> Result<T, E> {
+    let mut retries = DESCRIPTOR_RETRIES;
+    loop {
+        match read().await {
+            Ok(value) => return Ok(value),
+            Err(e) => {
+                if retries == 0 {
+                    return Err(e);
+                }
+                retries -= 1;
+                Timer::after_millis(DESCRIPTOR_RETRY_MS).await;
+            }
+        }
+    }
+}
 
 /// How a device's traffic reaches it on the bus.
 ///
@@ -111,9 +152,12 @@ impl EnumerationInfo {
         let mut index = None;
         let mut cfg_len = 0;
         for i in 0..self.device_desc.num_configurations {
-            let cfg_desc_short = channel
-                .request_descriptor::<ConfigurationDescriptor, { ConfigurationDescriptor::BUF_SIZE }>(i, false)
-                .await?;
+            let cfg_desc_short = retry_descriptor(async || {
+                channel
+                    .request_descriptor::<ConfigurationDescriptor, { ConfigurationDescriptor::BUF_SIZE }>(i, false)
+                    .await
+            })
+            .await?;
 
             if cfg_desc_short.configuration_value == cfg_id {
                 if cfg_desc_short.total_len as usize > cfg_desc_buf.len() {
@@ -127,9 +171,12 @@ impl EnumerationInfo {
 
         let index = index.ok_or(HostError::Other("Active configuration not found on device"))?;
         let dest = &mut cfg_desc_buf[0..cfg_len];
-        channel
-            .request_descriptor_bytes(ConfigurationDescriptor::DESC_TYPE, index, dest)
-            .await?;
+        retry_descriptor(async || {
+            channel
+                .request_descriptor_bytes(ConfigurationDescriptor::DESC_TYPE, index, &mut *dest)
+                .await
+        })
+        .await?;
 
         let cfg =
             ConfigurationDescriptorChain::try_from_slice(cfg_desc_buf).map_err(|_| HostError::InvalidDescriptor)?;
@@ -147,18 +194,44 @@ impl EnumerationInfo {
             return Err(HostError::InvalidDescriptor);
         }
 
-        let cfg_desc_short = channel
-            .request_descriptor::<ConfigurationDescriptor, { ConfigurationDescriptor::BUF_SIZE }>(index, false)
-            .await?;
+        // Both reads below are retried, for the same reason the device
+        // descriptor above them already is: some devices STALL a
+        // descriptor read once and answer the identical request
+        // milliseconds later. Leaving the configuration descriptor as
+        // the only unretried read in enumeration means one such device
+        // never enumerates at all, having already got past every step
+        // that does allow for it.
+        //
+        // Observed on a USB gamepad (0428:4001), which STALLs the first
+        // configuration-descriptor read issued after it is addressed and
+        // then answers the same request on the next attempt. Linux's
+        // usbcore makes the same allowance for every descriptor read in
+        // `usb_get_descriptor`, commented "some devices are flakey".
+        //
+        // Retrying is safe here in a way it would not be for a
+        // state-changing request: a descriptor read is idempotent, and a
+        // control transfer restarts from its SETUP, which clears a
+        // control endpoint's protocol stall (USB 2.0 §8.5.3.4) — so
+        // there is no leftover state from the failed attempt to undo
+        // first.
+        let cfg_desc_short = retry_descriptor(async || {
+            channel
+                .request_descriptor::<ConfigurationDescriptor, { ConfigurationDescriptor::BUF_SIZE }>(index, false)
+                .await
+        })
+        .await?;
 
         let total_len = cfg_desc_short.total_len as usize;
         if total_len > cfg_desc_buf.len() {
             return Err(HostError::InsufficientMemory);
         }
         let dest = &mut cfg_desc_buf[0..total_len];
-        channel
-            .request_descriptor_bytes(ConfigurationDescriptor::DESC_TYPE, index, dest)
-            .await?;
+        retry_descriptor(async || {
+            channel
+                .request_descriptor_bytes(ConfigurationDescriptor::DESC_TYPE, index, &mut *dest)
+                .await
+        })
+        .await?;
 
         trace!(
             "Full Configuration Descriptor [{}]: {:?}",

--- a/embassy-usb-host/src/lib.rs
+++ b/embassy-usb-host/src/lib.rs
@@ -383,22 +383,16 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
             .alloc_pipe::<pipe::Control, pipe::InOut>(addr.addr(), &ep0_info, route.split())
             .map_err(|_| EnumerationError::NoPipe)?;
 
-        let retries = 5;
-        let dev_desc = async {
-            for _ in 0..retries {
-                match ch
-                    .request_descriptor::<DeviceDescriptor, { DeviceDescriptor::BUF_SIZE }>(0, false)
-                    .await
-                {
-                    Err(HostError::PipeError(PipeError::Timeout)) => {
-                        Timer::after_millis(1).await;
-                        continue;
-                    }
-                    v => return v,
-                }
-            }
-            Err(HostError::PipeError(PipeError::Timeout))
-        }
+        // Retried on any error, not only on a timeout as this read used
+        // to be. A device flaky enough to STALL a descriptor read is the
+        // case the retry exists for, and a stall took the `v => return v`
+        // arm straight out of the loop — so the read with the largest
+        // retry budget in the function was also the one that gave up
+        // first on the most likely failure.
+        let dev_desc = crate::handler::retry_descriptor(async || {
+            ch.request_descriptor::<DeviceDescriptor, { DeviceDescriptor::BUF_SIZE }>(0, false)
+                .await
+        })
         .await?;
 
         info!(
@@ -408,7 +402,8 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         // Step 4: Get configuration descriptor header (9 bytes).
         let setup = SetupPacket::get_config_descriptor(0, 9);
-        let n = ch.control_in(&setup.to_bytes(), &mut config_buf[..9]).await?;
+        let n = crate::handler::retry_descriptor(async || ch.control_in(&setup.to_bytes(), &mut config_buf[..9]).await)
+            .await?;
 
         if n < 9 {
             return Err(EnumerationError::InvalidDescriptor);
@@ -424,7 +419,10 @@ impl<'d, A: UsbHostAllocator<'d>> BusHandle<'d, A> {
 
         // Get full configuration descriptor.
         let setup = SetupPacket::get_config_descriptor(0, total_len as u16);
-        let n = ch.control_in(&setup.to_bytes(), &mut config_buf[..total_len]).await?;
+        let n = crate::handler::retry_descriptor(async || {
+            ch.control_in(&setup.to_bytes(), &mut config_buf[..total_len]).await
+        })
+        .await?;
 
         // USB 2.0 §9.4.3: the device must return exactly total_len bytes for a full config descriptor.
         if n != total_len {


### PR DESCRIPTION
Some devices STALL a descriptor read once and answer the identical request milliseconds later. `enumerate` already allows for this on the device descriptor (10 attempts for the initial 8-byte read, 5 for the full one), but six other descriptor reads had no retry at all:

  - both configuration-descriptor reads in `enumerate`
  - both in `EnumerationInfo::get_configuration`
  - both in `EnumerationInfo::get_active_configuration`
  - the hub class descriptor in `HubHandler::try_register`
  - GET_CONFIGURATION in `ControlPipeExt::active_configuration_value`

A device flaky in that way therefore gets past every step that tolerates it and fails at one that does not. Observed on a USB gamepad (0428:4001), which refuses the first configuration-descriptor read issued after it is addressed: enumeration failed outright, and once that was fixed, class registration then failed at `active_configuration_value` instead.

Add a `handler::retry_descriptor` helper and route all of them through it. Retrying is safe here in a way it would not be for a state-changing request: a descriptor read is idempotent, and a control transfer restarts from its SETUP, which clears a control endpoint's protocol stall (USB 2.0 §8.5.3.4), so nothing is left over from the failed attempt. SET_ADDRESS and SET_CONFIGURATION deliberately do not go through it.

Linux's usbcore makes the same allowance for every descriptor read in `usb_get_descriptor`, commented "some devices are flakey".

---

Tested on Raspberry Pi 3 via https://github.com/joeferner/rpi-hal-embassy and https://github.com/joeferner/rpi-hal