### PR TITLE
docs: the mcxa examples are at examples/mcxa2xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Examples are found in the
 * `examples/nrf5340` run on the `nrf5340-dk` board (PCA10095).
 * `examples/stm32xx` for the various STM32 families.
 * `examples/rp` are for the RP2040 and RP235x chips.
-* `examples/mcxa` run on the `FRDM-MCXA266` board.
+* `examples/mcxa2xx` run on the `FRDM-MCXA266` board.
 * `examples/std` are designed to run locally on your PC.
 
 ### Running examples


### PR DESCRIPTION
The README lists `examples/mcxa`, which moved to `examples/mcxa2xx` in `f24815c3e` ("Move mcxa examples to mcxa2xx", 2026-02-27). `examples/mcxa` no longer exists on `main`.

One line, nothing else touched. The surrounding entries for `nrf52`, `nrf5340`, `stm32xx`, `rp` and `std` all still resolve and are left alone.
