### PR TITLE
rp/trng: avoid blocking forever after health errors

### DIFF
--- a/embassy-rp/src/trng.rs
+++ b/embassy-rp/src/trng.rs
@@ -219,6 +219,32 @@ impl<'d, T: Instance> Trng<'d, T> {
         T::Interrupt::disable();
     }
 
+    fn recover_or_panic_on_generation_error(&self) -> bool {
+        let regs = T::regs();
+        let isr = regs.rng_isr().read();
+
+        // CRNGT_ERR and VN_ERR can leave EHR invalid. The blocking API is
+        // infallible, so report the health-test failure loudly instead of
+        // spinning forever waiting for a result that may never become valid.
+        if isr.crngt_err() {
+            panic!("TRNG CRNGT error! Increase sample count to reduce likelihood");
+        }
+        if isr.vn_err() {
+            panic!("TRNG Von-Neumann balancer error! Increase sample count to reduce likelihood");
+        }
+
+        if isr.autocorr_err() {
+            regs.trng_sw_reset().write(|w| w.set_trng_sw_reset(true));
+            // Fixed delay is required after TRNG soft reset. This read is sufficient.
+            regs.trng_sw_reset().read();
+            self.initialize_rng();
+            self.start_rng();
+            return true;
+        }
+
+        false
+    }
+
     fn blocking_wait_for_successful_generation(&self) {
         let regs = T::regs();
 
@@ -227,15 +253,13 @@ impl<'d, T: Instance> Trng<'d, T> {
 
         let mut success = false;
         while success.not() {
-            while trng_busy_register.read().trng_busy() {}
+            while trng_busy_register.read().trng_busy() {
+                if self.recover_or_panic_on_generation_error() {
+                    continue;
+                }
+            }
             if trng_valid_register.read().ehr_valid().not() {
-                if regs.rng_isr().read().autocorr_err() {
-                    regs.trng_sw_reset().write(|w| w.set_trng_sw_reset(true));
-                    // Fixed delay is required after TRNG soft reset. This read is sufficient.
-                    regs.trng_sw_reset().read();
-                    self.initialize_rng();
-                    self.start_rng();
-                } else {
+                if self.recover_or_panic_on_generation_error().not() {
                     panic!("RNG not busy, but ehr is not valid!")
                 }
             } else {


### PR DESCRIPTION
## Summary

  This PR addresses #6756.

  It updates the RP2350 TRNG blocking path so that TRNG health-test failures do not leave the blocking API spinning forever.

  Currently `blocking_wait_for_successful_generation()` only handles `AUTOCORR_ERR`. If `CRNGT_ERR` or `VN_ERR` is raised while no valid EHR block is produced, the blocking path can keep waiting for a result that may never become valid.

  This PR makes the blocking path check all TRNG health-test error bits:

  - `AUTOCORR_ERR`: keep the existing soft-reset / reinitialize / restart recovery path.
  - `CRNGT_ERR`: panic instead of silently waiting forever.
  - `VN_ERR`: panic instead of silently waiting forever.

  The blocking API is infallible today, so this PR chooses a loud failure rather than changing the public API shape.

  ## Background

  This is an RP2350-specific fix, but the policy is the same as #6777: RNG health-test failures should not result in a silent hang. This is a general driver robustness issue, even though the concrete implementation is peripheral-specific.

  On Raspberry Pi Pico 2 W, I observed that after CYW43 initialization, a blocking RP2350 TRNG read can fail to make progress.

  I reduced the case with local minimal probes:

  1. A CYW43 LED-only probe works.
  2. A CYW43 + `embassy_rp::trng::Trng::blocking_fill_bytes()` probe stops after CYW43 initialization and before the TRNG call returns.
  3. A CYW43 + raw TRNG register probe, configured with embassy-rp default-like settings, reports `RNG_ISR.CRNGT_ERR`.

  This suggests the core issue is not BLE/GATT handling itself. The hardware reports a TRNG health-test failure, and the current blocking path does not handle `CRNGT_ERR`.

  ## Scope

  This PR does not try to make the TRNG health-test failure succeed. It only makes the blocking path fail loudly instead of silently waiting forever.

  A more complete design could add a fallible API such as `try_blocking_fill_bytes()`, bounded retry behavior, or a richer error type. I consider that an API design discussion and therefore out of scope for this small fix.

  ## Testing

  Ran locally on top of current `main`:

  ```sh
  cargo fmt --manifest-path embassy-rp/Cargo.toml --check

  cargo check \
    --manifest-path embassy-rp/Cargo.toml \
    --target thumbv8m.main-none-eabihf \
    --no-default-features \
    --features rp235xa,time-driver

  cargo check \
    --manifest-path embassy-rp/Cargo.toml \
    --target thumbv8m.main-none-eabihf \
    --no-default-features \
    --features rp235xa,time-driver,defmt
```

  I also tested the behavior on a Pico 2 W with local minimal probes as described above.