### PR TITLE
Update ALL_PERIPHERALS to properly support the rp235x

### DIFF
--- a/embassy-rp/src/reset.rs
+++ b/embassy-rp/src/reset.rs
@@ -2,7 +2,10 @@ pub use pac::resets::regs::Peripherals;
 
 use crate::pac;
 
+#[cfg(feature = "rp2040")]
 pub const ALL_PERIPHERALS: Peripherals = Peripherals(0x01ff_ffff);
+#[cfg(feature = "_rp235x")]
+pub const ALL_PERIPHERALS: Peripherals = Peripherals(0x1fff_ffff);
 
 pub(crate) fn reset(peris: Peripherals) {
     pac::RESETS.reset().write_value(peris);


### PR DESCRIPTION
The RP2040's reset register was only 25 bits wide (Refer to Section 2.13.3 Registers (Pg158) of the RP2040 datasheet).

The RP235x's reset register is now 29 bits wide (Refer to Section 7.5.2 Programmer's Model (Pg503) of the RP2350 datasheet).

This line needs to be updated to reflect that, or else the UARTs, TRNG and USB aren't reset on the rp235x.

Separate values must be specified, or else unreset_wait() will hang indefinitely on the rp2040.