### PR TITLE
fix(stm32): explicitly disable PLL during embassy_stm32::init

### DIFF
--- a/embassy-stm32/src/rcc/f013.rs
+++ b/embassy-stm32/src/rcc/f013.rs
@@ -184,6 +184,12 @@ pub(crate) unsafe fn init(config: Config) {
     RCC.cfgr().modify(|w| w.set_sw(Sysclk::Hsi));
     while RCC.cfgr().read().sws() != Sysclk::Hsi {}
 
+    // PLL configuration cannot be changed while PLL is enabled.
+    if RCC.cr().read().pllrdy() {
+        RCC.cr().modify(|w| w.set_pllon(false));
+        while RCC.cr().read().pllrdy() {}
+    }
+
     // Configure HSI
     let hsi = match config.hsi {
         false => None,


### PR DESCRIPTION
The PLL can not be reconfigured if it is already running.

This can be the case for example if a bootloader has configured/enabled the PLL before jumping to the application.