### PR TITLE
Export FirmwareUpdaterError from boot crates

### DIFF
--- a/embassy-boot-nrf/src/lib.rs
+++ b/embassy-boot-nrf/src/lib.rs
@@ -6,7 +6,7 @@ mod fmt;
 
 pub use embassy_boot::{
     AlignedBuffer, BlockingFirmwareState, BlockingFirmwareUpdater, BootError, BootLoaderConfig, FirmwareState,
-    FirmwareUpdater, FirmwareUpdaterConfig,
+    FirmwareUpdater, FirmwareUpdaterConfig, FirmwareUpdaterError,
 };
 use embassy_nrf::nvmc::PAGE_SIZE;
 use embassy_nrf::{Peri, wdt};

--- a/embassy-boot-rp/src/lib.rs
+++ b/embassy-boot-rp/src/lib.rs
@@ -6,7 +6,7 @@ mod fmt;
 
 pub use embassy_boot::{
     AlignedBuffer, BlockingFirmwareState, BlockingFirmwareUpdater, BootError, BootLoaderConfig, FirmwareState,
-    FirmwareUpdater, FirmwareUpdaterConfig, State,
+    FirmwareUpdater, FirmwareUpdaterConfig, FirmwareUpdaterError, State,
 };
 use embassy_rp::Peri;
 use embassy_rp::flash::{Blocking, ERASE_SIZE, Flash};

--- a/embassy-boot-stm32/src/lib.rs
+++ b/embassy-boot-stm32/src/lib.rs
@@ -6,7 +6,7 @@ mod fmt;
 
 pub use embassy_boot::{
     AlignedBuffer, BlockingFirmwareState, BlockingFirmwareUpdater, BootError, BootLoaderConfig, FirmwareState,
-    FirmwareUpdater, FirmwareUpdaterConfig, State,
+    FirmwareUpdater, FirmwareUpdaterConfig, FirmwareUpdaterError, State,
 };
 use embedded_storage::nor_flash::NorFlash;
 


### PR DESCRIPTION
## Summary

Re-export `FirmwareUpdaterError` from the nRF, RP, and STM32 boot crates so it is available through the platform-specific APIs, consistent with the other firmware updater types.

Fixes #6714

## Testing

- `embassy-boot-nrf`: `cargo check --target thumbv7em-none-eabi --features embassy-nrf/nrf52840`
- `embassy-boot-stm32`: `cargo check --target thumbv7em-none-eabi --features embassy-stm32/stm32f411ce`
- `embassy-boot-rp`: `cargo check --target thumbv6m-none-eabi --features embassy-rp/rp2040`
- `git diff --check`