### PR TITLE
rp: implement USB remote wakeup

### DIFF
--- a/embassy-rp/CHANGELOG.md
+++ b/embassy-rp/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## Unreleased - ReleaseDate
+- USB: support device-initiated remote wakeup on RP2040 and RP235x
 - Fix i2c_slave respond_to_read for buffers larger than one chunk
 
 - Update `fixed` dependency

--- a/embassy-rp/src/usb/device.rs
+++ b/embassy-rp/src/usb/device.rs
@@ -477,7 +477,21 @@ impl<'d, T: Instance> driver::Bus for Bus<'d, T> {
     async fn disable(&mut self) {}
 
     async fn remote_wakeup(&mut self) -> Result<(), Unsupported> {
-        Err(Unsupported)
+        // SIE_CTRL.RESUME ("Device: Remote wakeup. Device can initiate its own
+        // resume after suspend") is self-clearing per the RP2040 datasheet
+        // (pico-sdk: USB_SIE_CTRL_RESUME access type "SC"): the controller
+        // drives the resume signaling on the bus by itself, so a single write
+        // is sufficient.
+        //
+        // This returns once signaling is initiated rather than waiting for it
+        // to finish. That is safe because a full-speed device only transmits
+        // in response to host tokens: endpoints armed while the bus is still
+        // resuming simply wait until the host restarts polling. Callers must
+        // only invoke this while suspended with remote wakeup enabled by the
+        // host, which `embassy-usb`'s `UsbDevice::remote_wakeup` guarantees;
+        // calling it in any other bus state is unsupported.
+        T::regs().sie_ctrl().modify(|w| w.set_resume(true));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
`remote_wakeup()` in the RP USB device driver unconditionally returned `Err(Unsupported)`. A device that declares `supports_remote_wakeup` in its configuration descriptor advertises the capability, the host may then arm it with `SET_FEATURE(DEVICE_REMOTE_WAKEUP)`, but when the application calls `UsbDevice::remote_wakeup()` while suspended, the driver cannot signal resume — the host stays asleep, e.g. on a keypress from a suspended keyboard.

Implementation: set `SIE_CTRL.RESUME` ("Device: Remote wakeup. Device can initiate its own resume after suspend."). The bit is self-clearing per the RP2040 datasheet (pico-sdk: `USB_SIE_CTRL_RESUME` access type `"SC"`); the controller drives the resume signaling itself. The future completes once signaling is initiated — safe because a full-speed device only transmits in response to host tokens, so endpoints armed while the bus is still resuming just wait for the host to restart polling. The usual suspend/resume interrupt path is unaffected; a later host-driven resume event may still be reported, resulting in a redundant (idempotent) `suspended(false)` handler notification.

This follows #5978 (stm32 non-OTG) and #5992 (synopsys-otg), which added `remote_wakeup()` for their respective drivers. Whether `remote_wakeup()` should await completion of the signaling is left open by the trait docs (see #2883); this implementation initiates the signaling and documents in the code why returning at that point is safe on this hardware.

Scope of evidence:
- rp-pac SVDs: same bit position (12) and description on RP2040 and RP235x — layout-level check only; the SVDs do not encode the self-clearing property (that comes from the RP2040 datasheet / pico-sdk header).
- Tested on RP2040 hardware (custom keyboard) with a Windows host: the host armed the device (listed by `powercfg /devicequery wake_armed`) and the firmware calls `UsbDevice::remote_wakeup()` on input while suspended. Before this change the driver returned `Unsupported` and the host stayed asleep; with it, both keyboard- and mouse-triggered calls wake the host from sleep, and input works normally after resume. Device-side `SIE_STATUS` traces of the self-initiated resume were not captured.
- RP235x: compiles (`rp235xa`/`rp235xb`), not hardware-tested.