### PR TITLE
ptp-driver/stm32: network clock trait and impls

### DIFF
--- a/.github/ci/test.sh
+++ b/.github/ci/test.sh
@@ -19,6 +19,7 @@ cargo test --manifest-path ./embassy-embedded-hal/Cargo.toml
 cargo test --manifest-path ./embassy-hal-internal/Cargo.toml
 cargo test --manifest-path ./embassy-time/Cargo.toml --features mock-driver,embassy-time-queue-utils/generic-queue-8
 cargo test --manifest-path ./embassy-time-driver/Cargo.toml
+cargo test --manifest-path ./embassy-ptp-driver/Cargo.toml --all-features
 
 cargo test --manifest-path ./embassy-boot/Cargo.toml
 cargo test --manifest-path ./embassy-boot/Cargo.toml --features ed25519-dalek

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Rust's [async/await](https://rust-lang.github.io/async-book/) allows for unprece
 
 - **Networking** -
   The [embassy-net](https://docs.embassy.dev/embassy-net/) network stack implements extensive networking functionality, including Ethernet, IP, TCP, UDP, ICMP, and DHCP. Async drastically simplifies managing timeouts and serving multiple connections concurrently.
+  [embassy-ptp-driver](https://docs.embassy.dev/embassy-ptp-driver/) provides a network-stack-independent interface for reading and adjusting PTP hardware clocks.
 
 - **Bluetooth**
     - The [trouble](https://github.com/embassy-rs/trouble) crate provides a Bluetooth Low Energy 4.x and 5.x Host that runs on any microcontroller implementing the [bt-hci](https://github.com/embassy-rs/bt-hci) traits (currently

--- a/docs/pages/overview.adoc
+++ b/docs/pages/overview.adoc
@@ -41,6 +41,8 @@ as they implement both the link:https://github.com/rust-embedded/embedded-hal[Em
 === Networking
 The link:https://docs.embassy.dev/embassy-net/[embassy-net] network stack implements extensive networking functionality, including Ethernet, IP, TCP, UDP, ICMP and DHCP. Async drastically simplifies managing timeouts and serving multiple connections concurrently. Several drivers for WiFi and Ethernet chips can be found.
 
+The link:https://docs.embassy.dev/embassy-ptp-driver/[embassy-ptp-driver] crate defines a network-stack-independent interface for reading and adjusting PTP hardware clocks.
+
 === Bluetooth
 
 * The link:https://github.com/embassy-rs/trouble[trouble] crate provides a Bluetooth Low Energy 4.x and 5.x Host that runs on any microcontroller implementing the link:https://github.com/embassy-rs/bt-hci[bt-hci] traits (currently `nRF52`, `nrf54`, `rp2040`, `rp23xx` and `esp32` and `serial` controllers are supported).

--- a/embassy-ptp-driver/CHANGELOG.md
+++ b/embassy-ptp-driver/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!-- next-header -->
+## Unreleased - ReleaseDate
+
+## 0.1.0 - ReleaseDate
+
+- Initial release.

--- a/embassy-ptp-driver/Cargo.toml
+++ b/embassy-ptp-driver/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "embassy-ptp-driver"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+description = "Driver trait and types for PTP hardware clocks."
+repository = "https://github.com/embassy-rs/embassy"
+documentation = "https://docs.embassy.dev/embassy-ptp-driver"
+readme = "README.md"
+categories = [
+    "embedded",
+    "no-std",
+    "hardware-support",
+]
+
+[package.metadata.embassy_docs]
+src_base = "https://github.com/embassy-rs/embassy/blob/embassy-ptp-driver-v$VERSION/embassy-ptp-driver/src/"
+src_base_git = "https://github.com/embassy-rs/embassy/blob/$COMMIT/embassy-ptp-driver/src/"
+features = ["defmt"]
+target = "thumbv7em-none-eabi"
+
+[package.metadata.docs.rs]
+features = ["defmt"]
+
+[package.metadata.embassy]
+build = [
+    {target = "thumbv7em-none-eabi", features = ["defmt"]},
+]
+
+[dependencies]
+defmt = { version = "1.0.1", optional = true }
+
+[features]
+defmt = ["dep:defmt"]

--- a/embassy-ptp-driver/README.md
+++ b/embassy-ptp-driver/README.md
@@ -1,0 +1,18 @@
+# embassy-ptp-driver
+
+This crate defines the common timestamp type and adjustable clock trait for PTP
+hardware clocks. Hardware implementations and clock-synchronization engines can
+depend on this crate without depending on each other or on `embassy-net`.
+
+Packet timestamp transport and its timestamp type remain independently owned by
+`embassy-net-driver`. An integration crate may convert between timestamps when
+the packet timestamp source and adjustable clock are the same hardware time
+domain.
+
+The clock here is also distinct from `embassy-time-driver`: executor time is a
+global, monotonic scheduling clock, while a PTP hardware clock has an arbitrary
+epoch and is adjusted while it is being synchronized.
+
+## Interoperability
+
+This crate can run on any executor.

--- a/embassy-ptp-driver/src/lib.rs
+++ b/embassy-ptp-driver/src/lib.rs
@@ -1,0 +1,141 @@
+#![no_std]
+#![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
+
+/// A reading of a PTP hardware clock.
+///
+/// The clock has an arbitrary epoch and drifts with respect to other clocks
+/// unless it is actively disciplined. Do not mix this with executor time.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default)]
+pub struct Timestamp {
+    /// Whole seconds.
+    seconds: u32,
+    /// Fraction of a second, in units of 0.25 nanoseconds.
+    quarter_nanos: u32,
+}
+
+impl Timestamp {
+    /// Construct a timestamp from seconds and nanoseconds.
+    #[inline]
+    pub const fn from_seconds_and_nanos(seconds: u32, nanos: u32) -> Self {
+        debug_assert!(nanos < 1_000_000_000);
+        Self::from_seconds_and_quarter_nanos(seconds, nanos << 2)
+    }
+
+    /// Construct a timestamp from seconds and quarter nanoseconds.
+    #[inline]
+    pub const fn from_seconds_and_quarter_nanos(seconds: u32, quarter_nanos: u32) -> Self {
+        debug_assert!(quarter_nanos < 4_000_000_000);
+        Self { seconds, quarter_nanos }
+    }
+
+    /// Get the whole seconds.
+    #[inline]
+    pub const fn seconds(&self) -> u32 {
+        self.seconds
+    }
+
+    /// Get the fractional quarter nanoseconds within the current second.
+    #[inline]
+    pub const fn quarter_nanos(&self) -> u32 {
+        self.quarter_nanos
+    }
+
+    /// Get the whole nanoseconds within the current second.
+    #[inline]
+    pub const fn nanos(&self) -> u32 {
+        self.quarter_nanos >> 2
+    }
+}
+
+/// A signed frequency adjustment in parts per million with 16 fractional bits.
+///
+/// Zero selects the nominal clock frequency and positive values make the clock
+/// run faster. One raw unit is `2^-16` ppm, giving a range of approximately
+/// -32768 to +32768 ppm.
+#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+pub struct ScaledPpm(i32);
+
+impl ScaledPpm {
+    /// No frequency adjustment.
+    pub const ZERO: Self = Self(0);
+
+    /// Construct an adjustment from its signed fixed-point representation.
+    pub const fn from_raw(raw: i32) -> Self {
+        Self(raw)
+    }
+
+    /// Return the signed fixed-point representation.
+    pub const fn raw(self) -> i32 {
+        self.0
+    }
+}
+
+/// A readable and adjustable PTP hardware clock.
+///
+/// The clock must be the same time domain that produces packet timestamps.
+/// Frequency adjustments are absolute relative to the nominal frequency,
+/// rather than cumulative.
+pub trait Clock {
+    /// Error returned when adjusting the clock.
+    type Error: core::error::Error;
+
+    /// Read the current clock time.
+    fn now(&self) -> Timestamp;
+
+    /// Step the clock and return a timestamp sampled near the change.
+    ///
+    /// A positive offset moves the clock forward. Steps use whole nanoseconds
+    /// even when timestamp observations have subnanosecond resolution: stepping
+    /// is a coarse correction, while frequency adjustment preserves fine
+    /// steering.
+    fn step(&mut self, offset_nanos: i64) -> Result<Timestamp, Self::Error>;
+
+    /// Set the absolute frequency adjustment and return a timestamp sampled
+    /// near the change.
+    fn set_frequency(&mut self, adjustment: ScaledPpm) -> Result<Timestamp, Self::Error>;
+}
+
+impl<T: ?Sized + Clock> Clock for &mut T {
+    type Error = T::Error;
+
+    fn now(&self) -> Timestamp {
+        T::now(self)
+    }
+
+    fn step(&mut self, offset_nanos: i64) -> Result<Timestamp, Self::Error> {
+        T::step(self, offset_nanos)
+    }
+
+    fn set_frequency(&mut self, adjustment: ScaledPpm) -> Result<Timestamp, Self::Error> {
+        T::set_frequency(self, adjustment)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Timestamp;
+
+    #[test]
+    fn timestamp_preserves_quarter_nanoseconds() {
+        let timestamp = Timestamp::from_seconds_and_quarter_nanos(12, 3_999_999_999);
+
+        assert_eq!(timestamp.seconds(), 12);
+        assert_eq!(timestamp.quarter_nanos(), 3_999_999_999);
+        assert_eq!(timestamp.nanos(), 999_999_999);
+    }
+
+    #[test]
+    #[should_panic]
+    fn timestamp_rejects_a_full_second_of_nanoseconds() {
+        Timestamp::from_seconds_and_nanos(0, 1_000_000_000);
+    }
+
+    #[test]
+    #[should_panic]
+    fn timestamp_rejects_a_full_second_of_quarter_nanoseconds() {
+        Timestamp::from_seconds_and_quarter_nanos(0, 4_000_000_000);
+    }
+}

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -164,6 +164,7 @@ embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-4"] }
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
 embassy-net-driver = { version = "0.2.0", path = "../embassy-net-driver" }
+embassy-ptp-driver = { version = "0.1.0", path = "../embassy-ptp-driver", optional = true }
 embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-usb-synopsys-otg = { version = "0.4.0", path = "../embassy-usb-synopsys-otg" }
 embassy-executor = { version = "0.10.0", path = "../embassy-executor", optional = true }
@@ -245,6 +246,7 @@ defmt = [
     "embedded-io-async/defmt",
     "embassy-usb-driver/defmt",
     "embassy-net-driver/defmt",
+    "embassy-ptp-driver?/defmt",
     "embassy-time?/defmt",
     "embassy-usb-synopsys-otg/defmt",
     "stm32-metapac/defmt",
@@ -253,7 +255,7 @@ defmt = [
 ## Use log for logging
 log = ["dep:log"]
 ## Enable Ethernet PTP hardware timestamping.
-ptp = ["embassy-net-driver/packetmeta-timestamp"]
+ptp = ["embassy-net-driver/packetmeta-timestamp", "dep:embassy-ptp-driver"]
 ## Enable chrono support
 chrono = ["dep:chrono"]
 

--- a/embassy-stm32/src/eth/mod.rs
+++ b/embassy-stm32/src/eth/mod.rs
@@ -23,6 +23,13 @@ pub use crate::eth::generic_phy::*;
 pub use crate::eth::sma::{Instance as SmaInstance, Sma, StationManagement};
 use crate::pac::eth::Eth as Regs;
 
+#[cfg(feature = "ptp")]
+fn adjusted_ptp_addend(nominal: u32, adjustment: embassy_ptp_driver::ScaledPpm) -> u32 {
+    let scale = 1.0 + f64::from(adjustment.raw()) / ((1i32 << 16) as f64 * 1e6);
+    // The cast saturates; the addend must remain nonzero.
+    ((f64::from(nominal) * scale + 0.5) as u32).max(1)
+}
+
 #[allow(unused)]
 const MTU: usize = 1514;
 const TX_BUFFER_SIZE: usize = 1514;
@@ -186,6 +193,34 @@ impl<'d, T: Instance, P: Phy> embassy_net_driver::Driver for Ethernet<'d, T, P> 
 
     fn hardware_address(&self) -> HardwareAddress {
         HardwareAddress::Ethernet(self.mac_addr)
+    }
+}
+
+#[cfg(all(test, feature = "ptp"))]
+mod tests {
+    use embassy_ptp_driver::ScaledPpm;
+
+    use super::adjusted_ptp_addend;
+
+    const NOMINAL: u32 = 0xa000_0000;
+
+    #[test]
+    fn ptp_addend_uses_absolute_scaled_ppm() {
+        assert_eq!(adjusted_ptp_addend(NOMINAL, ScaledPpm::ZERO), NOMINAL);
+        assert_eq!(
+            adjusted_ptp_addend(NOMINAL, ScaledPpm::from_raw(500 << 16)),
+            0xa014_7ae1
+        );
+        assert_eq!(
+            adjusted_ptp_addend(NOMINAL, ScaledPpm::from_raw(-500 << 16)),
+            0x9feb_851f
+        );
+    }
+
+    #[test]
+    fn ptp_addend_stays_in_the_valid_register_range() {
+        assert!(adjusted_ptp_addend(NOMINAL, ScaledPpm::from_raw(i32::MIN)) >= 1);
+        assert_eq!(adjusted_ptp_addend(u32::MAX, ScaledPpm::from_raw(i32::MAX)), u32::MAX);
     }
 }
 

--- a/embassy-stm32/src/eth/v1/ptp.rs
+++ b/embassy-stm32/src/eth/v1/ptp.rs
@@ -1,7 +1,8 @@
+use core::convert::Infallible;
 use core::fmt;
 use core::marker::PhantomData;
 
-use embassy_net_driver::Timestamp as PtpTimestamp;
+use embassy_ptp_driver::{Clock, ScaledPpm, Timestamp as PtpTimestamp};
 
 use super::Instance;
 
@@ -147,10 +148,7 @@ impl<T: Instance> PtpClock<T> {
             _peri: PhantomData,
         };
         clock.configure();
-        clock.set_time(PtpTimestamp {
-            seconds: 0,
-            quarter_nanos: 0,
-        });
+        clock.set_time(PtpTimestamp::default());
         debug!(
             "eth ptp clock hclk={} increment={}ns addend={:#010x}",
             hclk.0,
@@ -227,6 +225,24 @@ impl<T: Instance> PtpClock<T> {
     }
 }
 
+impl<T: Instance> Clock for PtpClock<T> {
+    type Error = Infallible;
+
+    fn now(&self) -> PtpTimestamp {
+        PtpClock::now(self)
+    }
+
+    fn step(&mut self, offset_nanos: i64) -> Result<PtpTimestamp, Self::Error> {
+        self.offset_time(offset_nanos);
+        Ok(self.now())
+    }
+
+    fn set_frequency(&mut self, adjustment: ScaledPpm) -> Result<PtpTimestamp, Self::Error> {
+        self.set_addend(crate::eth::adjusted_ptp_addend(self.nominal_addend(), adjustment));
+        Ok(self.now())
+    }
+}
+
 fn read_timestamp<T: Instance>() -> PtpTimestamp {
     let ptp = T::regs().ethernet_ptp();
     loop {
@@ -250,7 +266,7 @@ fn apply_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool, updat
 
 fn write_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool) {
     let ptp = T::regs().ethernet_ptp();
-    ptp.ptptshur().write(|w| w.set_tsus(timestamp.seconds));
+    ptp.ptptshur().write(|w| w.set_tsus(timestamp.seconds()));
     ptp.ptptslur().write(|w| {
         w.set_tsuss(timestamp.nanos());
         w.set_tsupns(subtract);

--- a/embassy-stm32/src/eth/v2/ptp.rs
+++ b/embassy-stm32/src/eth/v2/ptp.rs
@@ -1,7 +1,8 @@
+use core::convert::Infallible;
 use core::fmt;
 use core::marker::PhantomData;
 
-use embassy_net_driver::Timestamp as PtpTimestamp;
+use embassy_ptp_driver::{Clock, ScaledPpm, Timestamp as PtpTimestamp};
 
 use super::Instance;
 
@@ -147,10 +148,7 @@ impl<T: Instance> PtpClock<T> {
             _peri: PhantomData,
         };
         clock.configure();
-        clock.set_time(PtpTimestamp {
-            seconds: 0,
-            quarter_nanos: 0,
-        });
+        clock.set_time(PtpTimestamp::default());
         debug!(
             "eth ptp clock hclk={} increment={}ns addend={:#010x}",
             hclk.0,
@@ -226,6 +224,24 @@ impl<T: Instance> PtpClock<T> {
     }
 }
 
+impl<T: Instance> Clock for PtpClock<T> {
+    type Error = Infallible;
+
+    fn now(&self) -> PtpTimestamp {
+        PtpClock::now(self)
+    }
+
+    fn step(&mut self, offset_nanos: i64) -> Result<PtpTimestamp, Self::Error> {
+        self.offset_time(offset_nanos);
+        Ok(self.now())
+    }
+
+    fn set_frequency(&mut self, adjustment: ScaledPpm) -> Result<PtpTimestamp, Self::Error> {
+        self.set_addend(crate::eth::adjusted_ptp_addend(self.nominal_addend(), adjustment));
+        Ok(self.now())
+    }
+}
+
 fn read_timestamp<T: Instance>() -> PtpTimestamp {
     let mac = T::regs().ethernet_mac();
     loop {
@@ -249,7 +265,7 @@ fn apply_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool, updat
 
 fn write_time_update<T: Instance>(timestamp: PtpTimestamp, subtract: bool) {
     let mac = T::regs().ethernet_mac();
-    mac.macstsur().write(|w| w.set_tss(timestamp.seconds));
+    mac.macstsur().write(|w| w.set_tss(timestamp.seconds()));
     mac.macstnur().write(|w| {
         w.set_tsss(timestamp.nanos());
         w.set_addsub(subtract);


### PR DESCRIPTION
Add `embassy-ptp-driver` with a small `Clock` trait for the adjustable clock behind network packet timestamps plus related `ScaledPpm` and `Timestamp`. In PTP lingo, this clock is the PHC.

Clock step offsets are in nanoseconds. That matches linuxptp and the linux kernel. While there is hardware that can timestamp finer (e.g. quarter nanos, 4 GHz, or phased clocks), a finer offset capability is neither needed in PTP nor practical. Clock algos do fine slew via frequency. Frequency corrections use signed Q16 ppm relative to the nominal rate. This is also modeled after linuxptp/linux kernel. With this trait a `statime::Clock` adapter (or some other consumer/runner/PTP/SyncE/White Rabbit impl) then becomes a thin newtype with a blanket impl.

`Timestamp` is duplicated from `embassy-net-driver` to not have a trait crate dependency edge. The associated conversion impact appears benign (and downstream).

Implement the trait for both STM32 Ethernet PTP versions.

Attribution: LLM was used in parts of the implementation and testing.