### PR TITLE
STM32: Add a `low_level::Timer::wait_for_update` function to timers

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -145,6 +145,7 @@ SPI:
 Timer:
 - feat: stm32/timer: add `set_period`, improve PSC/ARR calculation
 - change: stm32/timer/input_capture: use timer word size for all outputs
+- feat: stm32/timer: allow `low_level::Timer` to asynchronously wait for update events
 
 HRTIM:
 - change: stm32: Change HRTIM implementation to use stm32-hrtim driver for G474/484 and F334

--- a/embassy-stm32/src/timer/low_level.rs
+++ b/embassy-stm32/src/timer/low_level.rs
@@ -6,7 +6,11 @@
 //!
 //! The available functionality depends on the timer type.
 
+use core::future::Future;
+use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 
 use embassy_hal_internal::Peri;
 #[cfg(not(stm32l0))]
@@ -16,6 +20,8 @@ pub use stm32_metapac::timer::vals::{FilterValue, Mms as MasterMode, Sms as Slav
 
 use super::*;
 use crate::dma::{self, Transfer, WritableRingBuffer};
+use crate::interrupt::typelevel::{Binding, Interrupt};
+use crate::mode::{Async, Blocking, Mode};
 use crate::pac::timer::vals;
 use crate::rcc;
 use crate::time::Hertz;
@@ -402,12 +408,43 @@ fn div_round(numerator: u64, denominator: u64, round: RoundTo) -> u64 {
     }
 }
 
-/// Low-level timer driver.
-pub struct Timer<'d, T: CoreInstance> {
-    tim: Peri<'d, T>,
+struct TimerUpdateFuture<T: CoreInstance> {
+    _timer: PhantomData<T>,
 }
 
-impl<'d, T: CoreInstance> Drop for Timer<'d, T> {
+impl<T: CoreInstance> Future for TimerUpdateFuture<T> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        T::state().up_waker.register(cx.waker());
+
+        let regs = unsafe { crate::pac::timer::TimCore::from_ptr(T::regs()) };
+
+        if regs.dier().read().uie() {
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+}
+
+impl<T: CoreInstance> Drop for TimerUpdateFuture<T> {
+    fn drop(&mut self) {
+        critical_section::with(|_| {
+            let regs = unsafe { crate::pac::timer::TimCore::from_ptr(T::regs()) };
+
+            regs.dier().modify(|w| w.set_uie(false));
+        });
+    }
+}
+
+/// Low-level timer driver.
+pub struct Timer<'d, T: CoreInstance, U: Mode = Blocking> {
+    tim: Peri<'d, T>,
+    _update_mode: PhantomData<U>,
+}
+
+impl<'d, T: CoreInstance, U: Mode> Drop for Timer<'d, T, U> {
     fn drop(&mut self) {
         rcc::disable::<T>();
     }
@@ -418,12 +455,48 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
     pub fn new(tim: Peri<'d, T>) -> Self {
         rcc::enable_and_reset::<T>();
 
-        Self { tim }
+        Self {
+            tim,
+            _update_mode: PhantomData,
+        }
     }
+}
 
+impl<'d, T: CoreInstance> Timer<'d, T, Blocking> {
+    /// Enable asynchronous waiting for timer update events.
+    pub fn with_update_interrupt(
+        self,
+        _irq: impl Binding<T::UpdateInterrupt, UpdateInterruptHandler<T>> + 'd,
+    ) -> Timer<'d, T, Async> {
+        T::UpdateInterrupt::unpend();
+        unsafe { T::UpdateInterrupt::enable() };
+
+        let this = ManuallyDrop::new(self);
+        let tim = unsafe { core::ptr::read(&this.tim) };
+
+        Timer {
+            tim,
+            _update_mode: PhantomData,
+        }
+    }
+}
+
+impl<'d, T: CoreInstance> Timer<'d, T, Async> {
+    /// Wait for a pending or future timer update event.
+    pub async fn wait_for_update(&mut self) {
+        self.enable_update_interrupt(true);
+
+        TimerUpdateFuture::<T> { _timer: PhantomData }.await;
+    }
+}
+
+impl<'d, T: CoreInstance, U: Mode> Timer<'d, T, U> {
     pub(crate) unsafe fn clone_unchecked(&self) -> ManuallyDrop<Self> {
         let tim = unsafe { self.tim.clone_unchecked() };
-        ManuallyDrop::new(Self { tim })
+        ManuallyDrop::new(Self {
+            tim,
+            _update_mode: PhantomData,
+        })
     }
 
     /// Get access to the virutal core 16bit timer registers.
@@ -667,7 +740,7 @@ impl<'d, T: CoreInstance> Timer<'d, T> {
     }
 }
 
-impl<'d, T: BasicNoCr2Instance> Timer<'d, T> {
+impl<'d, T: BasicNoCr2Instance, U: Mode> Timer<'d, T, U> {
     /// Get access to the Baisc 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -689,7 +762,7 @@ impl<'d, T: BasicNoCr2Instance> Timer<'d, T> {
     }
 }
 
-impl<'d, T: BasicInstance> Timer<'d, T> {
+impl<'d, T: BasicInstance, U: Mode> Timer<'d, T, U> {
     /// Get access to the Baisc 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -706,7 +779,7 @@ impl<'d, T: BasicInstance> Timer<'d, T> {
     }
 }
 
-impl<'d, T: GeneralInstance1Channel> Timer<'d, T> {
+impl<'d, T: GeneralInstance1Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the general purpose 1 channel 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -749,7 +822,7 @@ impl<'d, T: GeneralInstance1Channel> Timer<'d, T> {
     }
 }
 
-impl<'d, T: GeneralInstance2Channel> Timer<'d, T> {
+impl<'d, T: GeneralInstance2Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the general purpose 2 channel 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -761,7 +834,7 @@ impl<'d, T: GeneralInstance2Channel> Timer<'d, T> {
     }
 }
 
-impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
+impl<'d, T: GeneralInstance4Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the general purpose 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -1252,7 +1325,7 @@ impl<'d, T: GeneralInstance4Channel> Timer<'d, T> {
 }
 
 #[cfg(not(stm32l0))]
-impl<'d, T: GeneralInstance32bit4Channel> Timer<'d, T> {
+impl<'d, T: GeneralInstance32bit4Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the general purpose 32bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -1265,7 +1338,7 @@ impl<'d, T: GeneralInstance32bit4Channel> Timer<'d, T> {
 }
 
 #[cfg(not(stm32l0))]
-impl<'d, T: AdvancedInstance1Channel> Timer<'d, T> {
+impl<'d, T: AdvancedInstance1Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the general purpose 1 channel with one complementary 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -1410,7 +1483,7 @@ impl<'d, T: AdvancedInstance1Channel> Timer<'d, T> {
 }
 
 #[cfg(not(stm32l0))]
-impl<'d, T: AdvancedInstance2Channel> Timer<'d, T> {
+impl<'d, T: AdvancedInstance2Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the general purpose 2 channel with one complementary 16bit timer registers.
     ///
     /// Note: This works even if the timer is more capable, because registers
@@ -1423,7 +1496,7 @@ impl<'d, T: AdvancedInstance2Channel> Timer<'d, T> {
 }
 
 #[cfg(not(stm32l0))]
-impl<'d, T: AdvancedInstance4Channel> Timer<'d, T> {
+impl<'d, T: AdvancedInstance4Channel, U: Mode> Timer<'d, T, U> {
     /// Get access to the advanced timer registers.
     pub fn regs_advanced(&self) -> crate::pac::timer::TimAdv {
         unsafe { crate::pac::timer::TimAdv::from_ptr(T::regs()) }


### PR DESCRIPTION
This is a new take on #4630.

I noticed there is now a `mode` thing in embassy-stm32 itself. The way I use it here is not quite how it's used elsewhere. I was trying to avoid a disruptive change to the low level timer constructor and to avoid requiring every user of this to pass every relevant IRQ binding.

You call `with_update_interrupt` on a `Timer` and this gives you a new `Timer` with a slightly different time indicating that the binding was passed. This unlocks `wait_for_update`. The idea is that capture compare and all the other timer specific interrupts could be added this way in the future without disrupting each other.

I believe this would eventually make the low-level timer driver powerful enough to implement _any_ of the high level drivers from normal code without necessarily needing direct support from embassy-stm32.

I think this does a good job of addressing some of the comments from the previous PR discussion while staying relatively small as a change.

But I understand that the `with_update_interrupt` approach is somewhat unusual here... Interested to hear opinions.