### PR TITLE
usb: claim SetEthernetPacketFilter in the CDC-NCM descriptor

### DIFF
--- a/embassy-usb/src/class/cdc_ncm/mod.rs
+++ b/embassy-usb/src/class/cdc_ncm/mod.rs
@@ -309,7 +309,19 @@ impl<'d, D: Driver<'d>> CdcNcmClass<'d, D> {
                 CDC_TYPE_NCM, // bDescriptorSubtype
                 0x00,         // bcdNCMVersion
                 0x01,         // |
-                0,            // bmNetworkCapabilities
+                // bmNetworkCapabilities. Bit 0 claims SetEthernetPacketFilter,
+                // which this class does not implement: `control_out` stalls the
+                // request along with every other one it does not recognise.
+                //
+                // The claim works around a macOS bug, Apple's r.170072016. A
+                // device declaring no capabilities is sent SET_INTERFACE(alt=1)
+                // and then SET_INTERFACE(alt=0) a few milliseconds later, and
+                // the data interface is never enabled again -- for roughly one
+                // attachment in three. Claiming the bit puts the host on a path
+                // that completes: it sends SetEthernetPacketFilter, we stall it,
+                // and the fallback macOS already has for that failure carries
+                // on correctly. Linux and Windows are unaffected either way.
+                1,
             ],
         );
 


### PR DESCRIPTION
## The problem

macOS drops the CDC-NCM data interface shortly after bringing it up, for
roughly one attachment in three. The host sends `SET_INTERFACE(iface, alt=1)`,
then `SET_INTERFACE(iface, alt=0)` a few milliseconds later, and never enables
the interface again. The device sees its link come up and go straight back
down. Linux and Windows never do this.

This is a bug on Apple's side, not in this class. It is Apple's r.170072016,
and their DTS describes it, and this workaround, in [developer forum thread
824727](https://developer.apple.com/forums/thread/824727).

Captured on a Beagle USB 480 analyser, every transfer is ACKed and no
descriptor is refused. The host simply gives up.

## The change

One byte: bit 0 of `bmNetworkCapabilities`, which claims support for
`SetEthernetPacketFilter`.

## The obvious objection

**We are claiming a capability this class does not implement.** That is worth
stating plainly, because it is the whole of the change.

`control_out` ends in `_ => Some(OutResponse::Rejected)`, so
`SetEthernetPacketFilter` is stalled along with every other request the class
does not recognise. That is exactly the path Apple describes: claiming the bit
makes macOS *send* the request, the stall tells it we cannot honour it, and the
fallback macOS already has for that failure carries on correctly. The
alternative — declaring nothing — is what triggers the bug.

The risk this raises is that some other host handles the stall less kindly. So
it was measured rather than argued.

## Measurements

Two boards, an i.MX RT1062 with a hand-written USB device driver and an RP2350
with `embassy-rp`'s. The failure appeared identically on both, which is what
placed it in this class rather than in either driver.

| Host | Before | After |
| --- | --- | --- |
| macOS 15 | 35–38% of attachments failed (94 attachments) | 1 in 50 |
| iOS / iPadOS | same failure | link-up markedly faster |
| Windows 11 Pro | unaffected | binds as a network adapter, no fault flagged, traffic flows |
| Linux (Raspberry Pi 5) | unaffected | unchanged |

A second board, RP2040 through this crate unmodified, showed 3 of 9
attachments needing a self-recovery reset before the change and 1 of 8 after.
Fewer samples, same direction.

The results going in different directions is the point: the macOS family
improves because it carried the bug, Linux does not move because it never did.

## Things tried first that changed nothing

For the record, so nobody repeats them: the notification format and timing, the
notification endpoint's size and `bInterval`, sending `CONNECTION_SPEED_CHANGE`
as one packet rather than two, and sending an empty NTB immediately after
enabling the endpoints. None of them moved the failure rate, because none of
them were the cause.

## Happy to gate it

If you would rather not have the class claim something it does not implement
unconditionally, I am glad to put this behind a Cargo feature or a field on
`State`. Say which you prefer and I will push it.
