### PR TITLE
Synopsys-OTG: Specify max TX FIFO size

### DIFF
--- a/embassy-nrf/src/usb/usbhs.rs
+++ b/embassy-nrf/src/usb/usbhs.rs
@@ -65,6 +65,7 @@ impl<'d, V: VbusDetect> Driver<'d, V> {
             regs: T::core_regs(),
             state: T::state(),
             fifo_depth_words: FIFO_DEPTH_WORDS,
+            tx_fifo_count: MAX_EP_COUNT as u8,
             phy_type: PhyType::InternalHighSpeed,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             calculate_trdt_fn: calculate_trdt,

--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 CAN:
 - fix: stm32/can/fdcan: write `FilterType::Range` bounds in the correct order (`from`→SFID1/EFID1, `to`→SFID2/EFID2). The swapped order prevented normal multi-ID ranges from matching, breaking both accepting and rejecting range filters.
 
+USB:
+- fix: OTG_FS on STM32F1 uses 4 endpoints and 320 FIFO words.
+- fix: OTG_FS on STM32H7RS uses 6 endpoints and 320 FIFO words.
+
 DMA:
 - fix: stm32/dma: fix HTIF masking TCIF in on_irq when both flags fire simultaneously
 - fix: stm32/dma: defer read_index advance until after copy in read_raw to avoid partial-advance on overrun

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -79,6 +79,7 @@ impl<'d, T: Instance> Driver<'d, T> {
             regs,
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
+            tx_fifo_count: T::state().endpoint_count() as u8,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             phy_type: PhyType::InternalFullSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
@@ -117,6 +118,7 @@ impl<'d, T: Instance> Driver<'d, T> {
             regs: T::regs(),
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
+            tx_fifo_count: T::state().endpoint_count() as u8,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             phy_type: PhyType::InternalHighSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
@@ -162,6 +164,7 @@ impl<'d, T: Instance> Driver<'d, T> {
             regs: T::regs(),
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
+            tx_fifo_count: T::state().endpoint_count() as u8,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             phy_type: PhyType::ExternalFullSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
@@ -209,6 +212,7 @@ impl<'d, T: Instance> Driver<'d, T> {
             regs: T::regs(),
             state: T::state(),
             fifo_depth_words: T::FIFO_DEPTH_WORDS,
+            tx_fifo_count: T::state().endpoint_count() as u8,
             extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
             phy_type: PhyType::ExternalHighSpeed,
             calculate_trdt_fn: calculate_trdt::<T>,
@@ -455,9 +459,8 @@ foreach_interrupt!(
     (USB_OTG_FS, otg, $block:ident, GLOBAL, $irq:ident) => {
         impl crate::peripherals::USB_OTG_FS {
             cfg_if::cfg_if! {
-                if #[cfg(stm32f1)] {
-                    const ENDPOINT_COUNT: usize = 8;
-                } else if #[cfg(any(
+                if #[cfg(any(
+                    stm32f1,
                     stm32f2,
                     stm32f401,
                     stm32f405,
@@ -482,14 +485,13 @@ foreach_interrupt!(
                     stm32l4,
                     stm32u5,
                     stm32wba,
+                    stm32h7rs,
                 ))] {
                     const ENDPOINT_COUNT: usize = 6;
                 } else if #[cfg(stm32g0x1)] {
                     const ENDPOINT_COUNT: usize = 8;
-                } else if #[cfg(any(stm32h7, stm32h7rs))] {
+                } else if #[cfg(stm32h7)] {
                     const ENDPOINT_COUNT: usize = 9;
-                } else if #[cfg(any(stm32wba, stm32u5))] {
-                    const ENDPOINT_COUNT: usize = 6;
                 } else {
                     compile_error!("USB_OTG_FS peripheral is not supported by this chip.");
                 }
@@ -500,9 +502,8 @@ foreach_interrupt!(
             const HIGH_SPEED: bool = false;
 
             cfg_if::cfg_if! {
-                if #[cfg(stm32f1)] {
-                    const FIFO_DEPTH_WORDS: u16 = 128;
-                } else if #[cfg(any(
+                if #[cfg(any(
+                    stm32f1,
                     stm32f2,
                     stm32f401,
                     stm32f405,
@@ -514,9 +515,6 @@ foreach_interrupt!(
                     stm32f429,
                     stm32f437,
                     stm32f439,
-                ))] {
-                    const FIFO_DEPTH_WORDS: u16 = 320;
-                } else if #[cfg(any(
                     stm32f412,
                     stm32f413,
                     stm32f423,
@@ -527,14 +525,13 @@ foreach_interrupt!(
                     stm32l4,
                     stm32u5,
                     stm32wba,
+                    stm32h7rs,
                 ))] {
                     const FIFO_DEPTH_WORDS: u16 = 320;
                 } else if #[cfg(stm32g0x1)] {
                     const FIFO_DEPTH_WORDS: u16 = 512;
-                } else if #[cfg(any(stm32h7, stm32h7rs))] {
+                } else if #[cfg(stm32h7)] {
                     const FIFO_DEPTH_WORDS: u16 = 1024;
-                } else if #[cfg(any(stm32wba, stm32u5))] {
-                    const FIFO_DEPTH_WORDS: u16 = 320;
                 } else {
                     compile_error!("USB_OTG_FS peripheral is not supported by this chip.");
                 }

--- a/embassy-usb-synopsys-otg/CHANGELOG.md
+++ b/embassy-usb-synopsys-otg/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased - ReleaseDate
 
+- **Breaking:** Add `tx_fifo_count` to `OtgInstance`. This is the number of TX FIFOs. If there is no free TX FIFO, allocation of an IN endpoint fails. The TX FIFO number is not the endpoint number.
 - Changed: `embassy-time` is now an optional feature for device mode. Remote wakeup is now supported via `embassy-time`.
 - Changed: The driver can be configured with any `embassy_sync` raw mutex implementation.
 - Fixed: Clearing an endpoint halt now resets the data toggle to DATA0, as does enabling an endpoint for a new configuration or alternate setting.

--- a/embassy-usb-synopsys-otg/src/lib.rs
+++ b/embassy-usb-synopsys-otg/src/lib.rs
@@ -297,6 +297,7 @@ struct EndpointData {
     ep_type: EndpointType,
     max_packet_size: u16,
     fifo_size_words: u16,
+    tx_fifo: u8,
 }
 
 /// Type-erased borrow of [`State`] passed to [`OtgInstance`], [`Driver`](crate::Driver), [`Bus`](crate::Bus),
@@ -336,6 +337,21 @@ where
     /// Returns the number of device endpoints supported by this state.
     pub fn endpoint_count(&self) -> usize {
         self.ep_states.len()
+    }
+
+    fn tx_fifo_in_use(&self, fifo: u8) -> bool {
+        (0..self.endpoint_count()).any(|i| self.ep_alloc_get(Direction::In, i).is_some_and(|ep| ep.tx_fifo == fifo))
+    }
+
+    fn alloc_tx_fifo(&self, ep_index: usize, tx_fifo_count: u8) -> Option<u8> {
+        if tx_fifo_count == 0 {
+            return None;
+        }
+        if ep_index == 0 {
+            (!self.tx_fifo_in_use(0)).then_some(0)
+        } else {
+            (1..tx_fifo_count).find(|&fifo| !self.tx_fifo_in_use(fifo))
+        }
     }
 }
 
@@ -561,6 +577,7 @@ where
         let dir = D::dir();
         let st = self.instance.state;
         let endpoint_count = st.endpoint_count();
+        let tx_fifo_count = self.instance.tx_fifo_count;
 
         // Find endpoint slot
         let index = if let Some(addr) = ep_addr {
@@ -595,6 +612,18 @@ where
             }
         };
 
+        let tx_fifo = if dir == Direction::In {
+            match st.alloc_tx_fifo(index, tx_fifo_count) {
+                Some(fifo) => fifo,
+                None => {
+                    error!("No free TX FIFO");
+                    return Err(EndpointAllocError);
+                }
+            }
+        } else {
+            0
+        };
+
         unsafe {
             st.alloc_slot_write(
                 dir,
@@ -603,6 +632,7 @@ where
                     ep_type,
                     max_packet_size,
                     fifo_size_words,
+                    tx_fifo,
                 },
             );
         };
@@ -1057,11 +1087,15 @@ where
             for i in 0..st.endpoint_count() {
                 if let Some(ep) = st.ep_alloc_get(Direction::In, i) {
                     trace!(
-                        "configuring tx fifo ep={}, offset={}, size={}",
-                        i, fifo_top, ep.fifo_size_words
+                        "configuring tx fifo ep={}, fifo={}, offset={}, size={}",
+                        i, ep.tx_fifo, fifo_top, ep.fifo_size_words
                     );
 
-                    let dieptxf = if i == 0 { regs.dieptxf0() } else { regs.dieptxf(i - 1) };
+                    let dieptxf = if ep.tx_fifo == 0 {
+                        regs.dieptxf0()
+                    } else {
+                        regs.dieptxf(ep.tx_fifo as usize - 1)
+                    };
 
                     dieptxf.write(|w| {
                         w.set_fd(ep.fifo_size_words);
@@ -1107,7 +1141,7 @@ where
                     // 0 this makes the device permanently unusable.
                     if regs.diepctl(index).read().epena() {
                         abort_in_endpoint(regs, index);
-                        flush_tx_fifo(regs, index as _);
+                        flush_tx_fifo(regs, ep.tx_fifo);
                     }
 
                     regs.diepctl(index).write(|w| {
@@ -1117,7 +1151,7 @@ where
                             w.set_mpsiz(ep.max_packet_size);
                             w.set_eptyp(to_eptyp(ep.ep_type));
                             w.set_sd0pid_sevnfrm(true);
-                            w.set_txfnum(index as _);
+                            w.set_txfnum(ep.tx_fifo);
                             w.set_snak(true);
                         }
                     });
@@ -1362,6 +1396,7 @@ where
             && st
                 .ep_alloc_get(dir, index)
                 .is_some_and(|ep| has_data_toggle(ep.ep_type));
+        let in_tx_fifo = st.ep_alloc_get(Direction::In, index).map(|ep| ep.tx_fifo);
 
         match dir {
             Direction::Out => {
@@ -1383,7 +1418,9 @@ where
                     // then does not operate again.
                     if stalled && regs.diepctl(index).read().epena() {
                         abort_in_endpoint(regs, index);
-                        flush_tx_fifo(regs, index as _);
+                        if let Some(tx_fifo) = in_tx_fifo {
+                            flush_tx_fifo(regs, tx_fifo);
+                        }
                     }
 
                     regs.diepctl(index).modify(|w| {
@@ -1491,7 +1528,9 @@ where
                         }
                     });
 
-                    flush_tx_fifo(regs, ep_addr.index() as _);
+                    if let Some(ep) = st.ep_alloc_get(Direction::In, ep_addr.index()) {
+                        flush_tx_fifo(regs, ep.tx_fifo);
+                    }
                 });
 
                 st.ep_states[ep_addr.index()]
@@ -1956,6 +1995,11 @@ where
     pub phy_type: PhyType,
     /// Extra RX FIFO words needed by some implementations.
     pub extra_rx_fifo_words: u16,
+    /// Number of TX FIFOs.
+    ///
+    /// This value can be less than [`State::endpoint_count`].
+    /// If there is no free TX FIFO, allocation of an IN endpoint fails.
+    pub tx_fifo_count: u8,
     /// Function to calculate TRDT value based on some internal clock speed.
     pub calculate_trdt_fn: fn(speed: vals::Dspd) -> u8,
 }

--- a/embassy-usb-synopsys-otg/src/otg_v1.rs
+++ b/embassy-usb-synopsys-otg/src/otg_v1.rs
@@ -252,7 +252,7 @@ impl Otg {
     #[doc = "Device IN endpoint transmit FIFO size register"]
     #[inline(always)]
     pub const fn dieptxf(self, n: usize) -> Reg<regs::Fsiz, RW> {
-        core::assert!(n < 8usize);
+        core::assert!(n < 15usize);
         unsafe { Reg::from_ptr(self.ptr.add(0x0104usize + n * 4usize) as _) }
     }
     #[doc = "Host configuration register"]


### PR DESCRIPTION
This PR makes it an error to allocate more IN endpoints than there are TX FIFOs.

Also fixes some incorrect STM USB facts.