### PR TITLE
RPi Uart Runtime Config

### DIFF
--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -179,7 +179,7 @@ impl BufferedUart {
 
     /// Set the configuration at runtime
     pub fn set_config<'d>(&mut self, config: Config) {
-        super::Uart::<'d, Async>::set_config_inner(self.rx.info, config);
+        self.tx.set_config(config);
     }
 
     /// Split into separate RX and TX handles.
@@ -491,6 +491,11 @@ impl BufferedUartTx {
     /// sets baudrate on runtime
     pub fn set_baudrate<'d>(&mut self, baudrate: u32) {
         super::Uart::<'d, Async>::set_baudrate_inner(self.info, baudrate);
+    }
+
+    /// Set the configuration at runtime
+    pub fn set_config<'d>(&mut self, config: Config) {
+        super::Uart::<'d, Async>::set_config_inner(self.info, config);
     }
 }
 

--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -177,6 +177,11 @@ impl BufferedUart {
         self.tx.set_baudrate(baudrate);
     }
 
+    /// Set the configuration at runtime
+    pub fn set_config<'d>(&mut self, config: Config) {
+        super::Uart::<'d, Async>::set_config_inner(self.rx.info, config);
+    }
+
     /// Split into separate RX and TX handles.
     pub fn split(self) -> (BufferedUartTx, BufferedUartRx) {
         (self.tx, self.rx)

--- a/embassy-rp/src/uart/buffered.rs
+++ b/embassy-rp/src/uart/buffered.rs
@@ -177,7 +177,7 @@ impl BufferedUart {
         self.tx.set_baudrate(baudrate);
     }
 
-    /// Set the configuration at runtime
+    /// Set the configuration at runtime (ignores pin inversions)
     pub fn set_config<'d>(&mut self, config: Config) {
         self.tx.set_config(config);
     }
@@ -493,7 +493,7 @@ impl BufferedUartTx {
         super::Uart::<'d, Async>::set_baudrate_inner(self.info, baudrate);
     }
 
-    /// Set the configuration at runtime
+    /// Set the configuration at runtime (ignores pin inversions)
     pub fn set_config<'d>(&mut self, config: Config) {
         super::Uart::<'d, Async>::set_config_inner(self.info, config);
     }

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -1085,6 +1085,28 @@ impl<'d, M: Mode> Uart<'d, M> {
 
         Self::lcr_modify(info, |_| {});
     }
+
+    /// Set the configuration at runtime
+    pub fn set_config(&mut self, config: Config) {
+        Self::set_config_inner(self.tx.info, config);
+    }
+
+    fn set_config_inner(info: &Info, config: Config) {
+        Self::set_baudrate_inner(info, config.baudrate);
+        let (pen, eps) = match config.parity {
+            Parity::ParityNone => (false, false),
+            Parity::ParityOdd => (true, false),
+            Parity::ParityEven => (true, true),
+        };
+
+        Self::lcr_modify(info, |w| {
+            w.set_wlen(config.data_bits.bits());
+            w.set_stp2(config.stop_bits == StopBits::STOP2);
+            w.set_pen(pen);
+            w.set_eps(eps);
+            w.set_fen(true);
+        })
+    }
 }
 
 impl<'d, M: Mode> Uart<'d, M> {

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -1051,7 +1051,7 @@ impl<'d, M: Mode> Uart<'d, M> {
     fn set_baudrate_inner(info: &Info, baudrate: u32) {
         Self::set_baudrate_nowait(info, baudrate);
 
-        // wait for the tx to clear before allowing more transmits
+        // wait for tx to clear before returning
         Self::lcr_modify(info, |_| {});
     }
 

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -1049,6 +1049,14 @@ impl<'d, M: Mode> Uart<'d, M> {
     }
 
     fn set_baudrate_inner(info: &Info, baudrate: u32) {
+        Self::set_baudrate_nowait(info, baudrate);
+
+        // wait for the tx to clear before allowing more transmits
+        Self::lcr_modify(info, |_| {});
+    }
+
+    /// Set the baudrate without waiting for the tx to clear
+    fn set_baudrate_nowait(info: &Info, baudrate: u32) {
         let r = info.regs;
 
         let clk_base = crate::clocks::clk_peri_freq();
@@ -1068,17 +1076,15 @@ impl<'d, M: Mode> Uart<'d, M> {
         // Load PL011's baud divisor registers
         r.uartibrd().write_value(pac::uart::regs::Uartibrd(baud_ibrd));
         r.uartfbrd().write_value(pac::uart::regs::Uartfbrd(baud_fbrd));
-
-        Self::lcr_modify(info, |_| {});
     }
 
-    /// Set the configuration at runtime
+    /// Set the configuration at runtime (ignores pin inversions)
     pub fn set_config(&mut self, config: Config) {
         Self::set_config_inner(self.tx.info, config);
     }
 
     fn set_config_inner(info: &Info, config: Config) {
-        Self::set_baudrate_inner(info, config.baudrate);
+        Self::set_baudrate_nowait(info, config.baudrate);
         let (pen, eps) = match config.parity {
             Parity::ParityNone => (false, false),
             Parity::ParityOdd => (true, false),

--- a/embassy-rp/src/uart/mod.rs
+++ b/embassy-rp/src/uart/mod.rs
@@ -974,21 +974,7 @@ impl<'d, M: Mode> Uart<'d, M> {
             });
         }
 
-        Self::set_baudrate_inner(info, config.baudrate);
-
-        let (pen, eps) = match config.parity {
-            Parity::ParityNone => (false, false),
-            Parity::ParityOdd => (true, false),
-            Parity::ParityEven => (true, true),
-        };
-
-        r.uartlcr_h().write(|w| {
-            w.set_wlen(config.data_bits.bits());
-            w.set_stp2(config.stop_bits == StopBits::STOP2);
-            w.set_pen(pen);
-            w.set_eps(eps);
-            w.set_fen(true);
-        });
+        Self::set_config_inner(info, config);
 
         r.uartifls().write(|w| {
             w.set_rxiflsel(0b100);

--- a/examples/rp235x/src/bin/usb_to_uart.rs
+++ b/examples/rp235x/src/bin/usb_to_uart.rs
@@ -18,7 +18,7 @@ use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::{UART0, USB};
 use embassy_rp::uart::{BufferedInterruptHandler, BufferedUart, Config};
 use embassy_rp::usb::{Driver as UsbDriver, InterruptHandler as UsbInterruptHandler};
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State, LineCoding};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, LineCoding, State};
 use embedded_io_async::{BufRead, Write};
 use panic_probe as _;
 use static_cell::StaticCell;

--- a/examples/rp235x/src/bin/usb_to_uart.rs
+++ b/examples/rp235x/src/bin/usb_to_uart.rs
@@ -18,7 +18,7 @@ use embassy_rp::bind_interrupts;
 use embassy_rp::peripherals::{UART0, USB};
 use embassy_rp::uart::{BufferedInterruptHandler, BufferedUart, Config};
 use embassy_rp::usb::{Driver as UsbDriver, InterruptHandler as UsbInterruptHandler};
-use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State, LineCoding};
 use embedded_io_async::{BufRead, Write};
 use panic_probe as _;
 use static_cell::StaticCell;
@@ -113,9 +113,9 @@ async fn main(_spawner: Spawner) {
             loop {
                 match select(usb_control.control_changed(), usb_rx.read_packet(&mut usb_buf)).await {
                     Either::First(_) => {
-                        let baud = usb_rx.line_coding().data_rate();
-                        info!("Setting baud to: {}", baud);
-                        uart_tx.set_baudrate(baud);
+                        let config = uart_config_from_line_coding(usb_rx.line_coding());
+                        info!("Setting line coding: {}", &config);
+                        uart_tx.set_config(config);
                     }
                     Either::Second(Err(err)) => {
                         error!("Usb read error: {:?}. Assume disconnection", Debug2Format(&err));
@@ -132,4 +132,26 @@ async fn main(_spawner: Spawner) {
     };
 
     join3(usb_fut, usb_rx_uart_tx, usb_tx_uart_rx).await;
+}
+
+fn uart_config_from_line_coding(lc: LineCoding) -> Config {
+    use embassy_rp::uart::{DataBits, Parity, StopBits};
+    let mut config = Config::default();
+    config.baudrate = lc.data_rate();
+    config.data_bits = match lc.data_bits() {
+        5 => DataBits::DataBits5,
+        6 => DataBits::DataBits6,
+        7 => DataBits::DataBits7,
+        _ => DataBits::DataBits8,
+    };
+    config.parity = match lc.parity_type() {
+        embassy_usb::class::cdc_acm::ParityType::Even => Parity::ParityEven,
+        embassy_usb::class::cdc_acm::ParityType::Odd => Parity::ParityOdd,
+        _ => Parity::ParityNone,
+    };
+    config.stop_bits = match lc.stop_bits() {
+        embassy_usb::class::cdc_acm::StopBits::Two => StopBits::STOP2,
+        _ => StopBits::STOP1,
+    };
+    config
 }


### PR DESCRIPTION
I was playing around with USB serial for UPDI and I discovered that it was kind of complicated change anything but the baud rate on the RPi uart driver after it's been constructed, so I made a way to do that.  (UPDI uses serial with parity and 2 stop bits)

Changes:

- Added a set_config function to all the places where set_baudrate exists.
- Modified usb_to_uart example to change the config when the line_coding changes.

Testing:

- With the rp235x usb_to_uart.rs example I can use avrdude successfully with an attiny1616 connected
  `avrdude -c serialupdi -p t1616 -P /dev/ttyACM0 -b 115200 -v`

Notes:

- I'm a little skeptical if there is a failure case for this that I don't see because `lcr_modify` function is already 90% of the way there, but there was no `set_config` function implemented.
- I didn't implement setting the pin inversions in `set_config` because it's not a control in the `cdc-acm` implementation, but I'm open to trying if people feel strongly it should be there.