### PR TITLE
fix(embassy-net-adin1110): clippy errors, readme

### DIFF
--- a/embassy-net-adin1110/README.md
+++ b/embassy-net-adin1110/README.md
@@ -10,32 +10,32 @@ SPE is full-duplex - it can transmit and receive ethernet packets at the same ti
 SPE also supports [`PoDL (Power over Data Line)`](https://www.ti.com/lit/an/snla395/snla395.pdf), power delivery from 0.5 up to 50 Watts, similar to [`PoE`](https://en.wikipedia.org/wiki/Power_over_Ethernet), but an additional hardware and handshake protocol are needed.
 
 SPE has many link speeds but only `10 BASE-T1L` is able to reach cable lengths up to 1000 meters in `2.4 Vpp` transmit amplitude.
-Currently in 2023, none of the standards are compatible with each other.
+As of 2023, none of the standards were compatible with each other.
 Thus `10 BASE-T1L` won't work with a `10 BASE-T1S`, `100 BASE-T1` or any standard `x BASE-T`.
 
 In the industry SPE is also called [`APL (Advanced Physical Layer)`](https://www.ethernet-apl.org), and is based on the `10 BASE-T1L` standard.
 
 APL can be used in [`intrinsic safety applications/explosion hazardous areas`](https://en.wikipedia.org/wiki/Electrical_equipment_in_hazardous_areas) which has its own name and standard called [`2-WISE (2-wire intrinsically safe ethernet) IEC TS 60079-47:2021`](https://webstore.iec.ch/publication/64292).
 
-`10 BASE-T1L` and `ADIN1110` are designed to support intrinsic safety applications. The power supply energy is fixed and PDoL is not supported.
+The `10 BASE-T1L` standard and the `ADIN1110` and `ADIN2111` chips are designed to support intrinsic safety applications.
 
 ## Supported SPI modes
 
-`ADIN1110` supports two SPI modes. `Generic` and [`OPEN Alliance 10BASE-T1x MAC-PHY serial interface`](https://opensig.org/wp-content/uploads/2023/12/OPEN_Alliance_10BASET1x_MAC-PHY_Serial_Interface_V1.1.pdf)
+These chips support two SPI modes. `Generic` and [`OPEN Alliance 10BASE-T1x MAC-PHY serial interface`](https://opensig.org/wp-content/uploads/2023/12/OPEN_Alliance_10BASET1x_MAC-PHY_Serial_Interface_V1.1.pdf).
 
 Both modes support with and without additional CRC.
-Currently only `Generic` SPI with or without CRC is supported.
 
 *NOTE:* SPI Mode is selected by the hardware pins `SPI_CFG0` and `SPI_CFG1`. Software can't detect nor change the mode.
 
 ## Hardware
 
 - Tested on [`Analog Devices EVAL-ADIN1110EBZ`](https://www.analog.com/en/design-center/evaluation-hardware-and-software/evaluation-boards-kits/eval-adin1110.html) with an `STM32L4S5QII3P`, see [`spe_adin1110_http_server`](../examples/stm32l4/src/bin/spe_adin1110_http_server.rs) for an example.
+- Tested on the [Bristlemouth dev kit](https://bristlemouth.org/) with an `STM32U575CIU6Q`, see [`spe_adin2111_http_server`](../examples/stm32u575/src/bin/spe_adin2111_http_server.rs) for an example.
 - [`SparkFun MicroMod Single Pair Ethernet Function Board`](https://www.sparkfun.com/products/19038) or [`SparkFun MicroMod Single Pair Ethernet Kit (End Of Life)`](https://www.sparkfun.com/products/19628), supporting multiple microcontrollers. **Make sure to check if it's a microcontroller that is supported by Embassy!**
 
 ## Other SPE chips
 
-* [`Analog ADIN2111`](https://www.analog.com/en/products/adin2111.html) 2 Port SPI version. Can work with this driver.
+* [`Analog ADIN2111`](https://www.analog.com/en/products/adin2111.html) 2 Port SPI version, also supported by this driver.
 * [`Analog ADIN1100`](https://www.analog.com/en/products/adin1100.html) RGMII version.
 
 ## Testing

--- a/embassy-net-adin1110/src/fmt.rs
+++ b/embassy-net-adin1110/src/fmt.rs
@@ -244,19 +244,19 @@ impl<T, E> Try for Result<T, E> {
 
 pub(crate) struct Bytes<'a>(pub &'a [u8]);
 
-impl<'a> Debug for Bytes<'a> {
+impl Debug for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#02x?}", self.0)
     }
 }
 
-impl<'a> Display for Bytes<'a> {
+impl Display for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#02x?}", self.0)
     }
 }
 
-impl<'a> LowerHex for Bytes<'a> {
+impl LowerHex for Bytes<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:#02x?}", self.0)
     }

--- a/embassy-net-adin1110/src/lib.rs
+++ b/embassy-net-adin1110/src/lib.rs
@@ -314,143 +314,141 @@ impl<SPI: SpiDevice, INT: Wait, RST: OutputPin> Runner<'_, GenericSpi<SPI>, INT,
     /// Run the driver.
     #[allow(clippy::too_many_lines)]
     pub async fn run(mut self) -> ! {
+        let (state_chan, mut rx_chan, mut tx_chan) = self.ch.split();
+
         loop {
-            let (state_chan, mut rx_chan, mut tx_chan) = self.ch.split();
+            debug!("Waiting for interrupts");
+            match select(self.int.wait_for_low(), tx_chan.tx_buf()).await {
+                Either::First(_) => {
+                    let mut status1_clr = Status1(0);
+                    let mut status1 = Status1(self.mac.read_reg(sr::STATUS1).await.unwrap());
 
-            loop {
-                debug!("Waiting for interrupts");
-                match select(self.int.wait_for_low(), tx_chan.tx_buf()).await {
-                    Either::First(_) => {
-                        let mut status1_clr = Status1(0);
-                        let mut status1 = Status1(self.mac.read_reg(sr::STATUS1).await.unwrap());
-
-                        while status1.p1_rx_rdy() {
-                            debug!("alloc RX packet buffer");
-                            match select(rx_chan.rx_buf(), tx_chan.tx_buf()).await {
-                                // Handle frames that needs to transmit from the wire.
-                                // Note: rx_chan.rx_buf() channel don´t accept new request
-                                //       when the tx_chan is full. So these will be handled
-                                //       automaticly.
-                                Either::First(mut frame) => match self.mac.read_fifo(&mut frame).await {
-                                    Ok(n) => {
-                                        frame.rx_done(n);
-                                    }
-                                    Err(e) => match e {
-                                        AdinError::PACKET_TOO_BIG => {
-                                            error!("RX Packet too big, DROP");
-                                            self.mac.write_reg(sr::FIFO_CLR, 1).await.unwrap();
-                                        }
-                                        AdinError::PACKET_TOO_SMALL => {
-                                            error!("RX Packet too small, DROP");
-                                            self.mac.write_reg(sr::FIFO_CLR, 1).await.unwrap();
-                                        }
-                                        AdinError::Spi(e) => {
-                                            error!("RX Spi error {}", e.kind());
-                                        }
-                                        e => {
-                                            error!("RX Error {:?}", e);
-                                        }
-                                    },
-                                },
-                                Either::Second(mut frame) => {
-                                    // Handle frames that needs to transmit to the wire.
-                                    self.mac.write_fifo(&mut frame).await.unwrap();
-                                    frame.tx_done();
+                    while status1.p1_rx_rdy() {
+                        debug!("alloc RX packet buffer");
+                        match select(rx_chan.rx_buf(), tx_chan.tx_buf()).await {
+                            // Handle frames that needs to transmit from the wire.
+                            // Note: rx_chan.rx_buf() channel don´t accept new request
+                            //       when the tx_chan is full. So these will be handled
+                            //       automaticly.
+                            Either::First(mut frame) => match self.mac.read_fifo(&mut frame).await {
+                                Ok(n) => {
+                                    frame.rx_done(n);
                                 }
+                                Err(e) => match e {
+                                    AdinError::PACKET_TOO_BIG => {
+                                        error!("RX Packet too big, DROP");
+                                        self.mac.write_reg(sr::FIFO_CLR, 1).await.unwrap();
+                                    }
+                                    AdinError::PACKET_TOO_SMALL => {
+                                        error!("RX Packet too small, DROP");
+                                        self.mac.write_reg(sr::FIFO_CLR, 1).await.unwrap();
+                                    }
+                                    AdinError::Spi(e) => {
+                                        error!("RX Spi error {}", e.kind());
+                                    }
+                                    e => {
+                                        error!("RX Error {:?}", e);
+                                    }
+                                },
+                            },
+                            Either::Second(frame) => {
+                                // Handle frames that needs to transmit to the wire.
+                                self.mac.write_fifo(&frame).await.unwrap();
+                                frame.tx_done();
                             }
-                            status1 = Status1(self.mac.read_reg(sr::STATUS1).await.unwrap());
                         }
+                        status1 = Status1(self.mac.read_reg(sr::STATUS1).await.unwrap());
+                    }
 
-                        let status0 = Status0(self.mac.read_reg(sr::STATUS0).await.unwrap());
-                        if status1.0 & !0x1b != 0 {
-                            error!("SPE CHIP STATUS 0:{:08x} 1:{:08x}", status0.0, status1.0);
-                        }
+                    let status0 = Status0(self.mac.read_reg(sr::STATUS0).await.unwrap());
+                    if status1.0 & !0x1b != 0 {
+                        error!("SPE CHIP STATUS 0:{:08x} 1:{:08x}", status0.0, status1.0);
+                    }
 
-                        if status1.tx_rdy() {
-                            status1_clr.set_tx_rdy(true);
-                            trace!("TX_DONE");
-                        }
+                    if status1.tx_rdy() {
+                        status1_clr.set_tx_rdy(true);
+                        trace!("TX_DONE");
+                    }
 
-                        if status1.link_change() {
-                            let link = status1.p1_link_status();
-                            self.is_link_up = link;
+                    if status1.link_change() {
+                        let link = status1.p1_link_status();
+                        self.is_link_up = link;
 
-                            if link {
-                                let link_status = self
-                                    .mac
-                                    .read_cl45(MDIO_PHY_ADDR, RegsC45::DA7::AN_STATUS_EXTRA.into())
-                                    .await
-                                    .unwrap();
+                        if link {
+                            let link_status = self
+                                .mac
+                                .read_cl45(MDIO_PHY_ADDR, RegsC45::DA7::AN_STATUS_EXTRA.into())
+                                .await
+                                .unwrap();
 
-                                let volt = if link_status & (0b11 << 5) == (0b11 << 5) {
-                                    "2.4"
-                                } else {
-                                    "1.0"
-                                };
-
-                                let mse = self
-                                    .mac
-                                    .read_cl45(MDIO_PHY_ADDR, RegsC45::DA1::MSE_VAL.into())
-                                    .await
-                                    .unwrap();
-
-                                info!("LINK Changed: Link Up, Volt: {} V p-p, MSE: {:0004}", volt, mse);
+                            let volt = if link_status & (0b11 << 5) == (0b11 << 5) {
+                                "2.4"
                             } else {
-                                info!("LINK Changed: Link Down");
-                            }
+                                "1.0"
+                            };
 
-                            state_chan.set_link_state(if link { LinkState::Up } else { LinkState::Down });
-                            status1_clr.set_link_change(true);
-                        }
-
-                        if status1.tx_ecc_err() {
-                            error!("SPI TX_ECC_ERR error, CLEAR TX FIFO");
-                            self.mac.write_reg(sr::FIFO_CLR, 2).await.unwrap();
-                            status1_clr.set_tx_ecc_err(true);
-                        }
-
-                        if status1.rx_ecc_err() {
-                            error!("SPI RX_ECC_ERR error");
-                            status1_clr.set_rx_ecc_err(true);
-                        }
-
-                        if status1.spi_err() {
-                            error!("SPI SPI_ERR CRC error");
-                            status1_clr.set_spi_err(true);
-                        }
-
-                        if status0.phyint() {
-                            let crsm_irq_st = self
+                            let mse = self
                                 .mac
-                                .read_cl45(MDIO_PHY_ADDR, RegsC45::DA1E::CRSM_IRQ_STATUS.into())
+                                .read_cl45(MDIO_PHY_ADDR, RegsC45::DA1::MSE_VAL.into())
                                 .await
                                 .unwrap();
 
-                            let phy_irq_st = self
-                                .mac
-                                .read_cl45(MDIO_PHY_ADDR, RegsC45::DA1F::PHY_SYBSYS_IRQ_STATUS.into())
-                                .await
-                                .unwrap();
-
-                            warn!(
-                                "SPE CHIP PHY CRSM_IRQ_STATUS {:04x} PHY_SUBSYS_IRQ_STATUS {:04x}",
-                                crsm_irq_st, phy_irq_st
-                            );
+                            info!("LINK Changed: Link Up, Volt: {} V p-p, MSE: {:0004}", volt, mse);
+                        } else {
+                            info!("LINK Changed: Link Down");
                         }
 
-                        if status0.txfcse() {
-                            error!("Ethernet Frame FCS and calc FCS don't match!");
-                        }
+                        state_chan.set_link_state(if link { LinkState::Up } else { LinkState::Down });
+                        status1_clr.set_link_change(true);
+                    }
 
-                        // Clear status0
-                        self.mac.write_reg(sr::STATUS0, 0xFFF).await.unwrap();
-                        self.mac.write_reg(sr::STATUS1, status1_clr.0).await.unwrap();
+                    if status1.tx_ecc_err() {
+                        error!("SPI TX_ECC_ERR error, CLEAR TX FIFO");
+                        self.mac.write_reg(sr::FIFO_CLR, 2).await.unwrap();
+                        status1_clr.set_tx_ecc_err(true);
                     }
-                    Either::Second(mut packet) => {
-                        // Handle frames that needs to transmit to the wire.
-                        self.mac.write_fifo(&mut packet).await.unwrap();
-                        packet.tx_done();
+
+                    if status1.rx_ecc_err() {
+                        error!("SPI RX_ECC_ERR error");
+                        status1_clr.set_rx_ecc_err(true);
                     }
+
+                    if status1.spi_err() {
+                        error!("SPI SPI_ERR CRC error");
+                        status1_clr.set_spi_err(true);
+                    }
+
+                    if status0.phyint() {
+                        let crsm_irq_st = self
+                            .mac
+                            .read_cl45(MDIO_PHY_ADDR, RegsC45::DA1E::CRSM_IRQ_STATUS.into())
+                            .await
+                            .unwrap();
+
+                        let phy_irq_st = self
+                            .mac
+                            .read_cl45(MDIO_PHY_ADDR, RegsC45::DA1F::PHY_SYBSYS_IRQ_STATUS.into())
+                            .await
+                            .unwrap();
+
+                        warn!(
+                            "SPE CHIP PHY CRSM_IRQ_STATUS {:04x} PHY_SUBSYS_IRQ_STATUS {:04x}",
+                            crsm_irq_st, phy_irq_st
+                        );
+                    }
+
+                    if status0.txfcse() {
+                        error!("Ethernet Frame FCS and calc FCS don't match!");
+                    }
+
+                    // Clear status0
+                    self.mac.write_reg(sr::STATUS0, 0xFFF).await.unwrap();
+                    self.mac.write_reg(sr::STATUS1, status1_clr.0).await.unwrap();
+                }
+                Either::Second(packet) => {
+                    // Handle frames that needs to transmit to the wire.
+                    self.mac.write_fifo(&packet).await.unwrap();
+                    packet.tx_done();
                 }
             }
         }


### PR DESCRIPTION
Some minor changes in the ADIN1110 driver:

- Readme changes to fix grammar and style and to mention the Bristlemouth dev kit example
- Fixed clippy errors:
  - A few elided lifetimes in `fmt.rs`
  - One big `never_loop` in `lib.rs`, removing a single, large, unused outer loop and one level of indentation for 135 llines that were inside the unused loop

I tested on hardware after the change, and everything's working fine.