### PR TITLE
Correct STM32 F2 F4 F7 PLL output frequency calculation

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -68,6 +68,7 @@ RCC:
 - change: stm32/rcc/c0: rename `Hsi::sys_div` to `Hsi::div` and `HsiSysDiv` to `HsiDiv` (breaking change). The field sets HSIDIV, not SYSDIV; the old name suggested otherwise
 - fix: stm32/rcc/c0: raise the flash read access latency before anything that can raise the core frequency, so a configuration handed over from a bootloader without a reset cannot run above 24 MHz with too few wait states
 - fix: stm32/rcc/l: set the maximum flash latency before raising the MSI range, so MSI above the reset wait-state limit (e.g. 48 MHz) as sysclk no longer hardfaults in `init()` on L4, L5, WB and U0 (extends the WL-only fix from #2786; L0/L1 are unaffected, their MSI tops out at 4.194 MHz)
+- fix: stm32/rcc/f247: report correct PLL output frequencies when the source clock is not evenly divisible by the PLL input divisor
 
 SPI:
 - change default NSS configuration from active-high to active-low

--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -15,7 +15,7 @@ use crate::pac::{FLASH, RCC};
 use crate::rcc::dsi;
 #[cfg(dsihost)]
 pub use crate::rcc::dsi::{DsiHostPllConfig, DsiPllInput, DsiPllNdiv, DsiPllOutput};
-use crate::time::Hertz;
+use crate::time::{Hertz, Prescaler};
 
 // TODO: on some F4s, PLLM is shared between all PLLs. Enforce that.
 // TODO: on some F4s, add support for plli2s_src
@@ -422,6 +422,12 @@ fn pll_enable(instance: PllInstance, enabled: bool) {
     }
 }
 
+fn divide_pll_output<D: Prescaler>(num: u64, denom: u64, div: D) -> Hertz {
+    let num = num * u64::from(div.denom());
+    let denom = denom * u64::from(div.num());
+    Hertz(unwrap!((num / denom).try_into()))
+}
+
 fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput) -> PllOutput {
     // Disable PLL
     pll_enable(instance, false);
@@ -444,7 +450,11 @@ fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput) -> Pll
 
     let in_freq = pll_src / pll.prediv;
     assert!(max::PLL_IN.contains(&in_freq));
-    let vco_freq = in_freq * pll.mul;
+
+    let vco_num = u64::from(pll_src.0) * u64::from(pll.mul.num()) * u64::from(pll.prediv.denom());
+    let vco_denom = u64::from(pll.mul.denom()) * u64::from(pll.prediv.num());
+
+    let vco_freq = Hertz(unwrap!((vco_num / vco_denom).try_into()));
     assert!(max::PLL_VCO.contains(&vco_freq));
 
     // stm32f2 plls are like swiss cheese
@@ -459,9 +469,9 @@ fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput) -> Pll
         }
     }
 
-    let p = pll.divp.map(|div| vco_freq / div);
-    let q = pll.divq.map(|div| vco_freq / div);
-    let r = pll.divr.map(|div| vco_freq / div);
+    let p = pll.divp.map(|div| divide_pll_output(vco_num, vco_denom, div));
+    let q = pll.divq.map(|div| divide_pll_output(vco_num, vco_denom, div));
+    let r = pll.divr.map(|div| divide_pll_output(vco_num, vco_denom, div));
 
     macro_rules! write_fields {
         ($w:ident) => {


### PR DESCRIPTION
This is a new take on #4642.

Calculate PLL outputs directly from the source frequency and complete prescaler ratio. This prevents intermediate truncation from affecting the reported output frequencies.

Tested with an STM32F411CE. I tried to think of useful tests to add but I couldn't see any obvious way to introduce tests for this. Let me know if you have an idea.

Fixes #3408.