### PR TITLE
nxp: add LPC55 SHA driver

### DIFF
--- a/embassy-nxp/src/lib.rs
+++ b/embassy-nxp/src/lib.rs
@@ -16,6 +16,8 @@ pub mod pwm;
 #[cfg(lpc55)]
 pub mod sct;
 #[cfg(lpc55)]
+pub mod sha;
+#[cfg(lpc55)]
 pub mod spi;
 #[cfg(lpc55)]
 pub mod usart;

--- a/embassy-nxp/src/sha.rs
+++ b/embassy-nxp/src/sha.rs
@@ -1,0 +1,8 @@
+//! Secure Hash Algorithm (SHA) driver.
+//!
+//! Currently supported:
+//! - SHA-256 on LPC55 HASHCRYPT.
+
+#[cfg_attr(lpc55, path = "./sha/lpc55.rs")]
+mod inner;
+pub use inner::*;

--- a/embassy-nxp/src/sha/lpc55.rs
+++ b/embassy-nxp/src/sha/lpc55.rs
@@ -1,0 +1,290 @@
+//! Blocking SHA-256 driver for the LPC55S69 HASHCRYPT peripheral.
+//!
+//! This module provides a blocking SHA-256 implementation using the hardware
+//! HASHCRYPT accelerator available on the LPC55S69 microcontroller.
+//!
+//! The driver feeds message blocks to the peripheral through the INDATA register
+//! and polls the peripheral status flags until processing is complete.
+//!
+//! # Features
+//!
+//! - SHA-256 hashing only
+//! - CPU polling mode (no DMA)
+//! - Streaming input through [`CpuSha256::update`]
+//! - Software-managed SHA-256 padding
+//!
+//! # Limitations
+//!
+//! This implementation is intentionally blocking. The CPU remains active while
+//! waiting for the HASHCRYPT peripheral. A future implementation could use
+//! interrupts or DMA to avoid polling.
+
+#![macro_use]
+
+use embassy_hal_internal::{Peri, PeripheralType};
+
+use crate::pac::hashcrypt::vals::Mode;
+use crate::pac::syscon::vals::HashAesRst;
+use crate::pac::{HASHCRYPT, SYSCON};
+
+/// SHA-256 processes data in 512-bit message blocks.
+const BLOCK_SIZE: usize = 64;
+
+/// Number of bytes reserved for the SHA-256 message length field.
+const LENGTH_FIELD_SIZE: usize = 8;
+
+/// Offset where the 64-bit message length is stored in the final block.
+const LENGTH_OFFSET: usize = BLOCK_SIZE - 8;
+
+/// Size of one HASHCRYPT input word.
+const WORD_SIZE: usize = 4;
+
+/// Errors returned by the SHA-256 hardware driver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub enum Error {
+    /// The HASHCRYPT peripheral reported an internal processing error.
+    HardwareFault,
+
+    /// The input message length exceeded the maximum supported SHA-256 length.
+    ///
+    /// SHA-256 stores the message length in a 64-bit field, limiting the
+    /// maximum message size to 2^64 - 1 bits.
+    LengthOverflow,
+}
+
+/// Marker trait implemented by peripherals capable of providing
+/// HASHCRYPT functionality.
+///
+/// This trait exists to allow the driver API to accept concrete peripheral
+/// instances while keeping the implementation independent of the PAC type.
+
+pub(crate) trait SealedInstance {}
+
+/// Marker trait implemented by HASHCRYPT peripherals supported by this driver.
+#[allow(private_bounds)]
+pub trait Instance: PeripheralType + SealedInstance + 'static {}
+
+impl SealedInstance for crate::peripherals::HASHCRYPT {}
+impl Instance for crate::peripherals::HASHCRYPT {}
+
+/// Blocking SHA-256 driver.
+///
+/// The driver owns the HASHCRYPT peripheral and maintains the software
+/// state required to perform streaming SHA-256 hash computations.
+#[must_use]
+pub struct CpuSha256<'d, T: Instance> {
+    _hashcrypt: Peri<'d, T>,
+
+    /// Partial message block waiting to be sent to HASHCRYPT.
+    buffer: [u8; BLOCK_SIZE],
+
+    /// Number of valid bytes currently stored in `buffer`.
+    buffer_len: usize,
+
+    /// Total length of the message processed so far, measured in bits.
+    total_bits: u64,
+}
+
+impl<'d, T: Instance> CpuSha256<'d, T> {
+    /// Creates a new SHA-256 driver.
+    ///
+    /// The driver takes ownership of the HASHCRYPT peripheral and initializes
+    /// both its software state and the underlying hardware.
+    ///
+    /// The returned instance is ready to receive message data through
+    /// [`CpuSha256::update`].
+    #[must_use]
+    pub fn new(hashcrypt: Peri<'d, T>) -> Self {
+        let mut driver = Self {
+            _hashcrypt: hashcrypt,
+            buffer: [0; BLOCK_SIZE],
+            buffer_len: 0,
+            total_bits: 0,
+        };
+
+        driver.reset();
+
+        driver
+    }
+
+    /// Feeds additional message bytes into the SHA-256 calculation.
+    ///
+    /// Input may be provided in arbitrary sized chunks. Internally, the driver
+    /// accumulates data until a complete 512-bit block is available and then sends
+    /// it to the HASHCRYPT peripheral.
+    ///
+    /// This method does not finalize the hash operation. Call [`finish`] after all
+    /// input data has been provided. To begin a new hash computation after
+    /// finalization, call [`reset`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::LengthOverflow`] if the total message length exceeds the
+    /// SHA-256 maximum representable size.
+    pub fn update(&mut self, mut data: &[u8]) -> Result<(), Error> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        self.total_bits = self
+            .total_bits
+            .checked_add((data.len() as u64) * 8)
+            .ok_or(Error::LengthOverflow)?;
+
+        if self.buffer_len > 0 {
+            let available = BLOCK_SIZE - self.buffer_len;
+            let to_copy = core::cmp::min(available, data.len());
+            self.buffer[self.buffer_len..self.buffer_len + to_copy].copy_from_slice(&data[..to_copy]);
+            self.buffer_len += to_copy;
+            data = &data[to_copy..];
+
+            if self.buffer_len == BLOCK_SIZE {
+                self.write_block(&self.buffer);
+                self.buffer_len = 0;
+            }
+        }
+
+        let mut chunks = data.chunks_exact(BLOCK_SIZE);
+        for block in &mut chunks {
+            let block: &[u8; BLOCK_SIZE] = block.try_into().unwrap();
+            self.write_block(block);
+        }
+
+        let remainder = chunks.remainder();
+        if !remainder.is_empty() {
+            self.buffer[..remainder.len()].copy_from_slice(remainder);
+            self.buffer_len = remainder.len();
+        }
+
+        Ok(())
+    }
+
+    /// Resets the driver to begin a new SHA-256 computation.
+    ///
+    /// This clears the software state, reinitializes the HASHCRYPT hardware,
+    /// and starts a new hash operation. Any previously computed digest is discarded.
+    pub fn reset(&mut self) {
+        self.buffer.fill(0);
+        self.buffer_len = 0;
+        self.total_bits = 0;
+
+        Self::init_hardware();
+    }
+
+    /// Completes the SHA-256 operation and returns the final digest.
+    ///
+    /// This method performs the SHA-256 finalization sequence:
+    ///
+    /// - appends the mandatory `1` bit,
+    /// - adds zero padding,
+    /// - appends the original message length,
+    /// - waits for HASHCRYPT completion,
+    /// - reads the resulting digest.
+    ///
+    /// The driver remains usable after finalization. Call [`reset`] before
+    /// beginning another independent hash operation using the same HASHCRYPT
+    /// peripheral.
+    pub fn finish(&mut self) -> Result<[u32; 8], Error> {
+        self.buffer[self.buffer_len] = 0x80;
+        self.buffer_len += 1;
+
+        if self.buffer_len > LENGTH_OFFSET {
+            self.buffer[self.buffer_len..BLOCK_SIZE].fill(0);
+            self.write_block(&self.buffer);
+            self.buffer_len = 0;
+        }
+
+        self.buffer[self.buffer_len..LENGTH_OFFSET].fill(0);
+
+        self.buffer[LENGTH_OFFSET..BLOCK_SIZE].copy_from_slice(&self.total_bits.to_be_bytes());
+
+        self.write_block(&self.buffer);
+
+        Self::wait_digest()?;
+
+        Ok(Self::read_digest())
+    }
+
+    /// Initializes the HASHCRYPT peripheral for a new SHA-256 operation.
+    fn init_hardware() {
+        Self::release_reset();
+        Self::enable_clock();
+        Self::configure();
+    }
+
+    /// Releases the HASHCRYPT peripheral from reset.
+    fn release_reset() {
+        SYSCON.presetctrl2().modify(|r| {
+            r.set_hash_aes_rst(HashAesRst::Released);
+        });
+    }
+
+    /// Enables the AHB clock for the HASHCRYPT peripheral.
+    fn enable_clock() {
+        SYSCON.ahbclkctrl2().modify(|r| {
+            r.set_hash_aes(true);
+        });
+    }
+
+    /// Configures the HASHCRYPT peripheral for SHA-256 and starts a new hardware hash session.
+    fn configure() {
+        HASHCRYPT.ctrl().modify(|r| {
+            r.set_mode(Mode::Sha2256);
+        });
+
+        HASHCRYPT.ctrl().modify(|r| {
+            r.set_new_hash(true);
+        });
+    }
+
+    /// Waits until HASHCRYPT finishes processing the current message.
+    fn wait_digest() -> Result<(), Error> {
+        loop {
+            let status = HASHCRYPT.status().read();
+
+            if status.error() {
+                return Err(Error::HardwareFault);
+            }
+
+            if status.digest() {
+                return Ok(());
+            }
+
+            cortex_m::asm::nop();
+        }
+    }
+
+    /// Transfers one complete 512-bit SHA-256 message block to the HASHCRYPT
+    /// peripheral.
+    ///
+    /// The peripheral accepts data through the 32-bit INDATA register, so the
+    /// block is written as sixteen consecutive 32-bit words. The driver waits
+    /// until the hardware is ready before writing each word.
+    #[inline(always)]
+    fn write_block(&self, block: &[u8; BLOCK_SIZE]) {
+        for chunk in block.chunks_exact(WORD_SIZE) {
+            // HASHCRYPT expects 32-bit little-endian words through INDATA.
+            let word = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+
+            while !HASHCRYPT.status().read().waiting() {
+                cortex_m::asm::nop();
+            }
+
+            HASHCRYPT.indata().write(|r| {
+                r.set_data(word);
+            });
+        }
+    }
+
+    /// Reads the 256-bit digest from the HASHCRYPT digest registers.
+    #[inline]
+    fn read_digest() -> [u32; LENGTH_FIELD_SIZE] {
+        let mut digest = [0u32; LENGTH_FIELD_SIZE];
+        for (i, word) in digest.iter_mut().enumerate() {
+            *word = HASHCRYPT.digest0(i).read().digest();
+        }
+
+        digest
+    }
+}

--- a/examples/lpc55s69/src/bin/sha_blocking.rs
+++ b/examples/lpc55s69/src/bin/sha_blocking.rs
@@ -1,0 +1,160 @@
+//! Blocking SHA-256 example using the LPC55S69 HASHCRYPT peripheral.
+//!
+//! This example demonstrates how to use the HASHCRYPT hardware accelerator
+//! through the `CpuSha256` driver.
+//!
+//! The example covers:
+//! - Creating a new hashing context.
+//! - Hashing a complete message.
+//! - Verifying the result against a known SHA-256 test vector.
+//! - Reusing the same hardware context with `reset()`.
+//! - Streaming data using multiple `update()` calls.
+//! - Feeding arbitrary chunk sizes.
+//!
+//! The resulting SHA-256 digests are printed over the debug console.
+
+#![no_std]
+#![no_main]
+
+use defmt::{info, unwrap};
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_nxp::sha::CpuSha256;
+use panic_probe as _;
+
+/// SHA-256 test vector for the message "abc".
+///
+/// Expected digest:
+/// ba7816bf8f01cfea414140de5dae2223
+/// b00361a396177a9cb410ff61f20015ad
+const SHA256_ABC: [u32; 8] = [
+    0xba7816bf, 0x8f01cfea, 0x414140de, 0x5dae2223, 0xb00361a3, 0x96177a9c, 0xb410ff61, 0xf20015ad,
+];
+
+/// Print a SHA-256 digest returned by the HASHCRYPT peripheral.
+///
+/// The hardware returns the digest as eight 32-bit words.
+fn print_digest(title: &str, digest: [u32; 8]) {
+    info!("----------------------------------------");
+    info!("{}", title);
+
+    for word in digest {
+        info!("{=u32:08x}", word);
+    }
+
+    info!("----------------------------------------");
+}
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_nxp::init(Default::default());
+    info!("LPC55S69 HASHCRYPT SHA-256 example");
+
+    //----------------------------------------------------------------------
+    // Create a SHA-256 driver.
+    //
+    // The driver takes ownership of the HASHCRYPT peripheral and
+    // initializes the hardware.
+    //----------------------------------------------------------------------
+    let mut sha = CpuSha256::new(p.HASHCRYPT);
+
+    //----------------------------------------------------------------------
+    // Example 1
+    //
+    // Hash a complete message using a single update() call.
+    //----------------------------------------------------------------------
+    info!("Example 1");
+
+    unwrap!(sha.update(b"abc"));
+
+    let digest = unwrap!(sha.finish());
+
+    print_digest("SHA-256(\"abc\")", digest);
+
+    // Verify the hardware result against the standard SHA-256 test vector.
+    assert_eq!(digest, SHA256_ABC);
+    info!("SHA-256(\"abc\") verification passed.");
+
+    //----------------------------------------------------------------------
+    // Prepare the driver for another independent hash operation.
+    //
+    // reset() clears the software state and starts a new HASHCRYPT session.
+    //----------------------------------------------------------------------
+    sha.reset();
+
+    //----------------------------------------------------------------------
+    // Example 2
+    //
+    // Hash the same message incrementally.
+    //
+    // Multiple update() calls are equivalent to one large update().
+    //----------------------------------------------------------------------
+    info!("Example 2");
+
+    unwrap!(sha.update(b"a"));
+    unwrap!(sha.update(b"b"));
+    unwrap!(sha.update(b"c"));
+
+    let digest = unwrap!(sha.finish());
+
+    print_digest("SHA-256 streamed \"abc\"", digest);
+
+    // Verify that streaming input produces the same digest.
+    assert_eq!(digest, SHA256_ABC);
+    info!("SHA-256 streamed \"abc\" verification passed.");
+
+    //----------------------------------------------------------------------
+    // Start another independent hash.
+    //----------------------------------------------------------------------
+    sha.reset();
+
+    //----------------------------------------------------------------------
+    // Example 3
+    //
+    // Feed a larger message in several chunks.
+    //
+    // The driver automatically buffers incomplete blocks and sends
+    // complete 512-bit blocks to the HASHCRYPT peripheral.
+    //----------------------------------------------------------------------
+    info!("Example 3");
+
+    unwrap!(sha.update(b"The quick "));
+    unwrap!(sha.update(b"brown fox "));
+    unwrap!(sha.update(b"jumps over "));
+    unwrap!(sha.update(b"the lazy dog"));
+
+    let digest = unwrap!(sha.finish());
+
+    print_digest("SHA-256(\"The quick brown fox jumps over the lazy dog\")", digest);
+
+    //----------------------------------------------------------------------
+    // Reuse the hardware once more.
+    //----------------------------------------------------------------------
+    sha.reset();
+
+    //----------------------------------------------------------------------
+    // Example 4
+    //
+    // update() accepts data of any size.
+    //
+    // Here we intentionally split the input into small pieces to exercise
+    // the driver's internal buffering logic.
+    //----------------------------------------------------------------------
+    info!("Example 4");
+
+    let message = b"Embassy makes embedded Rust development enjoyable and ergonomic.";
+
+    for chunk in message.chunks(5) {
+        unwrap!(sha.update(chunk));
+    }
+
+    let digest = unwrap!(sha.finish());
+
+    print_digest("SHA-256(chunked message)", digest);
+
+    info!("All SHA-256 examples completed.");
+
+    loop {
+        cortex_m::asm::wfi();
+    }
+}


### PR DESCRIPTION
## Summary

Adds a blocking SHA-256 driver for the LPC55S69 HASHCRYPT peripheral.

## Changes

- Add the `sha` module to `embassy-nxp`.
- Add a `CpuSha256` driver for LPC55S69 HASHCRYPT.
- Implement SHA-256 streaming through `update()`.
- Implement software-managed SHA-256 padding and message length encoding.
- Use CPU polling for HASHCRYPT input and digest completion.
- Add `reset()` support for starting independent hash operations.
- Add an LPC55S69 SHA-256 example covering single-shot and streaming input.
- Verify the SHA-256 result of `"abc"` against the standard test vector.

## Testing

Tested on an LPC55S69 using the HASHCRYPT hardware peripheral.

Verified the standard SHA-256 test vector for `"abc"`:

`ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad`

Also verified streamed input (`"a"`, `"b"`, `"c"`) produces the same digest.

The Embassy NXP crate and LPC55S69 example both pass `cargo check`, and the example was run successfully on the LPC55S69 hardware.