### PR TITLE
stm32/rcc: add system methods for unitrait drivers

### DIFF
--- a/embassy-stm32/src/hsem/mod.rs
+++ b/embassy-stm32/src/hsem/mod.rs
@@ -362,7 +362,7 @@ impl<T: Instance> HardwareSemaphore<T> {
         _peripheral: Peri<'d, T>,
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, HardwareSemaphoreInterruptHandler<T>> + 'd,
     ) -> Self {
-        critical_section::with(|cs| init_hsem(cs));
+        critical_section::with(|cs| init_hsem(cs, false));
 
         HardwareSemaphore { _type: PhantomData }
     }
@@ -437,10 +437,14 @@ impl<T: Instance> HardwareSemaphore<T> {
     }
 }
 
-pub(crate) fn init_hsem(cs: CriticalSection) {
+pub(crate) fn init_hsem(cs: CriticalSection, no_refcount: bool) {
     // Do not attempt to reset the HSEM, as a race condition and deadlock can occur between cores
     // It is assumed the HSEM is already initialized during `init_primary()`
-    crate::rcc::enable_with_cs::<HSEM>(cs);
+    if no_refcount {
+        crate::rcc::enable_with_cs_no_refcount::<HSEM>(cs);
+    } else {
+        crate::rcc::enable_with_cs::<HSEM>(cs);
+    }
 
     <HSEM as Instance>::Interrupt::unpend();
     unsafe {

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -615,7 +615,7 @@ mod dual_core {
         let shared_data = unsafe { shared_data.assume_init_ref() };
 
         // Enable hardware semaphore.
-        critical_section::with(|cs| crate::hsem::init_hsem(cs));
+        critical_section::with(|cs| crate::hsem::init_hsem(cs, true));
 
         #[cfg(stm32h7)]
         {
@@ -650,7 +650,7 @@ mod dual_core {
     /// A hardware semaphore is used to coordinate the init with the second core.
     pub fn try_init_secondary(shared_data: &'static MaybeUninit<SharedData>) -> Option<Peripherals> {
         critical_section::with(|cs| {
-            rcc::enable_with_cs::<peripherals::HSEM>(cs);
+            rcc::enable_with_cs_no_refcount::<peripherals::HSEM>(cs);
         });
 
         // Wait for the semaphore to be unlocked by the primary core
@@ -805,16 +805,16 @@ fn init_hw(config: Config) -> Peripherals {
 
         #[cfg(any(stm32h7rs))]
         // On the H7RS the SYSCFG should not be reset if it is already enabled. This is typically the case when running from external flash and the bootloader enables the SYSCFG.
-        rcc::enable_with_cs::<peripherals::SYSCFG>(cs);
+        rcc::enable_with_cs_no_refcount::<peripherals::SYSCFG>(cs);
         #[cfg(not(any(stm32f1, stm32wb, stm32wl, stm32h7rs, stm32c5)))]
-        rcc::enable_and_reset_with_cs::<peripherals::SYSCFG>(cs);
+        rcc::enable_and_reset_with_cs_no_refcount::<peripherals::SYSCFG>(cs);
         #[cfg(not(any(stm32h5, stm32h7, stm32h7rs, stm32wb, stm32wl, stm32c5)))]
-        rcc::enable_and_reset_with_cs::<peripherals::PWR>(cs);
+        rcc::enable_and_reset_with_cs_no_refcount::<peripherals::PWR>(cs);
         #[cfg(all(
             flash,
             not(any(stm32f2, stm32f4, stm32f7, stm32l0, stm32h5, stm32h7, stm32h7rs, stm32c5))
         ))]
-        rcc::enable_and_reset_with_cs::<peripherals::FLASH>(cs);
+        rcc::enable_and_reset_with_cs_no_refcount::<peripherals::FLASH>(cs);
 
         // Enable the VDDIO2 power supply on chips that have it.
         // Note that this requires the PWR peripheral to be enabled first.
@@ -981,11 +981,7 @@ fn init_hw(config: Config) -> Peripherals {
 
             // must be before time_driver init to allow refcount reset
             #[cfg(all(any(stm32wb, stm32wl5x), feature = "low-power"))]
-            hsem::init_hsem(cs);
-
-            // reset peripherals here
-            #[cfg(feature = "low-power")]
-            crate::rcc::reset_stop_refcount(cs);
+            hsem::init_hsem(cs, true);
 
             // must be after rcc init
             #[cfg(feature = "_time-driver")]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -983,6 +983,10 @@ fn init_hw(config: Config) -> Peripherals {
             #[cfg(all(any(stm32wb, stm32wl5x), feature = "low-power"))]
             hsem::init_hsem(cs);
 
+            // reset peripherals here
+            #[cfg(feature = "low-power")]
+            crate::rcc::reset_stop_refcount(cs);
+
             // must be after rcc init
             #[cfg(feature = "_time-driver")]
             crate::time_driver::init(cs);

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -174,12 +174,6 @@ pub fn get_stop_mode(_cs: CriticalSection) -> Option<StopMode> {
 }
 
 #[cfg(feature = "low-power")]
-pub(crate) unsafe fn reset_stop_refcount(_cs: CriticalSection) {
-    REFCOUNT_STOP2 = 0;
-    REFCOUNT_STOP1 = 0;
-}
-
-#[cfg(feature = "low-power")]
 fn increment_stop_refcount(_cs: CriticalSection, stop_mode: StopMode) {
     match stop_mode {
         StopMode::Standby => {}

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -174,7 +174,6 @@ pub fn get_stop_mode(_cs: CriticalSection) -> Option<StopMode> {
 }
 
 #[cfg(feature = "low-power")]
-#[allow(dead_code)]
 pub(crate) unsafe fn reset_stop_refcount(_cs: CriticalSection) {
     REFCOUNT_STOP2 = 0;
     REFCOUNT_STOP1 = 0;
@@ -298,6 +297,14 @@ impl RccInfo {
 
     // TODO: should this be `unsafe`?
     pub(crate) fn enable_and_reset_with_cs(&self, cs: CriticalSection) {
+        self.enable_and_reset_with_cs_inner(cs, false);
+    }
+
+    pub(crate) fn enable_and_reset_with_cs_no_refcount(&self, cs: CriticalSection) {
+        self.enable_and_reset_with_cs_inner(cs, true);
+    }
+
+    fn enable_and_reset_with_cs_inner(&self, cs: CriticalSection, no_refcount: bool) {
         if let Some(refcount_idx) = self.refcount_idx {
             let refcount_idx = refcount_idx as usize;
             let refcount = unsafe { &mut (*&raw mut crate::_generated::REFCOUNTS)[refcount_idx] };
@@ -327,11 +334,20 @@ impl RccInfo {
             }
         }
 
-        self.enable_with_cs(cs);
+        self.enable_with_cs_inner(cs, no_refcount);
+    }
+
+    pub(crate) fn enable_with_cs(&self, cs: CriticalSection) {
+        self.enable_with_cs_inner(cs, false);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn enable_with_cs_no_refcount(&self, cs: CriticalSection) {
+        self.enable_with_cs_inner(cs, true);
     }
 
     // TODO: should this be `unsafe`?
-    pub(crate) fn enable_with_cs(&self, cs: CriticalSection) {
+    fn enable_with_cs_inner(&self, cs: CriticalSection, no_refcount: bool) {
         // set the xxxEN bit
         let already_enabled = unsafe {
             let val = self.enable_ptr().read_volatile();
@@ -360,7 +376,7 @@ impl RccInfo {
             }
         }
 
-        if !already_enabled {
+        if !already_enabled && !no_refcount {
             self.increment_minimum_stop_refcount_with_cs(cs);
         }
     }
@@ -553,6 +569,17 @@ pub fn frequency<T: RccPeripheral>() -> Hertz {
     T::frequency()
 }
 
+/// Enables and resets peripheral `T` without incrementing refcount.
+///
+/// # Safety
+///
+/// Peripheral must not be in use.
+// TODO: should this be `unsafe`?
+#[allow(dead_code)]
+pub(crate) fn enable_and_reset_with_cs_no_refcount<T: RccPeripheral>(cs: CriticalSection) {
+    let _ = T::RCC_INFO.enable_and_reset_with_cs_no_refcount(cs);
+}
+
 /// Enables and resets peripheral `T`.
 ///
 /// # Safety
@@ -561,6 +588,16 @@ pub fn frequency<T: RccPeripheral>() -> Hertz {
 // TODO: should this be `unsafe`?
 pub fn enable_and_reset_with_cs<T: RccPeripheral>(cs: CriticalSection) {
     let _ = T::RCC_INFO.enable_and_reset_with_cs(cs);
+}
+
+/// Enables and clears the reset for peripheral `T` without incrementing refcount.
+///
+/// # Safety
+///
+/// The peripheral can be in use since this does not reset it
+#[allow(dead_code)]
+pub(crate) fn enable_with_cs_no_refcount<T: RccPeripheral>(cs: CriticalSection) {
+    T::RCC_INFO.enable_with_cs_no_refcount(cs);
 }
 
 /// Enables and clears the reset for peripheral `T`.

--- a/embassy-stm32/src/rtc/mod.rs
+++ b/embassy-stm32/src/rtc/mod.rs
@@ -214,7 +214,7 @@ impl Rtc {
 
     pub(self) fn new_inner(rtc_config: RtcConfig) -> Self {
         #[cfg(not(any(stm32l0, stm32f3, stm32l1, stm32f0, stm32f2)))]
-        crate::rcc::enable_and_reset::<RTC>();
+        critical_section::with(|cs| crate::rcc::enable_and_reset_with_cs_no_refcount::<RTC>(cs));
 
         let mut this = Self {
             #[cfg(all(feature = "low-power", not(feature = "_lp-time-driver")))]

--- a/embassy-stm32/src/time_driver/gp16.rs
+++ b/embassy-stm32/src/time_driver/gp16.rs
@@ -117,7 +117,7 @@ impl RtcDriver {
     pub(crate) fn init_timer(&'static self, cs: critical_section::CriticalSection) {
         let r = regs_gp16();
 
-        rcc::enable_and_reset_with_cs::<T>(cs);
+        rcc::enable_and_reset_with_cs_no_refcount::<T>(cs);
 
         let timer_freq = T::frequency();
 
@@ -152,9 +152,6 @@ impl RtcDriver {
         unsafe {
             <T as GeneralInstance1Channel>::CaptureCompareInterrupt::enable();
             <T as CoreInstance>::UpdateInterrupt::enable();
-
-            #[cfg(feature = "low-power")]
-            crate::rcc::reset_stop_refcount(cs);
         }
     }
 

--- a/embassy-stm32/src/time_driver/lptim.rs
+++ b/embassy-stm32/src/time_driver/lptim.rs
@@ -127,11 +127,11 @@ embassy_time_driver::time_driver_impl!(static DRIVER: RtcDriver = RtcDriver {
 impl RtcDriver {
     /// initialize the timer, but don't start it.  Used for chips like stm32wle5
     /// for low power where the timer config is lost in STOP2.
-    pub(crate) fn init_timer(&'static self, _cs: critical_section::CriticalSection) {
+    pub(crate) fn init_timer(&'static self, cs: critical_section::CriticalSection) {
         let r = regs_lptim();
 
         // we want this to increment the stop mode counter (some lp timer can't do STOP2)
-        rcc::enable_and_reset::<T>();
+        rcc::enable_and_reset_with_cs::<T>(cs);
 
         let timer_freq = T::frequency();
 


### PR DESCRIPTION
stops having to reset the rcc refcount; used for unitrait drivers

closes #6784 .
