### PR TITLE
updating I2C read to one continuous read

### DIFF
--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -290,6 +290,14 @@ impl TransferOptions {
         complete_transfer_interrupt: true,
         priority: Priority::LOWEST,
     };
+
+    
+    /// Short-hand to specify that both the half-transfer and complete transfer interrupts should be triggered.
+    pub const HALF_AND_COMPLETE_INTERRUPT: Self = Self {
+        half_transfer_interrupt: true,
+        complete_transfer_interrupt: true,
+        priority: Priority::LOWEST,
+    };
 }
 
 /// General DMA error types.
@@ -1629,6 +1637,11 @@ impl DmaChannel<'_> {
     /// Get the wait cell for this channel
     pub(crate) fn wait_cell(&self) -> &'static WaitCell {
         &STATES[self.channel.dma()][self.channel.channel()].waker
+    }
+
+    /// Get the half-transfer wait cell for this channel
+    pub(crate) fn half_wait_cell(&self) -> &'static WaitCell {
+        &STATES[self.channel.dma()][self.channel.channel()].half_waker
     }
 
     /// Enable the interrupt for this channel in the NVIC.

--- a/embassy-mcxa/src/dma.rs
+++ b/embassy-mcxa/src/dma.rs
@@ -290,14 +290,6 @@ impl TransferOptions {
         complete_transfer_interrupt: true,
         priority: Priority::LOWEST,
     };
-
-    
-    /// Short-hand to specify that both the half-transfer and complete transfer interrupts should be triggered.
-    pub const HALF_AND_COMPLETE_INTERRUPT: Self = Self {
-        half_transfer_interrupt: true,
-        complete_transfer_interrupt: true,
-        priority: Priority::LOWEST,
-    };
 }
 
 /// General DMA error types.
@@ -1637,11 +1629,6 @@ impl DmaChannel<'_> {
     /// Get the wait cell for this channel
     pub(crate) fn wait_cell(&self) -> &'static WaitCell {
         &STATES[self.channel.dma()][self.channel.channel()].waker
-    }
-
-    /// Get the half-transfer wait cell for this channel
-    pub(crate) fn half_wait_cell(&self) -> &'static WaitCell {
-        &STATES[self.channel.dma()][self.channel.channel()].half_waker
     }
 
     /// Enable the interrupt for this channel in the NVIC.

--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -1186,79 +1186,100 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
             return Err(IOError::InvalidReadBufferLength);
         }
 
-        for chunk in read.chunks_mut(256) {
-            self.async_start(address, true).await?;
-
-            // perform corrective action if the future is dropped or an
-            // error happens between here and the end of the read.
-            //
-            // NOTE: this *must* be set up *after* async_start. async_start
-            // already runs `status_and_act`, which on NACK performs its
-            // own remediation; if we set OnDrop earlier, the early `?`
-            // return would invoke remediation a second time and corrupt
-            // the controller state for the next transaction.
-            let on_drop = OnDrop::new(|| {
-                self.remediation();
-                self.info.regs().mder().modify(|w| w.set_rdde(false));
-            });
-
-            // send receive command
-            self.send_cmd(Cmd::RECEIVE, (chunk.len() - 1) as u8);
-
-            let peri_addr = self.info.regs().mrdr().as_ptr() as *const u8;
-
-            // _rx_dma is guaranteed to be Some
-            unsafe {
-                // Clean up channel state
-                self.mode.rx_dma.disable_request();
-                self.mode.rx_dma.clear_done();
-                self.mode.rx_dma.clear_interrupt();
-
-                // Set DMA request source from instance type (type-safe)
-                self.mode.rx_dma.set_request_source(self.mode.rx_request);
-
-                // Configure TCD for peripheral-to-memory transfer
-                self.mode.rx_dma.setup_read_from_peripheral(
-                    peri_addr,
-                    chunk,
-                    false,
-                    TransferOptions::COMPLETE_INTERRUPT,
-                )?;
-
-                // Enable I2C RX DMA request
-                self.info.regs().mder().modify(|w| w.set_rdde(true));
-
-                // Enable DMA channel request
-                self.mode.rx_dma.enable_request();
-            }
-
-            // Wait for completion asynchronously
-            core::future::poll_fn(|cx| {
-                let _ = self.mode.rx_dma.wait_cell().poll_wait(cx);
-                if self.mode.rx_dma.is_done() {
-                    core::task::Poll::Ready(())
-                } else {
-                    core::task::Poll::Pending
-                }
-            })
-            .await;
-
-            // Ensure DMA writes are visible to CPU
-            cortex_m::asm::dsb();
-            // Cleanup
+        // perform corrective action if the future is dropped
+        let on_drop = OnDrop::new(|| {
+            self.remediation();
             self.info.regs().mder().modify(|w| w.set_rdde(false));
-            unsafe {
-                self.mode.rx_dma.disable_request();
-                self.mode.rx_dma.clear_done();
+        });
+
+        // Issue a single START for the whole read. Re-addressing the device for
+        // each 256-byte chunk restarts its register pointer (e.g. HID-over-I2C
+        // devices answer a bare read with their input register), corrupting
+        // reads larger than 256 bytes.
+        self.async_start(address, true).await?;
+
+        // Drain the *entire* read with a single continuous DMA transfer. A
+        // single continuous DMA is essential: if the DMA were torn down and
+        // re-armed at each 256-byte boundary, the LPI2C command FIFO would run
+        // empty between chunks and the master would end the transfer (NACK +
+        // STOP), truncating the read. With one DMA the master simply
+        // clock-stretches whenever the RX FIFO fills, so there is no overflow
+        // and no truncation. The half-transfer interrupt lets us refill the
+        // command FIFO part-way through for reads larger than the FIFO can hold.
+        let peri_addr = self.info.regs().mrdr().as_ptr() as *const u8;
+        unsafe {
+            self.mode.rx_dma.disable_request();
+            self.mode.rx_dma.clear_done();
+            self.mode.rx_dma.clear_interrupt();
+            self.mode.rx_dma.set_request_source(self.mode.rx_request);
+            self.mode.rx_dma.setup_read_from_peripheral(
+                peri_addr,
+                read,
+                false,
+                TransferOptions::HALF_AND_COMPLETE_INTERRUPT,
+            )?;
+            self.info.regs().mder().modify(|w| w.set_rdde(true));
+            self.mode.rx_dma.enable_request();
+        }
+
+        // A single RECEIVE command can request at most 256 bytes (its count
+        // field is 8-bit), so larger reads need several RECEIVE commands in one
+        // continuous transaction. The command FIFO must never run empty
+        // mid-receive, so prime it up front and top it up as it drains until
+        // every byte has been requested.
+        let mut to_request = read.len();
+        while to_request > 0 && !self.is_tx_fifo_full() {
+            let n = to_request.min(256);
+            self.send_cmd(Cmd::RECEIVE, (n - 1) as u8);
+            to_request -= n;
+        }
+
+        // Wait for the DMA to drain the whole buffer, refilling the command
+        // FIFO on each wake (half-transfer or complete) so a RECEIVE is always
+        // pending until the read is fully requested.
+        let result = core::future::poll_fn(|cx| {
+            let _ = self.mode.rx_dma.wait_cell().poll_wait(cx);
+            let _ = self.mode.rx_dma.half_wait_cell().poll_wait(cx);
+
+            // Surface a bus error (NACK, arbitration loss, FIFO error) rather
+            // than waiting forever for data that will never arrive.
+            if let Err(e) = self.status() {
+                return core::task::Poll::Ready(Err(e));
             }
 
-            // defuse it; we'll re-arm on the next chunk if any.
-            on_drop.defuse();
+            // Keep the command FIFO fed as it drains.
+            while to_request > 0 && !self.is_tx_fifo_full() {
+                let n = to_request.min(256);
+                self.send_cmd(Cmd::RECEIVE, (n - 1) as u8);
+                to_request -= n;
+            }
+
+            if self.mode.rx_dma.is_done() {
+                core::task::Poll::Ready(Ok(()))
+            } else {
+                core::task::Poll::Pending
+            }
+        })
+        .await;
+
+        // Ensure DMA writes are visible to CPU
+        cortex_m::asm::dsb();
+
+        // Cleanup
+        self.info.regs().mder().modify(|w| w.set_rdde(false));
+        unsafe {
+            self.mode.rx_dma.disable_request();
+            self.mode.rx_dma.clear_done();
         }
+
+        result?;
 
         if send_stop == SendStop::Yes {
             self.async_stop().await?;
         }
+
+        // defuse it if the future is not dropped
+        on_drop.defuse();
 
         Ok(())
     }

--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -1209,12 +1209,9 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
             self.mode.rx_dma.clear_done();
             self.mode.rx_dma.clear_interrupt();
             self.mode.rx_dma.set_request_source(self.mode.rx_request);
-            self.mode.rx_dma.setup_read_from_peripheral(
-                peri_addr,
-                read,
-                false,
-                TransferOptions::COMPLETE_INTERRUPT,
-            )?;
+            self.mode
+                .rx_dma
+                .setup_read_from_peripheral(peri_addr, read, false, TransferOptions::COMPLETE_INTERRUPT)?;
             self.info.regs().mder().modify(|w| w.set_rdde(true));
             self.mode.rx_dma.enable_request();
         }

--- a/embassy-mcxa/src/i2c/controller.rs
+++ b/embassy-mcxa/src/i2c/controller.rs
@@ -1186,26 +1186,23 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
             return Err(IOError::InvalidReadBufferLength);
         }
 
-        // perform corrective action if the future is dropped
+        // Issue a single START for the whole read
+        self.async_start(address, true).await?;
+
+        // perform corrective action if the future is dropped or an
+        // error happens between here and the end of the read.
+        //
+        // NOTE: this *must* be set up *after* async_start. async_start
+        // already runs `status_and_act`, which on NACK performs its
+        // own remediation; if we set OnDrop earlier, the early `?`
+        // return would invoke remediation a second time and corrupt
+        // the controller state for the next transaction.
         let on_drop = OnDrop::new(|| {
             self.remediation();
             self.info.regs().mder().modify(|w| w.set_rdde(false));
         });
 
-        // Issue a single START for the whole read. Re-addressing the device for
-        // each 256-byte chunk restarts its register pointer (e.g. HID-over-I2C
-        // devices answer a bare read with their input register), corrupting
-        // reads larger than 256 bytes.
-        self.async_start(address, true).await?;
-
-        // Drain the *entire* read with a single continuous DMA transfer. A
-        // single continuous DMA is essential: if the DMA were torn down and
-        // re-armed at each 256-byte boundary, the LPI2C command FIFO would run
-        // empty between chunks and the master would end the transfer (NACK +
-        // STOP), truncating the read. With one DMA the master simply
-        // clock-stretches whenever the RX FIFO fills, so there is no overflow
-        // and no truncation. The half-transfer interrupt lets us refill the
-        // command FIFO part-way through for reads larger than the FIFO can hold.
+        // Drain the *entire* read with a single continuous DMA transfer
         let peri_addr = self.info.regs().mrdr().as_ptr() as *const u8;
         unsafe {
             self.mode.rx_dma.disable_request();
@@ -1216,30 +1213,25 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
                 peri_addr,
                 read,
                 false,
-                TransferOptions::HALF_AND_COMPLETE_INTERRUPT,
+                TransferOptions::COMPLETE_INTERRUPT,
             )?;
             self.info.regs().mder().modify(|w| w.set_rdde(true));
             self.mode.rx_dma.enable_request();
         }
 
         // A single RECEIVE command can request at most 256 bytes (its count
-        // field is 8-bit), so larger reads need several RECEIVE commands in one
-        // continuous transaction. The command FIFO must never run empty
-        // mid-receive, so prime it up front and top it up as it drains until
-        // every byte has been requested.
-        let mut to_request = read.len();
-        while to_request > 0 && !self.is_tx_fifo_full() {
-            let n = to_request.min(256);
-            self.send_cmd(Cmd::RECEIVE, (n - 1) as u8);
-            to_request -= n;
-        }
+        // field is 8-bit), and the command FIFO is only a few entries deep, so
+        // a large read needs many RECEIVE commands issued over the life of the
+        // transfer. Refills are driven by the LPI2C transmit-data flag (TDF) —
+        // i.e. by *command-FIFO space*
 
-        // Wait for the DMA to drain the whole buffer, refilling the command
-        // FIFO on each wake (half-transfer or complete) so a RECEIVE is always
-        // pending until the read is fully requested.
+        let mut to_request = read.len();
         let result = core::future::poll_fn(|cx| {
+            // Register wakers for both completion sources before touching
+            // hardware state: DMA-complete (whole buffer received) and the
+            // shared I2C interrupt (TDF command-FIFO space, plus bus errors).
             let _ = self.mode.rx_dma.wait_cell().poll_wait(cx);
-            let _ = self.mode.rx_dma.half_wait_cell().poll_wait(cx);
+            let _ = self.info.wait_cell().poll_wait(cx);
 
             // Surface a bus error (NACK, arbitration loss, FIFO error) rather
             // than waiting forever for data that will never arrive.
@@ -1247,12 +1239,23 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
                 return core::task::Poll::Ready(Err(e));
             }
 
-            // Keep the command FIFO fed as it drains.
+            // Refill the command FIFO while it has space and commands remain.
             while to_request > 0 && !self.is_tx_fifo_full() {
                 let n = to_request.min(256);
                 self.send_cmd(Cmd::RECEIVE, (n - 1) as u8);
                 to_request -= n;
             }
+
+            // Re-arm interrupts every poll: the shared I2C ISR disables MIER on
+            // each fire. Always keep the error interrupts armed so a NACK wakes
+            // us
+            self.info.regs().mier().write(|w| {
+                w.set_ndie(true);
+                w.set_alie(true);
+                w.set_feie(true);
+                w.set_pltie(true);
+                w.set_tdie(to_request > 0);
+            });
 
             if self.mode.rx_dma.is_done() {
                 core::task::Poll::Ready(Ok(()))
@@ -1262,10 +1265,8 @@ impl<'d> AsyncEngine for I2c<'d, Dma<'d>> {
         })
         .await;
 
-        // Ensure DMA writes are visible to CPU
         cortex_m::asm::dsb();
 
-        // Cleanup
         self.info.regs().mder().modify(|w| w.set_rdde(false));
         unsafe {
             self.mode.rx_dma.disable_request();


### PR DESCRIPTION
I ran into an issue when I tried read the report descriptor from ELAN touchpad and could only read the first 256 bytes due to the re-addressing in the looped read with the repeated START, because the read from ELAN IC is >256 bytes and the device treats a fresh read-addressed (repeated-)START as "start over", I couldn't perform a successful read. Changed to single START with repeated RECEIVE which resulted in the correct read and allows continuous transaction matching standard I²C