### PR TITLE
stm32: fix ringbuf constructor hack

### DIFF
--- a/embassy-stm32/src/exti/mod.rs
+++ b/embassy-stm32/src/exti/mod.rs
@@ -176,6 +176,24 @@ impl<'d> ExtiInput<'d, Async> {
         }
     }
 
+    /// Create an EXTI input from an existing [`Flex`] pin.
+    ///
+    /// Useful when a pin was previously used in bidirectional mode (e.g.,
+    /// driven as an output for a hardware entry sequence) and needs to be
+    /// switched to interrupt-driven input mode without re-acquiring the
+    /// peripheral token.
+    ///
+    /// The pin should be in input mode (configured via [`Flex::set_as_input()`])
+    /// before calling this.
+    ///
+    /// The Binding must bind the Channel's IRQ to [InterruptHandler].
+    pub unsafe fn from_flex_unchecked(pin: Flex<'d>) -> Self {
+        Self {
+            pin: Input::from_flex(pin),
+            _kind: PhantomData,
+        }
+    }
+
     /// Asynchronously wait until the pin is high.
     ///
     /// This returns immediately if the pin is already high.

--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -15,6 +15,10 @@ pub use ringbuffered::RingBufferedSpiRx;
 
 use crate::Peri;
 use crate::dma::{ChannelAndRequest, word};
+#[cfg(feature = "exti")]
+use crate::exti;
+#[cfg(feature = "exti")]
+use crate::gpio::ExtiPin;
 use crate::gpio::{AfType, Flex, OutputType, Pull, Speed};
 use crate::mode::{Async, Blocking, Mode as PeriMode};
 use crate::pac::spi::{Spi as Regs, regs, vals};
@@ -226,6 +230,7 @@ pub struct Spi<'d, M: PeriMode, CM: CommunicationMode> {
     _sck: Option<Flex<'d>>,
     _mosi: Option<Flex<'d>>,
     _miso: Option<Flex<'d>>,
+    _exti: bool,
     nss: Option<Flex<'d>>,
     tx_dma: Option<ChannelAndRequest<'d>>,
     rx_dma: Option<ChannelAndRequest<'d>>,
@@ -243,6 +248,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
         mosi: Option<Flex<'d>>,
         miso: Option<Flex<'d>>,
         nss: Option<Flex<'d>>,
+        exti: bool,
         tx_dma: Option<ChannelAndRequest<'d>>,
         rx_dma: Option<ChannelAndRequest<'d>>,
         config: Config,
@@ -253,6 +259,7 @@ impl<'d, M: PeriMode, CM: CommunicationMode> Spi<'d, M, CM> {
             _sck: sck,
             _mosi: mosi,
             _miso: miso,
+            _exti: exti,
             nss,
             tx_dma,
             rx_dma,
@@ -630,6 +637,7 @@ impl<'d> Spi<'d, Blocking, Slave> {
             new_pin!(mosi, AfType::input(config.input_pull)),
             new_pin!(miso, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(cs, AfType::input(config.nss_pull)),
+            false,
             None,
             None,
             config,
@@ -652,6 +660,7 @@ impl<'d> Spi<'d, Blocking, Master> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(miso, AfType::input(config.input_pull)),
             None,
+            false,
             None,
             None,
             config,
@@ -671,6 +680,7 @@ impl<'d> Spi<'d, Blocking, Master> {
             None,
             new_pin!(miso, AfType::input(config.input_pull)),
             None,
+            false,
             None,
             None,
             config,
@@ -690,6 +700,7 @@ impl<'d> Spi<'d, Blocking, Master> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
+            false,
             None,
             None,
             config,
@@ -710,6 +721,7 @@ impl<'d> Spi<'d, Blocking, Master> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
+            false,
             None,
             None,
             config,
@@ -717,19 +729,31 @@ impl<'d> Spi<'d, Blocking, Master> {
     }
 }
 
+#[cfg(feature = "exti")]
 impl<'d> Spi<'d, Async, Slave> {
     /// Create a new SPI slave driver.
-    pub fn new_slave<T: Instance, D1: TxDma<T>, D2: RxDma<T>, #[cfg(afio)] A>(
+    pub fn new_slave<
+        T: Instance,
+        D1: TxDma<T>,
+        D2: RxDma<T>,
+        #[cfg(not(afio))] C: CsPin<T> + ExtiPin,
+        #[cfg(afio)] C: CsPin<T, A> + ExtiPin,
+        #[cfg(afio)] A,
+    >(
         peri: Peri<'d, T>,
         sck: Peri<'d, if_afio!(impl SckPin<T, A>)>,
         mosi: Peri<'d, if_afio!(impl MosiPin<T, A>)>,
         miso: Peri<'d, if_afio!(impl MisoPin<T, A>)>,
-        cs: Peri<'d, if_afio!(impl CsPin<T, A>)>,
+        cs: Peri<'d, C>,
         tx_dma: Peri<'d, D1>,
         rx_dma: Peri<'d, D2>,
+        _exti: Option<Peri<'d, C::ExtiChannel>>,
         _irq: impl crate::interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
         + crate::interrupt::typelevel::Binding<D2::Interrupt, crate::dma::InterruptHandler<D2>>
-        + 'd,
+        + crate::interrupt::typelevel::Binding<
+            <<C as ExtiPin>::ExtiChannel as exti::Channel>::IRQ,
+            exti::InterruptHandler<<<C as ExtiPin>::ExtiChannel as exti::Channel>::IRQ>,
+        > + 'd,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -738,6 +762,7 @@ impl<'d> Spi<'d, Async, Slave> {
             new_pin!(mosi, AfType::input(config.input_pull)),
             new_pin!(miso, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(cs, AfType::input(config.nss_pull)),
+            _exti.is_some(),
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
@@ -745,13 +770,24 @@ impl<'d> Spi<'d, Async, Slave> {
     }
 
     /// Create a new SPI slave driver in RX-only mode (only MOSI pin, no MISO).
-    pub fn new_rxonly_slave<T: Instance, D1: RxDma<T>, #[cfg(afio)] A>(
+    pub fn new_rxonly_slave<
+        T: Instance,
+        D1: RxDma<T>,
+        #[cfg(not(afio))] C: CsPin<T> + ExtiPin,
+        #[cfg(afio)] C: CsPin<T, A> + ExtiPin,
+        #[cfg(afio)] A,
+    >(
         peri: Peri<'d, T>,
         sck: Peri<'d, if_afio!(impl SckPin<T, A>)>,
         mosi: Peri<'d, if_afio!(impl MosiPin<T, A>)>,
-        cs: Peri<'d, if_afio!(impl CsPin<T, A>)>,
+        cs: Peri<'d, C>,
         rx_dma: Peri<'d, D1>,
-        _irq: impl crate::interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>> + 'd,
+        _exti: Option<Peri<'d, C::ExtiChannel>>,
+        _irq: impl crate::interrupt::typelevel::Binding<D1::Interrupt, crate::dma::InterruptHandler<D1>>
+        + crate::interrupt::typelevel::Binding<
+            <<C as ExtiPin>::ExtiChannel as exti::Channel>::IRQ,
+            exti::InterruptHandler<<<C as ExtiPin>::ExtiChannel as exti::Channel>::IRQ>,
+        > + 'd,
         config: Config,
     ) -> Self {
         Self::new_inner(
@@ -760,6 +796,7 @@ impl<'d> Spi<'d, Async, Slave> {
             new_pin!(mosi, AfType::input(config.input_pull)),
             None,
             new_pin!(cs, AfType::input(config.nss_pull)),
+            _exti.is_some(),
             None,
             new_dma!(rx_dma, _irq),
             config,
@@ -787,6 +824,7 @@ impl<'d> Spi<'d, Async, Master> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             new_pin!(miso, AfType::input(config.input_pull)),
             None,
+            false,
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
@@ -819,6 +857,7 @@ impl<'d> Spi<'d, Async, Master> {
             None,
             new_pin!(miso, AfType::input(config.input_pull)),
             None,
+            false,
             #[cfg(any(spi_v1, spi_v2, spi_v3))]
             new_dma!(tx_dma, _irq),
             #[cfg(any(spi_v4, spi_v5, spi_v6))]
@@ -843,6 +882,7 @@ impl<'d> Spi<'d, Async, Master> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
+            false,
             new_dma!(tx_dma, _irq),
             None,
             config,
@@ -868,6 +908,7 @@ impl<'d> Spi<'d, Async, Master> {
             new_pin!(sdio, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
+            false,
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
@@ -892,6 +933,7 @@ impl<'d> Spi<'d, Async, Master> {
             new_pin!(mosi, AfType::output(OutputType::PushPull, config.gpio_speed)),
             None,
             None,
+            false,
             new_dma!(tx_dma, _irq),
             None,
             config,
@@ -924,6 +966,7 @@ impl<'d> Spi<'d, Async, Master> {
             None,
             None,
             None,
+            false,
             new_dma!(tx_dma, _irq),
             new_dma!(rx_dma, _irq),
             config,
@@ -937,7 +980,7 @@ impl<'d> Spi<'d, Async, Master> {
         rx_dma: Option<ChannelAndRequest<'d>>,
         config: Config,
     ) -> Self {
-        Self::new_inner(peri, None, None, None, None, tx_dma, rx_dma, config)
+        Self::new_inner(peri, None, None, None, None, false, tx_dma, rx_dma, config)
     }
 }
 

--- a/embassy-stm32/src/spi/ringbuffered.rs
+++ b/embassy-stm32/src/spi/ringbuffered.rs
@@ -5,14 +5,12 @@ use core::sync::atomic::{Ordering, compiler_fence};
 use core::task::Poll;
 
 use embassy_embedded_hal::SetConfig;
-use embassy_hal_internal::Peri;
 use embedded_io_async::ReadReady;
 use futures_util::future::select;
 
 use crate::dma::ReadableRingBuffer;
-use crate::exti::{Channel, ExtiInput, InterruptHandler};
-use crate::gpio::{Flex, Pin};
-use crate::interrupt::typelevel::Binding;
+use crate::exti::ExtiInput;
+use crate::gpio::Flex;
 use crate::mode::Async;
 use crate::rcc::WakeGuard;
 use crate::spi::mode::Slave;
@@ -76,13 +74,9 @@ impl<'d> Spi<'d, Async, Slave> {
     /// Turn the `Spi` into a buffered spi which can continuously receive in the background
     /// without the possibility of losing bytes. The `dma_buf` is a buffer registered to the
     /// DMA controller, and must be large enough to prevent overflows.
-    pub fn into_ring_buffered<W: Word, C: Channel>(
-        mut self,
-        dma_buf: &'d mut [W],
-        ch: Peri<'d, C>,
-        irq: impl Binding<C::IRQ, InterruptHandler<C::IRQ>>,
-    ) -> RingBufferedSpiRx<'d, W> {
+    pub fn into_ring_buffered<W: Word>(mut self, dma_buf: &'d mut [W]) -> RingBufferedSpiRx<'d, W> {
         assert!(!dma_buf.is_empty() && dma_buf.len() <= 0xFFFF);
+        assert!(self._exti, "exti required for ringbuf");
 
         self.info.regs.cr1().modify(|w| {
             w.set_spe(false);
@@ -107,11 +101,10 @@ impl<'d> Spi<'d, Async, Slave> {
         let miso = unsafe { self._miso.as_ref().map(|x| x.clone_unchecked()) };
         let nss = unsafe { self.nss.as_ref().unwrap().clone_unchecked() };
 
-        // verify at runtime whether given EXTI channel is associated with NSS pin
-        assert_eq!(nss.pin.pin(), ch.number());
-        // EXTI can be used on alternate function pins
-        // this feature seems to be undocumented though
-        let nss = unsafe { ExtiInput::from_flex(nss, ch, irq) };
+        // EXTI can be used on all stm32 GPIO pins. Irq handler is verified on constructor.
+        //
+        // Note: if same exti lines are used, then the exti input will fight on the waker (may be fixed in the future).
+        let nss = unsafe { ExtiInput::from_flex_unchecked(nss) };
 
         let wake_guard = self.info.rcc.wake_guard();
 

--- a/examples/stm32h723/src/bin/spi_ring_buffered.rs
+++ b/examples/stm32h723/src/bin/spi_ring_buffered.rs
@@ -47,13 +47,22 @@ async fn main(spawner: Spawner) {
     let tx_cs = Output::new(p.PA4, Level::Low, Speed::VeryHigh);
     spawner.spawn(tx_task(tx_spi, tx_cs).unwrap());
 
-    let rx_spi = Spi::new_rxonly_slave(p.SPI2, p.PB13, p.PB15, p.PB12, p.DMA1_CH3, Irqs, spi_config);
+    let rx_spi = Spi::new_rxonly_slave(
+        p.SPI2,
+        p.PB13,
+        p.PB15,
+        p.PB12,
+        p.DMA1_CH3,
+        Some(p.EXTI12),
+        Irqs,
+        spi_config,
+    );
 
     #[unsafe(link_section = ".sram1")]
     static mut BUF: [u8; 64] = [0; 64];
     let buf = unsafe { &mut BUF[..] };
 
-    let rx_spi = rx_spi.into_ring_buffered(buf, p.EXTI12, Irqs);
+    let rx_spi = rx_spi.into_ring_buffered(buf);
     spawner.spawn(rx_task(rx_spi).unwrap());
 }
 


### PR DESCRIPTION
this moves the binding into the original constructor--where it should be.