### PR TITLE
stm32: gpio: Implement AfType::output_pull for gpio_v1

### DIFF
--- a/embassy-stm32/src/gpio.rs
+++ b/embassy-stm32/src/gpio.rs
@@ -609,6 +609,15 @@ impl AfType {
             pull: Pull::None,
         }
     }
+
+    /// Output with output type, speed and pull-up or pull-down;
+    pub const fn output_pull(output_type: OutputType, speed: Speed, pull: Pull) -> Self {
+        Self {
+            mode: speed.to_mode(),
+            cnf: output_type.to_cnf_out().to_bits(),
+            pull,
+        }
+    }
 }
 
 #[inline(never)]


### PR DESCRIPTION
Fixes #6874

Tested some examples on stm32f103zet6.

Maybe those large pins variants should be tested in CI to catch this?