### PR TITLE
fix(rp-usb-host): reset handling, interrupt pipe cancellation, minor fixes

### DIFF
--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -18,7 +18,7 @@ fn split_to_pre(split: Option<SplitInfo>) -> bool {
 }
 use rp_pac::usb_dpram::vals::EpControlEndpointType;
 
-use super::{BUS_WAKER, DPRAM_DATA_OFFSET, EP_IN_WAKERS, EP_MEMORY, EndpointBuffer, Instance};
+use super::{BUS_WAKER, DPRAM_DATA_OFFSET, EP_COUNT, EP_IN_WAKERS, EP_MEMORY, EndpointBuffer, Instance};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::interrupt::{self};
 use crate::peripherals::USB;
@@ -1039,23 +1039,21 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
                 "rx timeout"
             } else if ints.buff_status() {
                 let status = regs.buff_status().read().0;
-                for i in 0..32 {
-                    // ith bit set
-                    if (status >> i) & 1 == 1 {
-                        regs.buff_status().write_clear(|w| w.0 = 1 << i);
-                        // control transfers (buffer 0)
-                        if i != 0 {
-                            let idx = i / 2;
-                            // T::regs().int_ep_ctrl().modify(|w| {
-                            //     w.set_int_ep_active(w.int_ep_active() | 1 << idx);
-                            // });
-                            trace!("USB IRQ: Interrupt EP {}", idx);
-                            EP_IN_WAKERS[idx].wake();
-                        } else {
-                            trace!("USB IRQ: EPx");
-                            EP_IN_WAKERS[0].wake();
-                        }
-                        break;
+
+                // Bits 0 and 1 are EPX's IN/OUT pair; from bit 2 up they are the
+                // dedicated interrupt endpoints, two bits per endpoint. Only interrupt IN
+                // gets a dedicated endpoint, so of each pair only the IN bit is ever armed.
+                if status & 0b11 != 0 {
+                    regs.buff_status().write_clear(|w| w.0 = status & 0b11);
+                    trace!("USB IRQ: EPx");
+                    EP_IN_WAKERS[0].wake();
+                }
+
+                for n in 1..EP_COUNT {
+                    if status & (1 << (n * 2)) != 0 {
+                        regs.buff_status().write_clear(|w| w.0 = 0b11 << (n * 2));
+                        trace!("USB IRQ: Interrupt EP {}", n);
+                        EP_IN_WAKERS[n].wake();
                     }
                 }
                 "^^^"

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -32,6 +32,7 @@ const ROOT_RESET_MS: u64 = 50;
 const RESET_RECOVERY_MS: u64 = 10;
 /// Register writes need two clk_usb cycles to transfer; 12 clk_sys cycles cover this at the supported 150 MHz maximum.
 const USB_CLOCK_DELAY_CYCLES: u32 = 12;
+const SIE_START_DELAY_CYCLES: u32 = 12;
 
 /// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
 pub struct HostState {
@@ -384,9 +385,8 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             w.set_error_rx_overflow(true);
         });
 
-        // Start transaction
-        // This field should be modified separately after delay
-        cortex_m::asm::delay(12);
+        // START_TRANS is synchronized separately (RP2040 §4.1.2.9, RP2350 §12.7.3.9).
+        cortex_m::asm::delay(SIE_START_DELAY_CYCLES);
         T::regs().sie_ctrl().modify(|w| {
             w.set_start_trans(true);
         });
@@ -541,8 +541,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
         //     w.set_pulldown_en(true);
         // });
 
-        // FIXME: delay reason
-        cortex_m::asm::delay(12);
+        cortex_m::asm::delay(USB_CLOCK_DELAY_CYCLES);
         T::regs().int_ep_ctrl().modify(|w| {
             w.set_int_ep_active(w.int_ep_active() | 1 << (self.index - 1));
         });

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -26,6 +26,10 @@ use crate::usb::EP_MEMORY_SIZE;
 use crate::{Peri, RegExt};
 
 const MAIN_BUFFER_SIZE: usize = 1024;
+/// Root port reset drive time (USB 2.0 §7.1.7.5, TDRSTR).
+const ROOT_RESET_MS: u64 = 50;
+/// Reset recovery time (USB 2.0 §7.1.7.5, TRSTRCY).
+const RESET_RECOVERY_MS: u64 = 10;
 /// Register writes need two clk_usb cycles to transfer; 12 clk_sys cycles cover this at the supported 150 MHz maximum.
 const USB_CLOCK_DELAY_CYCLES: u32 = 12;
 
@@ -81,17 +85,17 @@ impl<'d, T: SealedHostInstance> Driver<'d, T> {
     /// Create a new USB driver.
     pub fn new(_usb: Peri<'d, USB>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>>) -> Self {
         let regs = T::regs();
-        unsafe {
-            // FIXME(magic):
-            // zero fill regs
-            let p = regs.as_ptr() as *mut u32;
-            for i in 0..0x9c / 4 {
-                p.add(i).write_volatile(0)
-            }
 
-            // zero fill epmem
+        // Reset the peripheral: zeroing its registers by hand would clobber those that
+        // do not reset to zero, notably `USBPHY_TRIM` and `NAK_POLL`.
+        crate::pac::RESETS.reset().modify(|w| w.set_usbctrl(true));
+        crate::pac::RESETS.reset().modify(|w| w.set_usbctrl(false));
+        while !crate::pac::RESETS.reset_done().read().usbctrl() {}
+
+        // DPRAM is outside the peripheral reset, so clear the control area by hand.
+        unsafe {
             let p = EP_MEMORY as *mut u32;
-            for i in 0..0x180 / 4 {
+            for i in 0..DPRAM_DATA_OFFSET as usize / 4 {
                 p.add(i).write_volatile(0)
             }
         }
@@ -107,6 +111,9 @@ impl<'d, T: SealedHostInstance> Driver<'d, T> {
         regs.main_ctrl().modify(|w| {
             w.set_controller_en(true);
             w.set_host_ndevice(true);
+            // RP2350 resets PHY isolation asserted; the PHY is unusable until cleared (§12.7.2).
+            #[cfg(feature = "_rp235x")]
+            w.set_phy_iso(false);
         });
         regs.sie_ctrl().modify(|w| {
             w.set_sof_en(true);
@@ -975,11 +982,13 @@ impl<'d, T: SealedHostInstance> UsbHostController<'d> for Driver<'d, T> {
             w.set_reset_bus(true);
         });
 
-        embassy_time::Timer::after_millis(50).await;
+        embassy_time::Timer::after_millis(ROOT_RESET_MS).await;
 
         T::regs().sie_ctrl().modify(|w| {
             w.set_reset_bus(false);
         });
+
+        embassy_time::Timer::after_millis(RESET_RECOVERY_MS).await;
     }
 }
 

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -26,6 +26,8 @@ use crate::usb::EP_MEMORY_SIZE;
 use crate::{Peri, RegExt};
 
 const MAIN_BUFFER_SIZE: usize = 1024;
+/// Register writes need two clk_usb cycles to transfer; 12 clk_sys cycles cover this at the supported 150 MHz maximum.
+const USB_CLOCK_DELAY_CYCLES: u32 = 12;
 
 /// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
 pub struct HostState {
@@ -219,23 +221,26 @@ impl<T: SealedHostInstance> TransactionGuard<T> {
 
 impl<T: SealedHostInstance> Drop for TransactionGuard<T> {
     fn drop(&mut self) {
+        // Dedicated interrupt endpoints belong to the pipe
+        if self.interrupt {
+            return;
+        }
+
         let selected = self.state.current_channel.load(Ordering::Relaxed);
-        if self.interrupt || selected == self.index || selected == 0 {
-            if !self.interrupt {
-                if self.transaction_active && self.abort_on_drop {
-                    let regs = T::regs();
-                    regs.sie_ctrl().modify(|w| w.set_stop_trans(true));
-                    while regs.sie_ctrl().read().stop_trans() {}
-                    regs.sie_status().write_clear(|w| {
-                        w.set_trans_complete(true);
-                        w.set_stall_rec(true);
-                        w.set_rx_timeout(true);
-                        w.set_rx_overflow(true);
-                    });
-                    regs.buff_status().write_clear(|w| w.0 = 0b11);
-                }
-                self.state.current_channel.store(0, Ordering::Relaxed);
+        if selected == self.index || selected == 0 {
+            if self.transaction_active && self.abort_on_drop {
+                let regs = T::regs();
+                regs.sie_ctrl().modify(|w| w.set_stop_trans(true));
+                while regs.sie_ctrl().read().stop_trans() {}
+                regs.sie_status().write_clear(|w| {
+                    w.set_trans_complete(true);
+                    w.set_stall_rec(true);
+                    w.set_rx_timeout(true);
+                    w.set_rx_overflow(true);
+                });
+                regs.buff_status().write_clear(|w| w.0 = 0b11);
             }
+            self.state.current_channel.store(0, Ordering::Relaxed);
 
             self.ep_control.modify(|w| {
                 w.set_interrupt_per_buff(false);
@@ -265,6 +270,24 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             0
         };
         T::dpram().ep_in_buffer_control(index)
+    }
+
+    /// Give the buffer to the USB controller only after the rest of its
+    /// control fields have crossed into the USB clock domain.
+    fn write_buffer_control(&self, f: impl FnOnce(&mut rp_pac::usb_dpram::regs::EpBufferControl)) {
+        let reg = self.buffer_control();
+        let mut value = Default::default();
+        f(&mut value);
+
+        let available = value.available(0);
+        value.set_available(0, false);
+        reg.write_value(value);
+
+        if available {
+            cortex_m::asm::delay(USB_CLOCK_DELAY_CYCLES);
+            value.set_available(0, true);
+            reg.write_value(value);
+        }
     }
 
     /// Get endpoint control register
@@ -495,8 +518,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
     /// Reload interrupt channel buffer register
     fn interrupt_reload(&mut self) {
         assert!(E::ep_type() == EndpointType::Interrupt);
-        let ctrl = self.buffer_control();
-        ctrl.write(|w| {
+        self.write_buffer_control(|w| {
             w.set_last(0, true);
             w.set_pid(0, self.pid);
             w.set_full(0, false);
@@ -529,7 +551,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             pid
         };
 
-        self.buffer_control().write(|w| {
+        self.write_buffer_control(|w| {
             w.set_pid(0, pid);
             w.set_full(0, false);
             w.set_length(0, len);
@@ -563,7 +585,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
 
         self.buf.write(&chunk);
 
-        self.buffer_control().write(|w| {
+        self.write_buffer_control(|w| {
             w.set_available(0, true);
             w.set_pid(0, pid);
             w.set_full(0, true);
@@ -708,10 +730,13 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
 
         let res = loop {
             if Self::is_interrupt_in() {
-                trace!("CHANNEL {} WAIT FOR INTERRUPT", self.index);
-                self.interrupt_reload();
-                self.wait_available().await;
-                self.advance_pid();
+                // Consume completed packet that may have arrived after last poll.
+                // Reloading would discard the packet that hardware already ACKed.
+                if !self.buffer_control().read().full(0) {
+                    trace!("CHANNEL {} WAIT FOR INTERRUPT", self.index);
+                    self.interrupt_reload();
+                    self.wait_available().await;
+                }
             } else {
                 trace!("CHANNEL {} START READ, len = {}", self.index, buf.len());
                 let packet_len = core::cmp::min(buf.len() - count, self.max_packet_size as usize);
@@ -735,6 +760,12 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
 
             self.buf.read(&mut free[..rx_len]);
             count += rx_len;
+
+            if Self::is_interrupt_in() {
+                self.advance_pid();
+                self.interrupt_reload();
+                break Ok(count);
+            }
 
             // If transfer is smaller than max_packet_size, we are done
             // If we have read buf.len() bytes, we are done

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -439,8 +439,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
                 w.set_endpoint_type(EpControlEndpointType::Interrupt);
                 w.set_interrupt_per_buff(true);
 
-                // FIXME: host_poll_interval (bits 16:25)
-                let interval = self.interval as u32 - 1;
+                // `host_poll_interval` (bits 16:25) has no PAC accessor and counts from
+                // zero, so clamp: a descriptor may declare an interval of 0.
+                let interval = self.interval.max(1) as u32 - 1;
                 w.0 |= interval << 16;
 
                 w.set_buffer_address(self.buf.addr);
@@ -680,6 +681,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
     {
         trace!("CONTROL IN: {:?}", setup);
         let length = u16::from_le_bytes([setup[6], setup[7]]) as usize;
+        if length > buf.len() {
+            return Err(PipeError::BufferOverflow);
+        }
 
         // Setup stage
         // TODO: Whole transaction error handling?
@@ -705,6 +709,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
     {
         trace!("CONTROL OUT: {:?}", setup);
         let length = u16::from_le_bytes([setup[6], setup[7]]) as usize;
+        if length > buf.len() {
+            return Err(PipeError::BufferOverflow);
+        }
 
         // Setup stage
         // TODO: Whole transaction error handling?

--- a/examples/rp/src/bin/usb_host_enum.rs
+++ b/examples/rp/src/bin/usb_host_enum.rs
@@ -1,0 +1,335 @@
+//! Reset the bus, enumerate every device behind every hub, and print the tree.
+//!
+//! Walks the bus breadth-first: enumerate the device on the root port, and whenever one
+//! turns out to be a hub, register it and enumerate whatever is on its ports, until the
+//! tree is exhausted or the USB tier limit is reached.
+//!
+//! Device types come from the class drivers in `embassy-usb-host` rather than from
+//! hand-rolled class-code checks, so a device is reported the same way here as the driver
+//! that would actually claim it sees it. That matters for the awkward ones: smart-card
+//! readers are routinely shipped under the vendor-specific class, and a MIDI device is an
+//! audio-class device wearing a particular subclass.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either3, select3};
+use embassy_rp::bind_interrupts;
+use embassy_rp::peripherals::USB;
+use embassy_time::{Duration, Instant, Timer};
+use embassy_usb_driver::Speed;
+use embassy_usb_driver::host::UsbHostAllocator;
+use embassy_usb_host::class::cdc_acm::find_cdc_acm;
+use embassy_usb_host::class::gip::find_gip;
+use embassy_usb_host::class::hid::find_hid;
+use embassy_usb_host::class::hub::{HubEvent, HubHandler};
+use embassy_usb_host::class::msc::find_msc;
+use embassy_usb_host::class::uac::descriptors::AudioInterfaceCollection;
+use embassy_usb_host::class::vcp::cp210x::{find_cp210x, id};
+use embassy_usb_host::descriptor::{ConfigurationDescriptorChain, DeviceDescriptor};
+use embassy_usb_host::handler::{EnumerationInfo, HandlerEvent};
+use embassy_usb_host::{BusHandle, BusRoute, BusState};
+use heapless::Vec;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => embassy_rp::usb::host::InterruptHandler<USB>;
+});
+
+/// Devices the tree can hold, hubs included.
+const MAX_DEVICES: usize = 16;
+/// Ports handled per hub.
+const MAX_PORTS: usize = 8;
+/// Room for one configuration descriptor and everything nested in it.
+const CONFIG_BUF: usize = 512;
+
+/// Hub class code (USB 2.0 §11.23.1). A hub declares this at the device level, unlike every
+/// other class here, which lives on an interface.
+const CLASS_HUB: u8 = 0x09;
+
+/// How many hubs may be chained below the host.
+///
+/// USB 2.0 §4.1.1 allows seven tiers. The host is tier 1 and a device occupies the last
+/// tier, which leaves five for cascaded hubs. A deeper hub is out of spec, so it is
+/// reported and left unscanned rather than descended into.
+const MAX_HUB_DEPTH: u8 = 5;
+
+/// A hub reports its populated ports one after another once registered. When nothing new
+/// has arrived for this long, take the hub as having reported everything it has.
+const PORT_QUIET: Duration = Duration::from_millis(1500);
+/// Upper bound on one hub's scan, in case events keep trickling in.
+const PORT_SCAN_MAX: Duration = Duration::from_secs(6);
+
+/// What a device turned out to be.
+#[derive(Clone, Copy, Format)]
+enum Kind {
+    Hub,
+    Hid {
+        report_len: u16,
+    },
+    MassStorage,
+    CdcAcm,
+    Cp210x,
+    Gip,
+    Audio,
+    /// Nothing claimed it; the device's own class code is shown for triage.
+    Unknown {
+        class: u8,
+    },
+}
+
+/// One enumerated device, and where it hangs.
+///
+/// The position is tracked here rather than read back out of [`EnumerationInfo::route`],
+/// which cannot answer it. A `BusRoute` only carries a hub address and port when it is
+/// `Translated`, and everything on a full-speed bus behind full-speed hubs is `Direct`.
+/// Even when it is `Translated`, the `SplitInfo` names the transaction translator -- the
+/// hub doing the speed conversion, which for a device several tiers down is not its
+/// parent. The route describes how to talk to a device, not where it sits.
+#[derive(Clone, Copy)]
+struct Node {
+    info: EnumerationInfo,
+    /// Index of the hub this sits on, or `None` for the device on the root port.
+    parent: Option<u8>,
+    /// Port on that hub, as the hub numbers them.
+    port: u8,
+    kind: Kind,
+}
+
+#[embassy_executor::main(executor = "embassy_rp::executor::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let driver = embassy_rp::usb::host::Driver::new(p.USB, Irqs);
+
+    static BUS_STATE: BusState = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
+
+    info!("waiting for a device on the root port ...");
+    // Drives the bus reset and returns the speed the device settled on.
+    let speed = bus_ctrl.wait_for_connection().await;
+
+    let mut nodes: Vec<Node, MAX_DEVICES> = Vec::new();
+    let mut config_buf = [0u8; CONFIG_BUF];
+
+    match bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await {
+        Ok((info, len)) => {
+            let kind = classify(&info.device_desc, &config_buf[..len]);
+            // The table is empty here, so this cannot fail.
+            nodes
+                .push(Node {
+                    info,
+                    parent: None,
+                    port: 0,
+                    kind,
+                })
+                .ok();
+        }
+        Err(e) => {
+            error!("root port enumeration failed: {:?}", e);
+            idle().await
+        }
+    }
+
+    // Breadth-first: children are appended as they are found, so walking `nodes` in order
+    // reaches every hub exactly once and needs no separate queue.
+    let mut next = 0;
+    while next < nodes.len() {
+        let node = nodes[next];
+        let index = next as u8;
+        next += 1;
+
+        if !matches!(node.kind, Kind::Hub) {
+            continue;
+        }
+        let depth = depth_of(&nodes, index);
+        if depth >= MAX_HUB_DEPTH {
+            warn!(
+                "hub at address {} is {} hubs deep, past the {} USB allows - not descending",
+                node.info.device_address, depth, MAX_HUB_DEPTH
+            );
+            continue;
+        }
+
+        scan_hub(&bus, &node.info, index, &mut nodes).await;
+    }
+
+    info!("");
+    info!("=== USB device tree ===");
+    print_children(&nodes, None, 0);
+    info!("{} devices total", nodes.len());
+
+    idle().await
+}
+
+/// How many hubs sit between `index` and the host, by walking up the parent chain.
+fn depth_of(nodes: &[Node], index: u8) -> u8 {
+    let mut node = &nodes[index as usize];
+    let mut depth = 0;
+    while let Some(parent) = node.parent {
+        depth += 1;
+        node = &nodes[parent as usize];
+    }
+    depth
+}
+
+/// Register one hub and enumerate whatever is on its ports, appending each to `nodes`.
+async fn scan_hub<'d, A: UsbHostAllocator<'d>>(
+    bus: &BusHandle<'d, A>,
+    hub_info: &EnumerationInfo,
+    parent: u8,
+    nodes: &mut Vec<Node, MAX_DEVICES>,
+) {
+    // Dropped at the end of the scan, which releases the pipes it holds for the next hub.
+    let mut hub = match HubHandler::<_, MAX_PORTS>::try_register(bus, hub_info).await {
+        Ok(hub) => hub,
+        Err(e) => {
+            warn!("address {}: hub registration failed: {:?}", hub_info.device_address, e);
+            return;
+        }
+    };
+
+    let mut cap = Timer::at(Instant::now() + PORT_SCAN_MAX);
+
+    loop {
+        // `PORT_QUIET` restarts on every iteration, so it measures the gap since the last
+        // event rather than the length of the scan; `cap` bounds the scan as a whole.
+        let event = match select3(hub.wait_for_event(), Timer::after(PORT_QUIET), &mut cap).await {
+            Either3::First(Ok(event)) => event,
+            Either3::First(Err(e)) => {
+                warn!("hub event failed: {:?}", e);
+                return;
+            }
+            // Nothing new for a while: the hub has reported everything attached to it.
+            Either3::Second(_) => return,
+            Either3::Third(_) => {
+                warn!("hub scan hit its {} s cap", PORT_SCAN_MAX.as_secs());
+                return;
+            }
+        };
+
+        let HandlerEvent::HandlerEvent(HubEvent::DeviceDetected { port, speed }) = event else {
+            continue;
+        };
+
+        let mut config_buf = [0u8; CONFIG_BUF];
+        match hub.enumerate_port(&mut config_buf, port, speed).await {
+            Ok((info, len)) => {
+                let kind = classify(&info.device_desc, &config_buf[..len]);
+                let node = Node {
+                    info,
+                    parent: Some(parent),
+                    port,
+                    kind,
+                };
+                if nodes.push(node).is_err() {
+                    warn!("device table full at {} entries - stopping the walk", MAX_DEVICES);
+                    return;
+                }
+            }
+            Err(e) => warn!("port {}: enumeration failed: {:?}", port, e),
+        }
+    }
+}
+
+/// Work out what a device is, by asking the class drivers that would claim it.
+///
+/// Order matters where classes overlap, and the overlaps are called out below.
+fn classify(dev: &DeviceDescriptor, config: &[u8]) -> Kind {
+    // Hubs are the one class declared on the device descriptor rather than an interface.
+    if dev.device_class == CLASS_HUB {
+        return Kind::Hub;
+    }
+
+    if let Some(hid) = find_hid(config) {
+        return Kind::Hid {
+            report_len: hid.report_descriptor_len,
+        };
+    }
+    if find_msc(config).is_some() {
+        return Kind::MassStorage;
+    }
+    if find_cdc_acm(config).is_some() {
+        return Kind::CdcAcm;
+    }
+    // Vendor-specific, so it is identified by VID/PID rather than by class.
+    if dev.vendor_id == id::VID_SILABS && find_cp210x(config, 0).is_some() {
+        return Kind::Cp210x;
+    }
+    if find_gip(config).is_some() {
+        return Kind::Gip;
+    }
+    if let Ok(cfg) = ConfigurationDescriptorChain::try_from_slice(config) {
+        if AudioInterfaceCollection::try_from_configuration(&cfg).is_ok() {
+            return Kind::Audio;
+        }
+    }
+
+    // A composite device declares class 0 at the device level and puts the real class on
+    // each interface, so the first interface's class is the one worth showing.
+    let class = ConfigurationDescriptorChain::try_from_slice(config)
+        .ok()
+        .and_then(|cfg| cfg.iter_interface().next().map(|iface| iface.interface_class))
+        .unwrap_or(dev.device_class);
+
+    Kind::Unknown { class }
+}
+
+/// Print every child of `parent`, then each of their children, indented by depth.
+fn print_children(nodes: &[Node], parent: Option<u8>, depth: usize) {
+    const INDENT: &str = "                                ";
+
+    for (i, node) in nodes.iter().enumerate() {
+        if node.parent != parent {
+            continue;
+        }
+
+        let pad = &INDENT[..(depth * 2).min(INDENT.len())];
+        let desc = &node.info.device_desc;
+        if node.parent.is_none() {
+            info!(
+                "{}root port: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        } else {
+            info!(
+                "{}port {}: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                node.port,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        }
+
+        print_children(nodes, Some(i as u8), depth + 1);
+    }
+}
+
+/// [`Speed`] prints as its enum name; this shortens it for the tree.
+struct Sp(Speed);
+
+impl Format for Sp {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            Speed::Low => defmt::write!(f, "LS"),
+            Speed::Full => defmt::write!(f, "FS"),
+            Speed::High => defmt::write!(f, "HS"),
+        }
+    }
+}
+
+async fn idle() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(1)).await;
+    }
+}

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -13,6 +13,8 @@ embassy-executor = { version = "0.10.0", path = "../../embassy-executor", featur
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.10.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info", "executor-thread", "executor-interrupt"] }
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
+embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
+embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver" }
 embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "tcp", "tcp-listener", "udp", "raw-ethernet", "raw-ip", "dhcpv4", "medium-ethernet", "dns", "icmp-ping-reply"] }
 embassy-net-wiznet = { version = "0.3.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }

--- a/examples/rp235x/src/bin/usb_host_enum.rs
+++ b/examples/rp235x/src/bin/usb_host_enum.rs
@@ -1,0 +1,335 @@
+//! Reset the bus, enumerate every device behind every hub, and print the tree.
+//!
+//! Walks the bus breadth-first: enumerate the device on the root port, and whenever one
+//! turns out to be a hub, register it and enumerate whatever is on its ports, until the
+//! tree is exhausted or the USB tier limit is reached.
+//!
+//! Device types come from the class drivers in `embassy-usb-host` rather than from
+//! hand-rolled class-code checks, so a device is reported the same way here as the driver
+//! that would actually claim it sees it. That matters for the awkward ones: smart-card
+//! readers are routinely shipped under the vendor-specific class, and a MIDI device is an
+//! audio-class device wearing a particular subclass.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either3, select3};
+use embassy_rp::bind_interrupts;
+use embassy_rp::peripherals::USB;
+use embassy_time::{Duration, Instant, Timer};
+use embassy_usb_driver::Speed;
+use embassy_usb_driver::host::UsbHostAllocator;
+use embassy_usb_host::class::cdc_acm::find_cdc_acm;
+use embassy_usb_host::class::gip::find_gip;
+use embassy_usb_host::class::hid::find_hid;
+use embassy_usb_host::class::hub::{HubEvent, HubHandler};
+use embassy_usb_host::class::msc::find_msc;
+use embassy_usb_host::class::uac::descriptors::AudioInterfaceCollection;
+use embassy_usb_host::class::vcp::cp210x::{find_cp210x, id};
+use embassy_usb_host::descriptor::{ConfigurationDescriptorChain, DeviceDescriptor};
+use embassy_usb_host::handler::{EnumerationInfo, HandlerEvent};
+use embassy_usb_host::{BusHandle, BusRoute, BusState};
+use heapless::Vec;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => embassy_rp::usb::host::InterruptHandler<USB>;
+});
+
+/// Devices the tree can hold, hubs included.
+const MAX_DEVICES: usize = 16;
+/// Ports handled per hub.
+const MAX_PORTS: usize = 8;
+/// Room for one configuration descriptor and everything nested in it.
+const CONFIG_BUF: usize = 512;
+
+/// Hub class code (USB 2.0 §11.23.1). A hub declares this at the device level, unlike every
+/// other class here, which lives on an interface.
+const CLASS_HUB: u8 = 0x09;
+
+/// How many hubs may be chained below the host.
+///
+/// USB 2.0 §4.1.1 allows seven tiers. The host is tier 1 and a device occupies the last
+/// tier, which leaves five for cascaded hubs. A deeper hub is out of spec, so it is
+/// reported and left unscanned rather than descended into.
+const MAX_HUB_DEPTH: u8 = 5;
+
+/// A hub reports its populated ports one after another once registered. When nothing new
+/// has arrived for this long, take the hub as having reported everything it has.
+const PORT_QUIET: Duration = Duration::from_millis(1500);
+/// Upper bound on one hub's scan, in case events keep trickling in.
+const PORT_SCAN_MAX: Duration = Duration::from_secs(6);
+
+/// What a device turned out to be.
+#[derive(Clone, Copy, Format)]
+enum Kind {
+    Hub,
+    Hid {
+        report_len: u16,
+    },
+    MassStorage,
+    CdcAcm,
+    Cp210x,
+    Gip,
+    Audio,
+    /// Nothing claimed it; the device's own class code is shown for triage.
+    Unknown {
+        class: u8,
+    },
+}
+
+/// One enumerated device, and where it hangs.
+///
+/// The position is tracked here rather than read back out of [`EnumerationInfo::route`],
+/// which cannot answer it. A `BusRoute` only carries a hub address and port when it is
+/// `Translated`, and everything on a full-speed bus behind full-speed hubs is `Direct`.
+/// Even when it is `Translated`, the `SplitInfo` names the transaction translator -- the
+/// hub doing the speed conversion, which for a device several tiers down is not its
+/// parent. The route describes how to talk to a device, not where it sits.
+#[derive(Clone, Copy)]
+struct Node {
+    info: EnumerationInfo,
+    /// Index of the hub this sits on, or `None` for the device on the root port.
+    parent: Option<u8>,
+    /// Port on that hub, as the hub numbers them.
+    port: u8,
+    kind: Kind,
+}
+
+#[embassy_executor::main(executor = "embassy_rp::executor::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let driver = embassy_rp::usb::host::Driver::new(p.USB, Irqs);
+
+    static BUS_STATE: BusState = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
+
+    info!("waiting for a device on the root port ...");
+    // Drives the bus reset and returns the speed the device settled on.
+    let speed = bus_ctrl.wait_for_connection().await;
+
+    let mut nodes: Vec<Node, MAX_DEVICES> = Vec::new();
+    let mut config_buf = [0u8; CONFIG_BUF];
+
+    match bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await {
+        Ok((info, len)) => {
+            let kind = classify(&info.device_desc, &config_buf[..len]);
+            // The table is empty here, so this cannot fail.
+            nodes
+                .push(Node {
+                    info,
+                    parent: None,
+                    port: 0,
+                    kind,
+                })
+                .ok();
+        }
+        Err(e) => {
+            error!("root port enumeration failed: {:?}", e);
+            idle().await
+        }
+    }
+
+    // Breadth-first: children are appended as they are found, so walking `nodes` in order
+    // reaches every hub exactly once and needs no separate queue.
+    let mut next = 0;
+    while next < nodes.len() {
+        let node = nodes[next];
+        let index = next as u8;
+        next += 1;
+
+        if !matches!(node.kind, Kind::Hub) {
+            continue;
+        }
+        let depth = depth_of(&nodes, index);
+        if depth >= MAX_HUB_DEPTH {
+            warn!(
+                "hub at address {} is {} hubs deep, past the {} USB allows - not descending",
+                node.info.device_address, depth, MAX_HUB_DEPTH
+            );
+            continue;
+        }
+
+        scan_hub(&bus, &node.info, index, &mut nodes).await;
+    }
+
+    info!("");
+    info!("=== USB device tree ===");
+    print_children(&nodes, None, 0);
+    info!("{} devices total", nodes.len());
+
+    idle().await
+}
+
+/// How many hubs sit between `index` and the host, by walking up the parent chain.
+fn depth_of(nodes: &[Node], index: u8) -> u8 {
+    let mut node = &nodes[index as usize];
+    let mut depth = 0;
+    while let Some(parent) = node.parent {
+        depth += 1;
+        node = &nodes[parent as usize];
+    }
+    depth
+}
+
+/// Register one hub and enumerate whatever is on its ports, appending each to `nodes`.
+async fn scan_hub<'d, A: UsbHostAllocator<'d>>(
+    bus: &BusHandle<'d, A>,
+    hub_info: &EnumerationInfo,
+    parent: u8,
+    nodes: &mut Vec<Node, MAX_DEVICES>,
+) {
+    // Dropped at the end of the scan, which releases the pipes it holds for the next hub.
+    let mut hub = match HubHandler::<_, MAX_PORTS>::try_register(bus, hub_info).await {
+        Ok(hub) => hub,
+        Err(e) => {
+            warn!("address {}: hub registration failed: {:?}", hub_info.device_address, e);
+            return;
+        }
+    };
+
+    let mut cap = Timer::at(Instant::now() + PORT_SCAN_MAX);
+
+    loop {
+        // `PORT_QUIET` restarts on every iteration, so it measures the gap since the last
+        // event rather than the length of the scan; `cap` bounds the scan as a whole.
+        let event = match select3(hub.wait_for_event(), Timer::after(PORT_QUIET), &mut cap).await {
+            Either3::First(Ok(event)) => event,
+            Either3::First(Err(e)) => {
+                warn!("hub event failed: {:?}", e);
+                return;
+            }
+            // Nothing new for a while: the hub has reported everything attached to it.
+            Either3::Second(_) => return,
+            Either3::Third(_) => {
+                warn!("hub scan hit its {} s cap", PORT_SCAN_MAX.as_secs());
+                return;
+            }
+        };
+
+        let HandlerEvent::HandlerEvent(HubEvent::DeviceDetected { port, speed }) = event else {
+            continue;
+        };
+
+        let mut config_buf = [0u8; CONFIG_BUF];
+        match hub.enumerate_port(&mut config_buf, port, speed).await {
+            Ok((info, len)) => {
+                let kind = classify(&info.device_desc, &config_buf[..len]);
+                let node = Node {
+                    info,
+                    parent: Some(parent),
+                    port,
+                    kind,
+                };
+                if nodes.push(node).is_err() {
+                    warn!("device table full at {} entries - stopping the walk", MAX_DEVICES);
+                    return;
+                }
+            }
+            Err(e) => warn!("port {}: enumeration failed: {:?}", port, e),
+        }
+    }
+}
+
+/// Work out what a device is, by asking the class drivers that would claim it.
+///
+/// Order matters where classes overlap, and the overlaps are called out below.
+fn classify(dev: &DeviceDescriptor, config: &[u8]) -> Kind {
+    // Hubs are the one class declared on the device descriptor rather than an interface.
+    if dev.device_class == CLASS_HUB {
+        return Kind::Hub;
+    }
+
+    if let Some(hid) = find_hid(config) {
+        return Kind::Hid {
+            report_len: hid.report_descriptor_len,
+        };
+    }
+    if find_msc(config).is_some() {
+        return Kind::MassStorage;
+    }
+    if find_cdc_acm(config).is_some() {
+        return Kind::CdcAcm;
+    }
+    // Vendor-specific, so it is identified by VID/PID rather than by class.
+    if dev.vendor_id == id::VID_SILABS && find_cp210x(config, 0).is_some() {
+        return Kind::Cp210x;
+    }
+    if find_gip(config).is_some() {
+        return Kind::Gip;
+    }
+    if let Ok(cfg) = ConfigurationDescriptorChain::try_from_slice(config) {
+        if AudioInterfaceCollection::try_from_configuration(&cfg).is_ok() {
+            return Kind::Audio;
+        }
+    }
+
+    // A composite device declares class 0 at the device level and puts the real class on
+    // each interface, so the first interface's class is the one worth showing.
+    let class = ConfigurationDescriptorChain::try_from_slice(config)
+        .ok()
+        .and_then(|cfg| cfg.iter_interface().next().map(|iface| iface.interface_class))
+        .unwrap_or(dev.device_class);
+
+    Kind::Unknown { class }
+}
+
+/// Print every child of `parent`, then each of their children, indented by depth.
+fn print_children(nodes: &[Node], parent: Option<u8>, depth: usize) {
+    const INDENT: &str = "                                ";
+
+    for (i, node) in nodes.iter().enumerate() {
+        if node.parent != parent {
+            continue;
+        }
+
+        let pad = &INDENT[..(depth * 2).min(INDENT.len())];
+        let desc = &node.info.device_desc;
+        if node.parent.is_none() {
+            info!(
+                "{}root port: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        } else {
+            info!(
+                "{}port {}: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                node.port,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        }
+
+        print_children(nodes, Some(i as u8), depth + 1);
+    }
+}
+
+/// [`Speed`] prints as its enum name; this shortens it for the tree.
+struct Sp(Speed);
+
+impl Format for Sp {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            Speed::Low => defmt::write!(f, "LS"),
+            Speed::Full => defmt::write!(f, "FS"),
+            Speed::High => defmt::write!(f, "HS"),
+        }
+    }
+}
+
+async fn idle() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(1)).await;
+    }
+}


### PR DESCRIPTION
Part 2/5 of rp usb-host. Parts 3-5 coming soon.

Fix cancellation of transfers that tore down interrupt pipes and lost packets, removing race on write to usb controller. Improve wakes on IRQ that only signalled 1st pending then exited.

Minor cleanups and fixme's sorted, reset was clearing bits that should persist, etc.

Added two examples, rp + rp235x, that reset bus then enumerate all hubs and devices, printing the device tree.

Tested on tree with two hubs +  7 devices.

Researched, done and tested with assistance from Claude and Codex.