### PR TITLE
fix(embassy-embedded-hal): Add missing flush call to BlockingAsync

### DIFF
--- a/embassy-embedded-hal/src/adapter/blocking_async.rs
+++ b/embassy-embedded-hal/src/adapter/blocking_async.rs
@@ -73,6 +73,7 @@ where
     T: embedded_hal_1::spi::SpiBus<Error = E>,
 {
     async fn flush(&mut self) -> Result<(), Self::Error> {
+        self.wrapped.flush()?;
         Ok(())
     }
 


### PR DESCRIPTION
I'm trying to integrate the Embassy Net Wiznet into the Ariel OS. Without this one-line fix, it seems that the DHCP request wasn't sent and my ESP32-S3-ETH didn't receive an IP address, default gateway or DNS server. To me, this looks like an oversight, as all the other functions simply forward the call