### PR TITLE
fix(embassy-stm32): use fixed channel index as DMA request when peripheral has no DMAMUX

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2292,6 +2292,21 @@ fn main() {
                     let request = if let Some(request) = ch.request {
                         let request = request as u8;
                         quote!(#request)
+                    } else if let Some(channel) = &ch.channel
+                        && ch.dmamux.is_none()
+                    {
+                        // Peripheral is connected directly to a DMA/BDMA channel without going
+                        // through a DMAMUX. In that case there is no separate "request number" —
+                        // the request IS the fixed channel index (e.g. BDMA1/DFSDM1 on H7A3/H7B3/H7B0,
+                        // see RM0455 §16.3.2). Verified only for that case; if other chip families
+                        // hit this branch, confirm the same equivalence holds for them too.
+                        let found_channel = METADATA
+                            .dma_channels
+                            .iter()
+                            .find(|dma| dma.name == *channel)
+                            .expect("DMA channel not found in metadata");
+                        let request = found_channel.channel as u8;
+                        quote!(#request)
                     } else {
                         quote!(())
                     };

--- a/embassy-stm32/src/macros.rs
+++ b/embassy-stm32/src/macros.rs
@@ -178,7 +178,11 @@ macro_rules! dma_trait_impl {
     (crate::$mod:ident::$trait:ident$(<$mode:ident>)?, $instance:ident, $channel:ident, $request:expr, $remap:expr) => {
         impl crate::$mod::$trait<crate::peripherals::$instance $(, crate::$mod::$mode)?> for crate::peripherals::$channel {
             fn request(&self) -> crate::dma::Request {
-                $request
+                #[cfg(any(dma_v2, bdma_v2, gpdma, dmamux, lpdma))]
+                { return $request }
+
+                #[cfg(not(any(dma_v2, bdma_v2, gpdma, dmamux, lpdma)))]
+                { return () }
             }
 
             fn remap(&self) {


### PR DESCRIPTION
## Problem

For DMA/BDMA channels that are connected to a peripheral **without** going through a DMAMUX, the generated `dma_trait_impl!` calls currently emit an empty/placeholder request instead of a request number, because the code only handles the "has explicit request" and "has DMAMUX" cases.

Concretely this affects **BDMA1 on STM32H7A3/H7B3/H7B0**, which is dedicated to DFSDM1 and has no DMAMUX in front of it.

Example
```rust
PeripheralDmaChannel {
    signal: "FLT0",
    channel: Some("BDMA1_CH0"),
    dmamux: None,
    remap: &[],
    dma: None,
    request: None,
},

// yields:
dma_trait_impl!(crate::dfsdm::Dma<Flt3>, DFSDM1, BDMA1_CH0, (), {});

// the empty tuple is not permitted.
```

This is contrasted with BDMA2 (also on H7A3/H7B3/H7B0), which *is* behind DMAMUX2 and uses a fixed request number (e.g. request `18` for DFSDM2, routable through any of BDMA2's 8 channels) — see RM0455 §17.3.3 / Table 105.

Example:
```rust
DmaChannel {
    name: "BDMA2_CH0",
    dma: "BDMA2",
    channel: 0,
    dmamux: Some("DMAMUX2"),
    dmamux_channel: Some(0),
    supports_2d: None,
},

// yields:
dma_trait_impl!(crate::dfsdm::Dma<Flt0>, DFSDM2, BDMA2_CH0, 18u8, {});

// No tuple but a proper u8.
```

## Fix

When a DMA channel has a fixed `channel` but no `dmamux`, use the channel's index as the request number, per RM0455 §16.3.2 ("BDMA request mapping"):

> "A channel request x of the BDMA1 is connected to the DFSDM request of the same index x."

Additionally, the `dma_trait_impl` macro was adjusted to gate the `u8` and `()` `Request` variants in the same way as the Request definition does. Currently, the `()` case is handled implicitly by passing an empty tuple when no channel is found. Without this change, the macro would fail on chip variants that still use `Request = ()`. 

I'm open to feedback on this "fix", as this was the most robust and straightforward solution I could think of. If there is a more idiomatic way to handle this, please let me know.

I feel like this might deserve a more structural fix, as the current implicit handling of "no channel => `()`" feels rather opaque. Having to duplicate the same cfg gates here also feels a bit clumsy.

I haven't fully wrapped my head around the architecture behind the DMA request handling yet, though, so there may be a better way to do this that I'm missing.

## Scope check

Cross-checks might need to be done to ensure stability along other chip-families.

## Reproduce:
Use my WIP DFSDM implementations as a reference for reproduction: 
- https://github.com/embassy-rs/embassy/pull/6806