### PR TITLE
embassy-mspm0: I2C clock and system clock selection added

### DIFF
--- a/embassy-mspm0/src/i2c.rs
+++ b/embassy-mspm0/src/i2c.rs
@@ -144,6 +144,10 @@ pub enum ConfigError {
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 /// Config
 pub struct Config {
+    /// User selection of clock source
+    /// If None, clock source selected by define_clock_source()
+    pub clock_source_sel: Option<ClockSel>,
+
     /// I2C clock source.
     pub(crate) clock_source: ClockSel,
 
@@ -169,6 +173,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            clock_source_sel: None,
             clock_source: ClockSel::MfClk,
             clock_div: ClockDiv::DivBy1,
             invert_sda: false,
@@ -235,19 +240,26 @@ impl Config {
     }
 
     fn define_clock_source(&mut self) -> bool {
-        // decide which clock source to choose based on i2c clock.
-        // If i2c speed <= 200kHz, use MfClk, otherwise use BusClk
-        if self.bus_speed.hertz() / self.clock_div.divider() > 200_000 {
-            // TODO: check if BUSCLK enabled
-            self.clock_source = ClockSel::BusClk;
-        } else {
-            // is MFCLK enabled
-            if !pac::SYSCTL.mclkcfg().read().usemftick() {
-                return false;
+        // decide which clock source to choose based on i2c clock if source selection is None (auto).
+        // If i2c speed <= 200kHz and MfClk enabled, use MfClk, otherwise use BusClk
+        if let Some(clk) = self.clock_source_sel {
+            if let ClockSel::MfClk = clk {
+                if !pac::SYSCTL.mclkcfg().read().usemftick() {
+                    return false;
+                }
             }
-            self.clock_source = ClockSel::MfClk;
+            self.clock_source = clk;
+        } else {
+            if (self.bus_speed.hertz() / self.clock_div.divider() > 200_000)
+                || !pac::SYSCTL.mclkcfg().read().usemftick()
+            {
+                // TODO: check if BUSCLK enabled
+                self.clock_source = ClockSel::BusClk;
+            } else {
+                self.clock_source = ClockSel::MfClk;
+            }
         }
-        return true;
+        true
     }
 
     /// Check the config.
@@ -256,7 +268,7 @@ impl Config {
     pub fn check_config(&mut self) -> Result<(), ConfigError> {
         if !self.define_clock_source() {
             return Err(ConfigError::ClockSourceNotEnabled);
-        }
+        };
 
         if !self.check_clock_i2c() {
             return Err(ConfigError::InvalidClockRate);

--- a/embassy-mspm0/src/lib.rs
+++ b/embassy-mspm0/src/lib.rs
@@ -76,6 +76,7 @@ pub use mspm0_metapac as pac;
 pub(crate) use mspm0_metapac as pac;
 
 pub use crate::_generated::interrupt;
+use crate::ClockSource::MfClk;
 
 /// Macro to bind interrupts to handlers.
 ///
@@ -151,11 +152,23 @@ macro_rules! bind_interrupts {
     }
 }
 
+/// System clock selection
+#[derive(Clone, Copy)]
+pub enum ClockSource {
+    MfClk,
+    LfClk,
+    SysOsc,
+    // Not tested
+    HsClk,
+}
+
 /// `embassy-mspm0` global configuration.
 #[non_exhaustive]
 #[derive(Clone, Copy)]
 pub struct Config {
-    // TODO: OSC configuration.
+    /// Clock source
+    pub clock_source: ClockSource,
+
     /// The size of DMA block transfer burst.
     ///
     /// If this is set to a value
@@ -172,6 +185,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            clock_source: MfClk,
             dma_burst_size: dma::BurstSize::Complete,
             dma_round_robin: false,
         }
@@ -185,8 +199,23 @@ pub fn init(config: Config) -> Peripherals {
         // TODO: Further clock configuration
 
         pac::SYSCTL.mclkcfg().modify(|w| {
-            // Enable MFCLK
-            w.set_usemftick(true);
+            // Configure clock based on source chosen
+            match config.clock_source {
+                ClockSource::MfClk => {
+                    w.set_usemftick(true);
+                }
+                ClockSource::HsClk => {
+                    w.set_usehsclk(true);
+                }
+                ClockSource::LfClk => {
+                    w.set_uselfclk(true);
+                }
+                ClockSource::SysOsc => {
+                    w.set_usehsclk(false);
+                    w.set_uselfclk(false);
+                    w.set_usemftick(false);
+                }
+            }
             // MDIV must be disabled if MFCLK is enabled.
             w.set_mdiv(0);
         });
@@ -198,6 +227,9 @@ pub fn init(config: Config) -> Peripherals {
             w.set_mfpclken(true);
         });
 
+        if let ClockSource::LfClk = config.clock_source {
+            pac::SYSCTL.sysosccfg().modify(|w| w.set_disable(true));
+        }
         // TODO: Errata PCMU_ERR_03 states that BOR thresholds other than 0 don't work in STANDBY.
         pac::SYSCTL.borthreshold().modify(|w| {
             w.set_level(0);

--- a/embassy-mspm0/src/lib.rs
+++ b/embassy-mspm0/src/lib.rs
@@ -158,8 +158,6 @@ pub enum ClockSource {
     MfClk,
     LfClk,
     SysOsc,
-    // Not tested
-    HsClk,
 }
 
 /// `embassy-mspm0` global configuration.
@@ -204,14 +202,10 @@ pub fn init(config: Config) -> Peripherals {
                 ClockSource::MfClk => {
                     w.set_usemftick(true);
                 }
-                ClockSource::HsClk => {
-                    w.set_usehsclk(true);
-                }
                 ClockSource::LfClk => {
                     w.set_uselfclk(true);
                 }
                 ClockSource::SysOsc => {
-                    w.set_usehsclk(false);
                     w.set_uselfclk(false);
                     w.set_usemftick(false);
                 }


### PR DESCRIPTION
I2C clock can be selected using configuration or automatically as before. Necessary to avoid ERR-03 from errata when clocking I2C from MfClk.
MCLK clock source configuration added to embassy peripherals init.