### PR TITLE
stm32: support GLOBAL ADC DMA signals

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -2129,6 +2129,7 @@ fn main() {
         (("adc", "ADC1"), quote!(crate::adc::RxDma)),
         (("adc", "ADC2"), quote!(crate::adc::RxDma)),
         (("adc", "ADC3"), quote!(crate::adc::RxDma)),
+        (("adc", "GLOBAL"), quote!(crate::adc::RxDma)),
         (("ucpd", "RX"), quote!(crate::ucpd::RxDma)),
         (("ucpd", "TX"), quote!(crate::ucpd::TxDma)),
         (("usart", "RX"), quote!(crate::usart::RxDma)),

--- a/examples/stm32c5/src/bin/adc_dma.rs
+++ b/examples/stm32c5/src/bin/adc_dma.rs
@@ -1,0 +1,43 @@
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, AdcChannel, AdcConfig, SampleTime};
+use embassy_stm32::{Config, bind_interrupts, dma, peripherals};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    LPDMA1_CH0 =>
+        dma::InterruptHandler<peripherals::LPDMA1_CH0>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut config = Config::default();
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.mux.adcdacsel = mux::Adcdacsel::Hclk1;
+        config.rcc.adcdac_pre = embassy_stm32::pac::rcc::vals::Adcdacpre::Div2;
+    }
+    let p = embassy_stm32::init(config);
+
+    info!("ADC DMA example");
+
+    let mut adc1 = Adc::new_with_config(p.ADC1, AdcConfig::default());
+
+    let mut adc1_channel = p.PA0.degrade_adc();
+    let mut readings = [0u16; 1];
+
+    adc1.read(
+        p.LPDMA1_CH0,
+        Irqs,
+        [(adc1_channel.reborrow_adc(), SampleTime::Cycles289)].into_iter(),
+        None,
+        &mut readings,
+    )
+    .await;
+
+    info!("PA0: {}", readings[0]);
+}


### PR DESCRIPTION
Some STM32 metadata, including STM32C5, describes ADC DMA channels using the `GLOBAL` signal name.

The embassy-stm32 build script previously recognized `ADC`, `ADC1`, `ADC2`, and `ADC3`, but ignored `GLOBAL`. Therefore, valid STM32C5 ADC DMA metadata did not generate the required `RxDma<ADCx>` implementations.

This change maps ADC `GLOBAL` signals to `adc::RxDma` and adds an STM32C5 ADC DMA example as compile-time coverage.

Tested with:

cargo build --manifest-path examples/stm32c5/Cargo.toml --bin adc_dma