### PR TITLE
fix(rp-usb-host): Individual buffers and wakers for EPX pipes

### DIFF
--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -55,6 +55,9 @@ pub struct HostState {
     allocated_pipes: AtomicU16,
     /// Bitset of allocated EPX pipes, indexed by `Channel::index - EP_COUNT`.
     allocated_epx: AtomicU16,
+    /// One waiter per EPX pipe. Completion is routed to the pipe that owns EPX,
+    /// while releasing it wakes every contender.
+    epx_wakers: [AtomicWaker; EPX_MAX_PIPES],
     /// Bitmap of used EPX buffer blocks, one bit per [`EPX_BLOCK_SIZE`] block.
     used_blocks: critical_section::Mutex<Cell<u64>>,
 }
@@ -66,6 +69,7 @@ impl HostState {
             current_channel: AtomicUsize::new(0),
             allocated_pipes: AtomicU16::new(0),
             allocated_epx: AtomicU16::new(0),
+            epx_wakers: [const { AtomicWaker::new() }; EPX_MAX_PIPES],
             used_blocks: critical_section::Mutex::new(Cell::new(0)),
         }
     }
@@ -75,6 +79,29 @@ impl HostState {
         self.allocated_pipes.store(0, Ordering::Relaxed);
         self.allocated_epx.store(0, Ordering::Relaxed);
         critical_section::with(|cs| self.used_blocks.borrow(cs).set(0));
+    }
+
+    /// Slot of an EPX pipe in [`HostState::epx_wakers`], or `None` for the idle
+    /// sentinel and for interrupt pipes.
+    fn epx_slot(index: usize) -> Option<usize> {
+        index.checked_sub(EP_COUNT).filter(|slot| *slot < EPX_MAX_PIPES)
+    }
+
+    /// Wake the pipe currently holding EPX.
+    fn wake_current_epx(&self) {
+        if let Some(slot) = Self::epx_slot(self.current_channel.load(Ordering::Acquire)) {
+            self.epx_wakers[slot].wake();
+        }
+    }
+
+    /// Wake every allocated EPX pipe, so whoever is queued can claim EPX.
+    fn wake_all_epx(&self) {
+        let allocated = self.allocated_epx.load(Ordering::Acquire);
+        for slot in 0..EPX_MAX_PIPES {
+            if allocated & (1 << slot) != 0 {
+                self.epx_wakers[slot].wake();
+            }
+        }
     }
 }
 
@@ -264,7 +291,8 @@ impl<T: SealedHostInstance> Drop for TransactionGuard<T> {
                 });
                 regs.buff_status().write_clear(|w| w.0 = 0b11);
             }
-            self.state.current_channel.store(0, Ordering::Relaxed);
+            self.state.current_channel.store(0, Ordering::Release);
+            self.state.wake_all_epx();
 
             self.ep_control.modify(|w| {
                 w.set_interrupt_per_buff(false);
@@ -281,7 +309,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
         if Self::is_interrupt_in() {
             &EP_IN_WAKERS[self.index]
         } else {
-            &EP_IN_WAKERS[0]
+            &T::host_state().epx_wakers[self.index - EP_COUNT]
         }
     }
 
@@ -369,9 +397,6 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
     }
 
     async fn wait_ready_for_transaction(&self) {
-        // Wait transfer buffer to be free
-        self.wait_available().await;
-
         trace!("CHANNEL {} WAIT READY", self.index);
         // Wait for other transaction end
         poll_fn(|cx| {
@@ -385,6 +410,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             Poll::Ready(())
         })
         .await;
+
+        // Once this pipe owns EPX, wait for its transfer buffer to be free.
+        self.wait_available().await;
     }
 
     // FIXME: RX Timeout with LS device on hub
@@ -1103,7 +1131,7 @@ pub struct InterruptHandler<T: Instance> {
     _usb: PhantomData<T>,
 }
 
-impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
+impl<T: SealedHostInstance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let regs = T::regs();
         let ints = regs.ints().read();
@@ -1130,30 +1158,29 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
                 "data sequence error"
             } else if ints.stall() {
                 regs.inte().write_clear(|w| w.set_stall(true));
-                EP_IN_WAKERS[0].wake();
+                T::host_state().wake_current_epx();
                 "stall"
             } else if ints.error_rx_overflow() {
                 regs.inte().write_clear(|w| w.set_error_rx_overflow(true));
-                EP_IN_WAKERS[0].wake();
+                T::host_state().wake_current_epx();
                 "rx overflow"
             } else if ints.trans_complete() {
                 regs.inte().write_clear(|w| w.set_trans_complete(true));
-                EP_IN_WAKERS[0].wake();
+                T::host_state().wake_current_epx();
                 "transaction complete"
             } else if ints.error_rx_timeout() {
                 regs.inte().write_clear(|w| w.set_error_rx_timeout(true));
-                EP_IN_WAKERS[0].wake();
+                T::host_state().wake_current_epx();
                 "rx timeout"
             } else if ints.buff_status() {
                 let status = regs.buff_status().read().0;
-
                 // Bits 0 and 1 are EPX's IN/OUT pair; from bit 2 up they are the
                 // dedicated interrupt endpoints, two bits per endpoint. Only interrupt IN
                 // gets a dedicated endpoint, so of each pair only the IN bit is ever armed.
                 if status & 0b11 != 0 {
                     regs.buff_status().write_clear(|w| w.0 = status & 0b11);
                     trace!("USB IRQ: EPx");
-                    EP_IN_WAKERS[0].wake();
+                    T::host_state().wake_current_epx();
                 }
 
                 for n in 1..EP_COUNT {

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -18,7 +18,7 @@ fn split_to_pre(split: Option<SplitInfo>) -> bool {
 }
 use rp_pac::usb_dpram::vals::EpControlEndpointType;
 
-use super::{BUS_WAKER, DPRAM_DATA_OFFSET, EP_IN_WAKERS, EP_MEMORY, EndpointBuffer, Instance};
+use super::{BUS_WAKER, DPRAM_DATA_OFFSET, EP_COUNT, EP_IN_WAKERS, EP_MEMORY, EndpointBuffer, Instance};
 use crate::interrupt::typelevel::{Binding, Interrupt};
 use crate::interrupt::{self};
 use crate::peripherals::USB;
@@ -1039,23 +1039,21 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
                 "rx timeout"
             } else if ints.buff_status() {
                 let status = regs.buff_status().read().0;
-                for i in 0..32 {
-                    // ith bit set
-                    if (status >> i) & 1 == 1 {
-                        regs.buff_status().write_clear(|w| w.0 = 1 << i);
-                        // control transfers (buffer 0)
-                        if i != 0 {
-                            let idx = i / 2;
-                            // T::regs().int_ep_ctrl().modify(|w| {
-                            //     w.set_int_ep_active(w.int_ep_active() | 1 << idx);
-                            // });
-                            trace!("USB IRQ: Interrupt EP {}", idx);
-                            EP_IN_WAKERS[idx].wake();
-                        } else {
-                            trace!("USB IRQ: EPx");
-                            EP_IN_WAKERS[0].wake();
-                        }
-                        break;
+
+                // Bits 0 and 1 are EPX's IN/OUT pair; from bit 2 up they are the
+                // dedicated interrupt endpoints, two bits per endpoint. Only interrupt IN
+                // gets a dedicated endpoint, so of each pair only the IN bit is ever armed.
+                if status & 0b11 != 0 {
+                    regs.buff_status().write_clear(|w| w.0 = status & 0b11);
+                    trace!("USB IRQ: EPx");
+                    EP_IN_WAKERS[0].wake();
+                }
+
+                for n in 1..EP_COUNT {
+                    if status & (1 << (n * 2)) != 0 {
+                        regs.buff_status().write_clear(|w| w.0 = 0b11 << (n * 2));
+                        trace!("USB IRQ: Interrupt EP {}", n);
+                        EP_IN_WAKERS[n].wake();
                     }
                 }
                 "^^^"

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -32,6 +32,7 @@ const ROOT_RESET_MS: u64 = 50;
 const RESET_RECOVERY_MS: u64 = 10;
 /// Register writes need two clk_usb cycles to transfer; 12 clk_sys cycles cover this at the supported 150 MHz maximum.
 const USB_CLOCK_DELAY_CYCLES: u32 = 12;
+const SIE_START_DELAY_CYCLES: u32 = 12;
 
 /// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
 pub struct HostState {
@@ -384,9 +385,8 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             w.set_error_rx_overflow(true);
         });
 
-        // Start transaction
-        // This field should be modified separately after delay
-        cortex_m::asm::delay(12);
+        // START_TRANS is synchronized separately (RP2040 §4.1.2.9, RP2350 §12.7.3.9).
+        cortex_m::asm::delay(SIE_START_DELAY_CYCLES);
         T::regs().sie_ctrl().modify(|w| {
             w.set_start_trans(true);
         });
@@ -541,8 +541,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
         //     w.set_pulldown_en(true);
         // });
 
-        // FIXME: delay reason
-        cortex_m::asm::delay(12);
+        cortex_m::asm::delay(USB_CLOCK_DELAY_CYCLES);
         T::regs().int_ep_ctrl().modify(|w| {
             w.set_int_ep_active(w.int_ep_active() | 1 << (self.index - 1));
         });

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -1,3 +1,4 @@
+use core::cell::Cell;
 use core::future::poll_fn;
 use core::marker::PhantomData;
 use core::sync::atomic::{AtomicU16, AtomicUsize, Ordering};
@@ -25,7 +26,6 @@ use crate::peripherals::USB;
 use crate::usb::EP_MEMORY_SIZE;
 use crate::{Peri, RegExt};
 
-const MAIN_BUFFER_SIZE: usize = 1024;
 /// Root port reset drive time (USB 2.0 §7.1.7.5, TDRSTR).
 const ROOT_RESET_MS: u64 = 50;
 /// Reset recovery time (USB 2.0 §7.1.7.5, TRSTRCY).
@@ -34,6 +34,16 @@ const RESET_RECOVERY_MS: u64 = 10;
 const USB_CLOCK_DELAY_CYCLES: u32 = 12;
 const SIE_START_DELAY_CYCLES: u32 = 12;
 
+// DPRAM layout - `EP_COUNT` blocks for control and interrupts, then remaining blocks
+// allocatable to EPX pipes.
+const EPX_BLOCK_SIZE: usize = 64;
+
+/// First EPX buffer after the control and interrupt buffers.
+const EPX_BUFFER_OFFSET: u16 = DPRAM_DATA_OFFSET + ((EP_COUNT - 1) * EPX_BLOCK_SIZE) as u16;
+
+/// Number of allocatable EPX blocks.
+const EPX_NUM_BLOCKS: usize = (EP_MEMORY_SIZE - EPX_BUFFER_OFFSET as usize) / EPX_BLOCK_SIZE;
+
 /// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
 pub struct HostState {
     /// Current channel with ongoing non-interrupt transfer. `0` means None.
@@ -41,8 +51,10 @@ pub struct HostState {
     /// Bitset of allocated interrupt pipes.
     allocated_pipes: AtomicU16,
     /// Next 'allocated' non-interrupt channel index. Indexes 1-15 are reserved for
-    /// interrupt endpoints, so allocation starts at 16.
+    /// interrupt endpoints, so allocation starts at [`EP_COUNT`].
     channel_index: AtomicUsize,
+    /// Bitmap of used EPX buffer blocks, one bit per [`EPX_BLOCK_SIZE`] block.
+    used_blocks: critical_section::Mutex<Cell<u64>>,
 }
 
 impl HostState {
@@ -51,14 +63,16 @@ impl HostState {
         Self {
             current_channel: AtomicUsize::new(0),
             allocated_pipes: AtomicU16::new(0),
-            channel_index: AtomicUsize::new(16),
+            channel_index: AtomicUsize::new(EP_COUNT),
+            used_blocks: critical_section::Mutex::new(Cell::new(0)),
         }
     }
 
     fn reset(&self) {
         self.current_channel.store(0, Ordering::Relaxed);
         self.allocated_pipes.store(0, Ordering::Relaxed);
-        self.channel_index.store(16, Ordering::Relaxed);
+        self.channel_index.store(EP_COUNT, Ordering::Relaxed);
+        critical_section::with(|cs| self.used_blocks.borrow(cs).set(0));
     }
 }
 
@@ -179,9 +193,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
         assert!(!(E::ep_type() == EndpointType::Interrupt && D::is_out()));
 
         if ep_info.ep_type == EndpointType::Interrupt {
-            assert!(index > 0 && index < 16);
+            assert!(index > 0 && index < EP_COUNT);
         } else {
-            assert!(index >= 16);
+            assert!(index >= EP_COUNT);
         }
 
         Self {
@@ -852,7 +866,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
 
 impl<'d, T: SealedHostInstance, E, D> Drop for Channel<'d, T, E, D> {
     fn drop(&mut self) {
-        if self.index < 16 {
+        if self.index < EP_COUNT {
             // Disarm and clear stale state so the interrupt slot can be reused safely.
             let regs = T::regs();
             let dpram = T::dpram();
@@ -869,6 +883,9 @@ impl<'d, T: SealedHostInstance, E, D> Drop for Channel<'d, T, E, D> {
                 let pipes = &state.allocated_pipes;
                 pipes.store(pipes.load(Ordering::Relaxed) & !(1 << self.index), Ordering::Relaxed);
             });
+        } else {
+            // Return the EPX buffer to the pool.
+            free_epx_mem(T::host_state(), self.buf.addr, self.buf.len);
         }
     }
 }
@@ -886,6 +903,50 @@ impl<'d, T: Instance> Clone for Allocator<'d, T> {
 
 impl<'d, T: Instance> Copy for Allocator<'d, T> {}
 
+/// Number of [`EPX_BLOCK_SIZE`] blocks needed to hold `len` bytes.
+fn blocks_for(len: u16) -> usize {
+    (len as usize).div_ceil(EPX_BLOCK_SIZE)
+}
+
+/// `used_blocks` mask for a run of `blocks` blocks starting at `start`.
+fn block_mask(start: usize, blocks: usize) -> u64 {
+    ((1u64 << blocks) - 1) << start
+}
+
+/// Allocate `len` bytes of EPX buffer memory, returning its [`EP_MEMORY`]-relative byte address.
+/// First-fit over contiguous free blocks.
+fn alloc_epx_mem(state: &HostState, len: u16) -> Result<u16, ()> {
+    let blocks = blocks_for(len);
+    if blocks == 0 || blocks > EPX_NUM_BLOCKS {
+        error!("EPX buffer request of {} bytes is too large", len);
+        return Err(());
+    }
+    critical_section::with(|cs| {
+        let used_blocks = state.used_blocks.borrow(cs);
+        let used = used_blocks.get();
+        for start in 0..=(EPX_NUM_BLOCKS - blocks) {
+            let mask = block_mask(start, blocks);
+            if used & mask == 0 {
+                used_blocks.set(used | mask);
+                return Ok(EPX_BUFFER_OFFSET + (start * EPX_BLOCK_SIZE) as u16);
+            }
+        }
+        error!("EPX buffer memory full");
+        Err(())
+    })
+}
+
+/// Free EPX buffer memory previously returned by [`alloc_epx_mem`].
+fn free_epx_mem(state: &HostState, addr: u16, len: u16) {
+    let blocks = blocks_for(len);
+    let start = (addr - EPX_BUFFER_OFFSET) as usize / EPX_BLOCK_SIZE;
+    let mask = block_mask(start, blocks);
+    critical_section::with(|cs| {
+        let used_blocks = state.used_blocks.borrow(cs);
+        used_blocks.set(used_blocks.get() & !mask);
+    });
+}
+
 impl<'d, T: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, T> {
     type Pipe<E: pipe::Type, D: pipe::Direction> = Channel<'d, T, E, D>;
 
@@ -900,15 +961,15 @@ impl<'d, T: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, T> {
         if E::ep_type() == EndpointType::Interrupt {
             let free_index = critical_section::with(|_| {
                 let alloc = state.allocated_pipes.load(Ordering::Relaxed);
-                if let Some(idx) = (1..16).find(|i| alloc & (1 << i) == 0) {
+                if let Some(idx) = (1..EP_COUNT).find(|i| alloc & (1 << i) == 0) {
                     state.allocated_pipes.store(alloc | (1 << idx), Ordering::Relaxed);
                     Ok(idx as u8)
                 } else {
                     Err(HostError::OutOfPipes)
                 }
             })?;
-            // Use fixed layout
-            let addr = DPRAM_DATA_OFFSET + MAIN_BUFFER_SIZE as u16 + free_index as u16 * 64;
+            // Fixed layout: pipe index 1..EP_COUNT maps to block 0..EP_COUNT-1.
+            let addr = DPRAM_DATA_OFFSET + (free_index as u16 - 1) * EPX_BLOCK_SIZE as u16;
 
             Ok(Channel::new(free_index as _, addr, 64, endpoint, dev_addr, pre))
         } else {
@@ -917,14 +978,12 @@ impl<'d, T: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, T> {
                 state.channel_index.store(old + 1, Ordering::Relaxed);
                 old
             });
-            Ok(Channel::new(
-                index,
-                DPRAM_DATA_OFFSET,
-                MAIN_BUFFER_SIZE as u16,
-                endpoint,
-                dev_addr,
-                pre,
-            ))
+            // One buffer per pipe: a parked transfer's data must survive another pipe
+            // taking EPX in the meantime.
+            let len = (blocks_for(endpoint.max_packet_size) * EPX_BLOCK_SIZE) as u16;
+            let addr = alloc_epx_mem(state, len).map_err(|()| HostError::InsufficientMemory)?;
+
+            Ok(Channel::new(index, addr, len, endpoint, dev_addr, pre))
         }
     }
 }

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -26,6 +26,10 @@ use crate::usb::EP_MEMORY_SIZE;
 use crate::{Peri, RegExt};
 
 const MAIN_BUFFER_SIZE: usize = 1024;
+/// Root port reset drive time (USB 2.0 §7.1.7.5, TDRSTR).
+const ROOT_RESET_MS: u64 = 50;
+/// Reset recovery time (USB 2.0 §7.1.7.5, TRSTRCY).
+const RESET_RECOVERY_MS: u64 = 10;
 /// Register writes need two clk_usb cycles to transfer; 12 clk_sys cycles cover this at the supported 150 MHz maximum.
 const USB_CLOCK_DELAY_CYCLES: u32 = 12;
 
@@ -81,17 +85,17 @@ impl<'d, T: SealedHostInstance> Driver<'d, T> {
     /// Create a new USB driver.
     pub fn new(_usb: Peri<'d, USB>, _irq: impl Binding<T::Interrupt, InterruptHandler<T>>) -> Self {
         let regs = T::regs();
-        unsafe {
-            // FIXME(magic):
-            // zero fill regs
-            let p = regs.as_ptr() as *mut u32;
-            for i in 0..0x9c / 4 {
-                p.add(i).write_volatile(0)
-            }
 
-            // zero fill epmem
+        // Reset the peripheral: zeroing its registers by hand would clobber those that
+        // do not reset to zero, notably `USBPHY_TRIM` and `NAK_POLL`.
+        crate::pac::RESETS.reset().modify(|w| w.set_usbctrl(true));
+        crate::pac::RESETS.reset().modify(|w| w.set_usbctrl(false));
+        while !crate::pac::RESETS.reset_done().read().usbctrl() {}
+
+        // DPRAM is outside the peripheral reset, so clear the control area by hand.
+        unsafe {
             let p = EP_MEMORY as *mut u32;
-            for i in 0..0x180 / 4 {
+            for i in 0..DPRAM_DATA_OFFSET as usize / 4 {
                 p.add(i).write_volatile(0)
             }
         }
@@ -107,6 +111,9 @@ impl<'d, T: SealedHostInstance> Driver<'d, T> {
         regs.main_ctrl().modify(|w| {
             w.set_controller_en(true);
             w.set_host_ndevice(true);
+            // RP2350 resets PHY isolation asserted; the PHY is unusable until cleared (§12.7.2).
+            #[cfg(feature = "_rp235x")]
+            w.set_phy_iso(false);
         });
         regs.sie_ctrl().modify(|w| {
             w.set_sof_en(true);
@@ -975,11 +982,13 @@ impl<'d, T: SealedHostInstance> UsbHostController<'d> for Driver<'d, T> {
             w.set_reset_bus(true);
         });
 
-        embassy_time::Timer::after_millis(50).await;
+        embassy_time::Timer::after_millis(ROOT_RESET_MS).await;
 
         T::regs().sie_ctrl().modify(|w| {
             w.set_reset_bus(false);
         });
+
+        embassy_time::Timer::after_millis(RESET_RECOVERY_MS).await;
     }
 }
 

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -669,51 +669,62 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
         }
     }
 
+    /// Claim EPX and run one transaction on it. `arm` programs the buffer once this
+    /// pipe owns the endpoint.
+    async fn run_transaction(&mut self, arm: impl FnOnce(&mut Self)) -> Result<(), PipeError> {
+        self.wait_ready_for_transaction().await;
+        self.set_current();
+        let mut guard = self.transaction_guard();
+
+        arm(self);
+        guard.arm();
+        let result = self.wait_transaction().await;
+        guard.disarm();
+
+        result
+    }
+
+    /// Receive one packet, returning its length.
+    async fn transfer_in_packet(&mut self, len: u16, pid: bool) -> Result<usize, PipeError> {
+        self.run_transaction(|s| s.set_data_in(len, pid)).await?;
+
+        Ok(self.buffer_control().read().length(0) as usize)
+    }
+
+    /// Send one packet, returning how much of `data` it carried.
+    async fn transfer_out_packet(&mut self, data: &[u8], pid: bool) -> Result<usize, PipeError> {
+        let mut len = 0;
+        self.run_transaction(|s| len = s.set_data_out(data, pid)).await?;
+
+        Ok(len)
+    }
+
     /// Send SETUP packet
     ///
     /// WARNING: This flips PID
     async fn send_setup(&mut self, setup: &[u8; 8]) -> Result<(), PipeError> {
-        // Wait transfer buffer to be free
-        self.wait_ready_for_transaction().await;
-
-        // Set this channel for transaction
-        self.set_current();
-        let _guard = self.transaction_guard();
-
         trace!("SEND SETUP");
-        // Prepare HW
-        self.set_setup_packet(setup);
+        self.run_transaction(|s| s.set_setup_packet(setup)).await?;
+        self.pid = true;
 
-        // Wait for SETUP end
-        let res = self.wait_transaction().await;
-        if res.is_ok() {
-            self.pid = true;
-        }
-        res
+        Ok(())
     }
 
     /// Send status packet
     async fn control_status(&mut self, active_direction_out: bool) -> Result<(), PipeError> {
-        // Wait transfer buffer to be free
-        self.wait_ready_for_transaction().await;
-
-        // Set this channel for transaction
-        self.set_current();
-        let _guard = self.transaction_guard();
-
         // Status packet always have DATA1
         trace!("SEND STATUS");
-        if active_direction_out {
-            self.set_data_in(0, true);
-        } else {
-            self.set_data_out(&[], true);
-        }
+        self.run_transaction(|s| {
+            if active_direction_out {
+                s.set_data_in(0, true);
+            } else {
+                s.set_data_out(&[], true);
+            }
+        })
+        .await?;
+        self.pid = false;
 
-        let res = self.wait_transaction().await;
-        if res.is_ok() {
-            self.pid = false;
-        }
-        res
+        Ok(())
     }
 }
 
@@ -776,17 +787,19 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
     where
         D: pipe::IsIn,
     {
-        // Wait transfer buffer to be free
-        self.wait_ready_for_transaction().await;
-
-        // Set this channel for transaction
-        self.set_current();
-        let mut guard = self.transaction_guard();
+        // An interrupt pipe owns its endpoint for the whole read.
+        let _interrupt_guard = if Self::is_interrupt_in() {
+            self.wait_ready_for_transaction().await;
+            self.set_current();
+            Some(self.transaction_guard())
+        } else {
+            None
+        };
 
         let mut count: usize = 0;
 
         let res = loop {
-            if Self::is_interrupt_in() {
+            let rx_len = if Self::is_interrupt_in() {
                 // Consume completed packet that may have arrived after last poll.
                 // Reloading would discard the packet that hardware already ACKed.
                 if !self.buffer_control().read().full(0) {
@@ -794,21 +807,17 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
                     self.interrupt_reload();
                     self.wait_available().await;
                 }
+                self.buffer_control().read().length(0) as usize
             } else {
                 trace!("CHANNEL {} START READ, len = {}", self.index, buf.len());
                 let packet_len = core::cmp::min(buf.len() - count, self.max_packet_size as usize);
-                self.set_data_in(packet_len as u16, self.pid);
-                guard.arm();
-                let result = self.wait_transaction().await;
-                guard.disarm();
-                if let Err(e) = result {
-                    break Err(e);
-                }
+                let rx_len = self.transfer_in_packet(packet_len as u16, self.pid).await?;
                 self.advance_pid();
-            }
+
+                rx_len
+            };
 
             let free = &mut buf[count..];
-            let rx_len = self.buffer_control().read().length(0) as usize;
             trace!("CHANNEL {} READ DONE, rx_len = {}", self.index, rx_len);
 
             if rx_len > free.len() {
@@ -838,27 +847,11 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
     where
         D: pipe::IsOut,
     {
-        // Wait transfer buffer to be free
-        self.wait_ready_for_transaction().await;
-
-        let _regs = T::regs();
-
-        // Set this channel for transaction
-        self.set_current();
-        let mut guard = self.transaction_guard();
-
         let mut count = 0;
 
         let res = loop {
             trace!("CHANNEL {} START WRITE", self.index);
-            let packet = self.set_data_out(&buf[count..], self.pid);
-
-            guard.arm();
-            let result = self.wait_transaction().await;
-            guard.disarm();
-            if let Err(e) = result {
-                break Err(e);
-            }
+            let packet = self.transfer_out_packet(&buf[count..], self.pid).await?;
             self.advance_pid();
 
             trace!("WRITE DONE, tx_len = {}", packet);
@@ -868,13 +861,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
             if count == buf.len() {
                 if packet == self.max_packet_size as usize && ensure_transaction_end {
                     trace!("CHANNEL {} START ZLP WRITE", self.index);
-                    self.set_data_out(&[], self.pid);
-                    guard.arm();
-                    let result = self.wait_transaction().await;
-                    guard.disarm();
-                    if let Err(e) = result {
-                        break Err(e);
-                    }
+                    self.transfer_out_packet(&[], self.pid).await?;
                     self.advance_pid();
                     trace!("ZLP WRITE DONE");
                 }

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -26,6 +26,8 @@ use crate::usb::EP_MEMORY_SIZE;
 use crate::{Peri, RegExt};
 
 const MAIN_BUFFER_SIZE: usize = 1024;
+/// Register writes need two clk_usb cycles to transfer; 12 clk_sys cycles cover this at the supported 150 MHz maximum.
+const USB_CLOCK_DELAY_CYCLES: u32 = 12;
 
 /// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
 pub struct HostState {
@@ -219,23 +221,26 @@ impl<T: SealedHostInstance> TransactionGuard<T> {
 
 impl<T: SealedHostInstance> Drop for TransactionGuard<T> {
     fn drop(&mut self) {
+        // Dedicated interrupt endpoints belong to the pipe
+        if self.interrupt {
+            return;
+        }
+
         let selected = self.state.current_channel.load(Ordering::Relaxed);
-        if self.interrupt || selected == self.index || selected == 0 {
-            if !self.interrupt {
-                if self.transaction_active && self.abort_on_drop {
-                    let regs = T::regs();
-                    regs.sie_ctrl().modify(|w| w.set_stop_trans(true));
-                    while regs.sie_ctrl().read().stop_trans() {}
-                    regs.sie_status().write_clear(|w| {
-                        w.set_trans_complete(true);
-                        w.set_stall_rec(true);
-                        w.set_rx_timeout(true);
-                        w.set_rx_overflow(true);
-                    });
-                    regs.buff_status().write_clear(|w| w.0 = 0b11);
-                }
-                self.state.current_channel.store(0, Ordering::Relaxed);
+        if selected == self.index || selected == 0 {
+            if self.transaction_active && self.abort_on_drop {
+                let regs = T::regs();
+                regs.sie_ctrl().modify(|w| w.set_stop_trans(true));
+                while regs.sie_ctrl().read().stop_trans() {}
+                regs.sie_status().write_clear(|w| {
+                    w.set_trans_complete(true);
+                    w.set_stall_rec(true);
+                    w.set_rx_timeout(true);
+                    w.set_rx_overflow(true);
+                });
+                regs.buff_status().write_clear(|w| w.0 = 0b11);
             }
+            self.state.current_channel.store(0, Ordering::Relaxed);
 
             self.ep_control.modify(|w| {
                 w.set_interrupt_per_buff(false);
@@ -265,6 +270,24 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             0
         };
         T::dpram().ep_in_buffer_control(index)
+    }
+
+    /// Give the buffer to the USB controller only after the rest of its
+    /// control fields have crossed into the USB clock domain.
+    fn write_buffer_control(&self, f: impl FnOnce(&mut rp_pac::usb_dpram::regs::EpBufferControl)) {
+        let reg = self.buffer_control();
+        let mut value = Default::default();
+        f(&mut value);
+
+        let available = value.available(0);
+        value.set_available(0, false);
+        reg.write_value(value);
+
+        if available {
+            cortex_m::asm::delay(USB_CLOCK_DELAY_CYCLES);
+            value.set_available(0, true);
+            reg.write_value(value);
+        }
     }
 
     /// Get endpoint control register
@@ -495,8 +518,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
     /// Reload interrupt channel buffer register
     fn interrupt_reload(&mut self) {
         assert!(E::ep_type() == EndpointType::Interrupt);
-        let ctrl = self.buffer_control();
-        ctrl.write(|w| {
+        self.write_buffer_control(|w| {
             w.set_last(0, true);
             w.set_pid(0, self.pid);
             w.set_full(0, false);
@@ -529,7 +551,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
             pid
         };
 
-        self.buffer_control().write(|w| {
+        self.write_buffer_control(|w| {
             w.set_pid(0, pid);
             w.set_full(0, false);
             w.set_length(0, len);
@@ -563,7 +585,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
 
         self.buf.write(&chunk);
 
-        self.buffer_control().write(|w| {
+        self.write_buffer_control(|w| {
             w.set_available(0, true);
             w.set_pid(0, pid);
             w.set_full(0, true);
@@ -708,10 +730,13 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
 
         let res = loop {
             if Self::is_interrupt_in() {
-                trace!("CHANNEL {} WAIT FOR INTERRUPT", self.index);
-                self.interrupt_reload();
-                self.wait_available().await;
-                self.advance_pid();
+                // Consume completed packet that may have arrived after last poll.
+                // Reloading would discard the packet that hardware already ACKed.
+                if !self.buffer_control().read().full(0) {
+                    trace!("CHANNEL {} WAIT FOR INTERRUPT", self.index);
+                    self.interrupt_reload();
+                    self.wait_available().await;
+                }
             } else {
                 trace!("CHANNEL {} START READ, len = {}", self.index, buf.len());
                 let packet_len = core::cmp::min(buf.len() - count, self.max_packet_size as usize);
@@ -735,6 +760,12 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
 
             self.buf.read(&mut free[..rx_len]);
             count += rx_len;
+
+            if Self::is_interrupt_in() {
+                self.advance_pid();
+                self.interrupt_reload();
+                break Ok(count);
+            }
 
             // If transfer is smaller than max_packet_size, we are done
             // If we have read buf.len() bytes, we are done

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -439,8 +439,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
                 w.set_endpoint_type(EpControlEndpointType::Interrupt);
                 w.set_interrupt_per_buff(true);
 
-                // FIXME: host_poll_interval (bits 16:25)
-                let interval = self.interval as u32 - 1;
+                // `host_poll_interval` (bits 16:25) has no PAC accessor and counts from
+                // zero, so clamp: a descriptor may declare an interval of 0.
+                let interval = self.interval.max(1) as u32 - 1;
                 w.0 |= interval << 16;
 
                 w.set_buffer_address(self.buf.addr);
@@ -680,6 +681,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
     {
         trace!("CONTROL IN: {:?}", setup);
         let length = u16::from_le_bytes([setup[6], setup[7]]) as usize;
+        if length > buf.len() {
+            return Err(PipeError::BufferOverflow);
+        }
 
         // Setup stage
         // TODO: Whole transaction error handling?
@@ -705,6 +709,9 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> UsbPipe<E, D>
     {
         trace!("CONTROL OUT: {:?}", setup);
         let length = u16::from_le_bytes([setup[6], setup[7]]) as usize;
+        if length > buf.len() {
+            return Err(PipeError::BufferOverflow);
+        }
 
         // Setup stage
         // TODO: Whole transaction error handling?

--- a/embassy-rp/src/usb/host.rs
+++ b/embassy-rp/src/usb/host.rs
@@ -44,15 +44,17 @@ const EPX_BUFFER_OFFSET: u16 = DPRAM_DATA_OFFSET + ((EP_COUNT - 1) * EPX_BLOCK_S
 /// Number of allocatable EPX blocks.
 const EPX_NUM_BLOCKS: usize = (EP_MEMORY_SIZE - EPX_BUFFER_OFFSET as usize) / EPX_BLOCK_SIZE;
 
+/// Maximum number of concurrently allocated EPX pipes.
+const EPX_MAX_PIPES: usize = 16;
+
 /// Per-instance state shared between [`Driver`], [`Allocator`] and [`Channel`].
 pub struct HostState {
     /// Current channel with ongoing non-interrupt transfer. `0` means None.
     current_channel: AtomicUsize,
     /// Bitset of allocated interrupt pipes.
     allocated_pipes: AtomicU16,
-    /// Next 'allocated' non-interrupt channel index. Indexes 1-15 are reserved for
-    /// interrupt endpoints, so allocation starts at [`EP_COUNT`].
-    channel_index: AtomicUsize,
+    /// Bitset of allocated EPX pipes, indexed by `Channel::index - EP_COUNT`.
+    allocated_epx: AtomicU16,
     /// Bitmap of used EPX buffer blocks, one bit per [`EPX_BLOCK_SIZE`] block.
     used_blocks: critical_section::Mutex<Cell<u64>>,
 }
@@ -63,7 +65,7 @@ impl HostState {
         Self {
             current_channel: AtomicUsize::new(0),
             allocated_pipes: AtomicU16::new(0),
-            channel_index: AtomicUsize::new(EP_COUNT),
+            allocated_epx: AtomicU16::new(0),
             used_blocks: critical_section::Mutex::new(Cell::new(0)),
         }
     }
@@ -71,7 +73,7 @@ impl HostState {
     fn reset(&self) {
         self.current_channel.store(0, Ordering::Relaxed);
         self.allocated_pipes.store(0, Ordering::Relaxed);
-        self.channel_index.store(EP_COUNT, Ordering::Relaxed);
+        self.allocated_epx.store(0, Ordering::Relaxed);
         critical_section::with(|cs| self.used_blocks.borrow(cs).set(0));
     }
 }
@@ -195,7 +197,7 @@ impl<'d, T: SealedHostInstance, E: pipe::Type, D: pipe::Direction> Channel<'d, T
         if ep_info.ep_type == EndpointType::Interrupt {
             assert!(index > 0 && index < EP_COUNT);
         } else {
-            assert!(index >= EP_COUNT);
+            assert!(index >= EP_COUNT && index < EP_COUNT + EPX_MAX_PIPES);
         }
 
         Self {
@@ -884,8 +886,21 @@ impl<'d, T: SealedHostInstance, E, D> Drop for Channel<'d, T, E, D> {
                 pipes.store(pipes.load(Ordering::Relaxed) & !(1 << self.index), Ordering::Relaxed);
             });
         } else {
-            // Return the EPX buffer to the pool.
-            free_epx_mem(T::host_state(), self.buf.addr, self.buf.len);
+            let state = T::host_state();
+            // Return the EPX buffer and the pipe slot to the pool.
+            free_epx_mem(state, self.buf.addr, self.buf.len);
+            critical_section::with(|_| {
+                let epx = &state.allocated_epx;
+                epx.store(
+                    epx.load(Ordering::Relaxed) & !(1 << (self.index - EP_COUNT)),
+                    Ordering::Relaxed,
+                );
+            });
+            debug!(
+                "EPX pipe FREE  slot {} (bitset {:04x})",
+                self.index - EP_COUNT,
+                state.allocated_epx.load(Ordering::Relaxed)
+            );
         }
     }
 }
@@ -974,14 +989,40 @@ impl<'d, T: SealedHostInstance> UsbHostAllocator<'d> for Allocator<'d, T> {
             Ok(Channel::new(free_index as _, addr, 64, endpoint, dev_addr, pre))
         } else {
             let index = critical_section::with(|_| {
-                let old = state.channel_index.load(Ordering::Relaxed);
-                state.channel_index.store(old + 1, Ordering::Relaxed);
-                old
-            });
+                let alloc = state.allocated_epx.load(Ordering::Relaxed);
+                let slot = alloc.trailing_ones() as usize;
+                if slot >= EPX_MAX_PIPES {
+                    return Err(HostError::OutOfPipes);
+                }
+                state.allocated_epx.store(alloc | (1 << slot), Ordering::Relaxed);
+                Ok(EP_COUNT + slot)
+            })?;
             // One buffer per pipe: a parked transfer's data must survive another pipe
             // taking EPX in the meantime.
             let len = (blocks_for(endpoint.max_packet_size) * EPX_BLOCK_SIZE) as u16;
-            let addr = alloc_epx_mem(state, len).map_err(|()| HostError::InsufficientMemory)?;
+            let addr = match alloc_epx_mem(state, len) {
+                Ok(addr) => addr,
+                Err(()) => {
+                    // Hand back the slot claimed above, or repeated buffer failures
+                    // would exhaust the bitset and report `OutOfPipes` instead.
+                    critical_section::with(|_| {
+                        let epx = &state.allocated_epx;
+                        epx.store(
+                            epx.load(Ordering::Relaxed) & !(1 << (index - EP_COUNT)),
+                            Ordering::Relaxed,
+                        );
+                    });
+
+                    return Err(HostError::InsufficientMemory);
+                }
+            };
+            debug!(
+                "EPX pipe ALLOC slot {} (bitset {:04x}) buf {:#x}+{}",
+                index - EP_COUNT,
+                state.allocated_epx.load(Ordering::Relaxed),
+                addr,
+                len
+            );
 
             Ok(Channel::new(index, addr, len, endpoint, dev_addr, pre))
         }

--- a/examples/rp/src/bin/usb_host_enum.rs
+++ b/examples/rp/src/bin/usb_host_enum.rs
@@ -1,0 +1,335 @@
+//! Reset the bus, enumerate every device behind every hub, and print the tree.
+//!
+//! Walks the bus breadth-first: enumerate the device on the root port, and whenever one
+//! turns out to be a hub, register it and enumerate whatever is on its ports, until the
+//! tree is exhausted or the USB tier limit is reached.
+//!
+//! Device types come from the class drivers in `embassy-usb-host` rather than from
+//! hand-rolled class-code checks, so a device is reported the same way here as the driver
+//! that would actually claim it sees it. That matters for the awkward ones: smart-card
+//! readers are routinely shipped under the vendor-specific class, and a MIDI device is an
+//! audio-class device wearing a particular subclass.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either3, select3};
+use embassy_rp::bind_interrupts;
+use embassy_rp::peripherals::USB;
+use embassy_time::{Duration, Instant, Timer};
+use embassy_usb_driver::Speed;
+use embassy_usb_driver::host::UsbHostAllocator;
+use embassy_usb_host::class::cdc_acm::find_cdc_acm;
+use embassy_usb_host::class::gip::find_gip;
+use embassy_usb_host::class::hid::find_hid;
+use embassy_usb_host::class::hub::{HubEvent, HubHandler};
+use embassy_usb_host::class::msc::find_msc;
+use embassy_usb_host::class::uac::descriptors::AudioInterfaceCollection;
+use embassy_usb_host::class::vcp::cp210x::{find_cp210x, id};
+use embassy_usb_host::descriptor::{ConfigurationDescriptorChain, DeviceDescriptor};
+use embassy_usb_host::handler::{EnumerationInfo, HandlerEvent};
+use embassy_usb_host::{BusHandle, BusRoute, BusState};
+use heapless::Vec;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => embassy_rp::usb::host::InterruptHandler<USB>;
+});
+
+/// Devices the tree can hold, hubs included.
+const MAX_DEVICES: usize = 16;
+/// Ports handled per hub.
+const MAX_PORTS: usize = 8;
+/// Room for one configuration descriptor and everything nested in it.
+const CONFIG_BUF: usize = 512;
+
+/// Hub class code (USB 2.0 §11.23.1). A hub declares this at the device level, unlike every
+/// other class here, which lives on an interface.
+const CLASS_HUB: u8 = 0x09;
+
+/// How many hubs may be chained below the host.
+///
+/// USB 2.0 §4.1.1 allows seven tiers. The host is tier 1 and a device occupies the last
+/// tier, which leaves five for cascaded hubs. A deeper hub is out of spec, so it is
+/// reported and left unscanned rather than descended into.
+const MAX_HUB_DEPTH: u8 = 5;
+
+/// A hub reports its populated ports one after another once registered. When nothing new
+/// has arrived for this long, take the hub as having reported everything it has.
+const PORT_QUIET: Duration = Duration::from_millis(1500);
+/// Upper bound on one hub's scan, in case events keep trickling in.
+const PORT_SCAN_MAX: Duration = Duration::from_secs(6);
+
+/// What a device turned out to be.
+#[derive(Clone, Copy, Format)]
+enum Kind {
+    Hub,
+    Hid {
+        report_len: u16,
+    },
+    MassStorage,
+    CdcAcm,
+    Cp210x,
+    Gip,
+    Audio,
+    /// Nothing claimed it; the device's own class code is shown for triage.
+    Unknown {
+        class: u8,
+    },
+}
+
+/// One enumerated device, and where it hangs.
+///
+/// The position is tracked here rather than read back out of [`EnumerationInfo::route`],
+/// which cannot answer it. A `BusRoute` only carries a hub address and port when it is
+/// `Translated`, and everything on a full-speed bus behind full-speed hubs is `Direct`.
+/// Even when it is `Translated`, the `SplitInfo` names the transaction translator -- the
+/// hub doing the speed conversion, which for a device several tiers down is not its
+/// parent. The route describes how to talk to a device, not where it sits.
+#[derive(Clone, Copy)]
+struct Node {
+    info: EnumerationInfo,
+    /// Index of the hub this sits on, or `None` for the device on the root port.
+    parent: Option<u8>,
+    /// Port on that hub, as the hub numbers them.
+    port: u8,
+    kind: Kind,
+}
+
+#[embassy_executor::main(executor = "embassy_rp::executor::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let driver = embassy_rp::usb::host::Driver::new(p.USB, Irqs);
+
+    static BUS_STATE: BusState = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
+
+    info!("waiting for a device on the root port ...");
+    // Drives the bus reset and returns the speed the device settled on.
+    let speed = bus_ctrl.wait_for_connection().await;
+
+    let mut nodes: Vec<Node, MAX_DEVICES> = Vec::new();
+    let mut config_buf = [0u8; CONFIG_BUF];
+
+    match bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await {
+        Ok((info, len)) => {
+            let kind = classify(&info.device_desc, &config_buf[..len]);
+            // The table is empty here, so this cannot fail.
+            nodes
+                .push(Node {
+                    info,
+                    parent: None,
+                    port: 0,
+                    kind,
+                })
+                .ok();
+        }
+        Err(e) => {
+            error!("root port enumeration failed: {:?}", e);
+            idle().await
+        }
+    }
+
+    // Breadth-first: children are appended as they are found, so walking `nodes` in order
+    // reaches every hub exactly once and needs no separate queue.
+    let mut next = 0;
+    while next < nodes.len() {
+        let node = nodes[next];
+        let index = next as u8;
+        next += 1;
+
+        if !matches!(node.kind, Kind::Hub) {
+            continue;
+        }
+        let depth = depth_of(&nodes, index);
+        if depth >= MAX_HUB_DEPTH {
+            warn!(
+                "hub at address {} is {} hubs deep, past the {} USB allows - not descending",
+                node.info.device_address, depth, MAX_HUB_DEPTH
+            );
+            continue;
+        }
+
+        scan_hub(&bus, &node.info, index, &mut nodes).await;
+    }
+
+    info!("");
+    info!("=== USB device tree ===");
+    print_children(&nodes, None, 0);
+    info!("{} devices total", nodes.len());
+
+    idle().await
+}
+
+/// How many hubs sit between `index` and the host, by walking up the parent chain.
+fn depth_of(nodes: &[Node], index: u8) -> u8 {
+    let mut node = &nodes[index as usize];
+    let mut depth = 0;
+    while let Some(parent) = node.parent {
+        depth += 1;
+        node = &nodes[parent as usize];
+    }
+    depth
+}
+
+/// Register one hub and enumerate whatever is on its ports, appending each to `nodes`.
+async fn scan_hub<'d, A: UsbHostAllocator<'d>>(
+    bus: &BusHandle<'d, A>,
+    hub_info: &EnumerationInfo,
+    parent: u8,
+    nodes: &mut Vec<Node, MAX_DEVICES>,
+) {
+    // Dropped at the end of the scan, which releases the pipes it holds for the next hub.
+    let mut hub = match HubHandler::<_, MAX_PORTS>::try_register(bus, hub_info).await {
+        Ok(hub) => hub,
+        Err(e) => {
+            warn!("address {}: hub registration failed: {:?}", hub_info.device_address, e);
+            return;
+        }
+    };
+
+    let mut cap = Timer::at(Instant::now() + PORT_SCAN_MAX);
+
+    loop {
+        // `PORT_QUIET` restarts on every iteration, so it measures the gap since the last
+        // event rather than the length of the scan; `cap` bounds the scan as a whole.
+        let event = match select3(hub.wait_for_event(), Timer::after(PORT_QUIET), &mut cap).await {
+            Either3::First(Ok(event)) => event,
+            Either3::First(Err(e)) => {
+                warn!("hub event failed: {:?}", e);
+                return;
+            }
+            // Nothing new for a while: the hub has reported everything attached to it.
+            Either3::Second(_) => return,
+            Either3::Third(_) => {
+                warn!("hub scan hit its {} s cap", PORT_SCAN_MAX.as_secs());
+                return;
+            }
+        };
+
+        let HandlerEvent::HandlerEvent(HubEvent::DeviceDetected { port, speed }) = event else {
+            continue;
+        };
+
+        let mut config_buf = [0u8; CONFIG_BUF];
+        match hub.enumerate_port(&mut config_buf, port, speed).await {
+            Ok((info, len)) => {
+                let kind = classify(&info.device_desc, &config_buf[..len]);
+                let node = Node {
+                    info,
+                    parent: Some(parent),
+                    port,
+                    kind,
+                };
+                if nodes.push(node).is_err() {
+                    warn!("device table full at {} entries - stopping the walk", MAX_DEVICES);
+                    return;
+                }
+            }
+            Err(e) => warn!("port {}: enumeration failed: {:?}", port, e),
+        }
+    }
+}
+
+/// Work out what a device is, by asking the class drivers that would claim it.
+///
+/// Order matters where classes overlap, and the overlaps are called out below.
+fn classify(dev: &DeviceDescriptor, config: &[u8]) -> Kind {
+    // Hubs are the one class declared on the device descriptor rather than an interface.
+    if dev.device_class == CLASS_HUB {
+        return Kind::Hub;
+    }
+
+    if let Some(hid) = find_hid(config) {
+        return Kind::Hid {
+            report_len: hid.report_descriptor_len,
+        };
+    }
+    if find_msc(config).is_some() {
+        return Kind::MassStorage;
+    }
+    if find_cdc_acm(config).is_some() {
+        return Kind::CdcAcm;
+    }
+    // Vendor-specific, so it is identified by VID/PID rather than by class.
+    if dev.vendor_id == id::VID_SILABS && find_cp210x(config, 0).is_some() {
+        return Kind::Cp210x;
+    }
+    if find_gip(config).is_some() {
+        return Kind::Gip;
+    }
+    if let Ok(cfg) = ConfigurationDescriptorChain::try_from_slice(config) {
+        if AudioInterfaceCollection::try_from_configuration(&cfg).is_ok() {
+            return Kind::Audio;
+        }
+    }
+
+    // A composite device declares class 0 at the device level and puts the real class on
+    // each interface, so the first interface's class is the one worth showing.
+    let class = ConfigurationDescriptorChain::try_from_slice(config)
+        .ok()
+        .and_then(|cfg| cfg.iter_interface().next().map(|iface| iface.interface_class))
+        .unwrap_or(dev.device_class);
+
+    Kind::Unknown { class }
+}
+
+/// Print every child of `parent`, then each of their children, indented by depth.
+fn print_children(nodes: &[Node], parent: Option<u8>, depth: usize) {
+    const INDENT: &str = "                                ";
+
+    for (i, node) in nodes.iter().enumerate() {
+        if node.parent != parent {
+            continue;
+        }
+
+        let pad = &INDENT[..(depth * 2).min(INDENT.len())];
+        let desc = &node.info.device_desc;
+        if node.parent.is_none() {
+            info!(
+                "{}root port: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        } else {
+            info!(
+                "{}port {}: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                node.port,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        }
+
+        print_children(nodes, Some(i as u8), depth + 1);
+    }
+}
+
+/// [`Speed`] prints as its enum name; this shortens it for the tree.
+struct Sp(Speed);
+
+impl Format for Sp {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            Speed::Low => defmt::write!(f, "LS"),
+            Speed::Full => defmt::write!(f, "FS"),
+            Speed::High => defmt::write!(f, "HS"),
+        }
+    }
+}
+
+async fn idle() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(1)).await;
+    }
+}

--- a/examples/rp235x/Cargo.toml
+++ b/examples/rp235x/Cargo.toml
@@ -13,6 +13,8 @@ embassy-executor = { version = "0.10.0", path = "../../embassy-executor", featur
 embassy-time = { version = "0.5.1", path = "../../embassy-time", features = ["defmt", "defmt-timestamp-uptime"] }
 embassy-rp = { version = "0.10.0", path = "../../embassy-rp", features = ["defmt", "unstable-pac", "time-driver", "critical-section-impl", "rp235xa", "binary-info", "executor-thread", "executor-interrupt"] }
 embassy-usb = { version = "0.6.0", path = "../../embassy-usb", features = ["defmt"] }
+embassy-usb-host = { version = "0.1.0", path = "../../embassy-usb-host", features = ["defmt"] }
+embassy-usb-driver = { version = "0.2.2", path = "../../embassy-usb-driver" }
 embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt", "tcp", "tcp-listener", "udp", "raw-ethernet", "raw-ip", "dhcpv4", "medium-ethernet", "dns", "icmp-ping-reply"] }
 embassy-net-wiznet = { version = "0.3.0", path = "../../embassy-net-wiznet", features = ["defmt"] }
 embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }

--- a/examples/rp235x/src/bin/usb_host_enum.rs
+++ b/examples/rp235x/src/bin/usb_host_enum.rs
@@ -1,0 +1,335 @@
+//! Reset the bus, enumerate every device behind every hub, and print the tree.
+//!
+//! Walks the bus breadth-first: enumerate the device on the root port, and whenever one
+//! turns out to be a hub, register it and enumerate whatever is on its ports, until the
+//! tree is exhausted or the USB tier limit is reached.
+//!
+//! Device types come from the class drivers in `embassy-usb-host` rather than from
+//! hand-rolled class-code checks, so a device is reported the same way here as the driver
+//! that would actually claim it sees it. That matters for the awkward ones: smart-card
+//! readers are routinely shipped under the vendor-specific class, and a MIDI device is an
+//! audio-class device wearing a particular subclass.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_futures::select::{Either3, select3};
+use embassy_rp::bind_interrupts;
+use embassy_rp::peripherals::USB;
+use embassy_time::{Duration, Instant, Timer};
+use embassy_usb_driver::Speed;
+use embassy_usb_driver::host::UsbHostAllocator;
+use embassy_usb_host::class::cdc_acm::find_cdc_acm;
+use embassy_usb_host::class::gip::find_gip;
+use embassy_usb_host::class::hid::find_hid;
+use embassy_usb_host::class::hub::{HubEvent, HubHandler};
+use embassy_usb_host::class::msc::find_msc;
+use embassy_usb_host::class::uac::descriptors::AudioInterfaceCollection;
+use embassy_usb_host::class::vcp::cp210x::{find_cp210x, id};
+use embassy_usb_host::descriptor::{ConfigurationDescriptorChain, DeviceDescriptor};
+use embassy_usb_host::handler::{EnumerationInfo, HandlerEvent};
+use embassy_usb_host::{BusHandle, BusRoute, BusState};
+use heapless::Vec;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USBCTRL_IRQ => embassy_rp::usb::host::InterruptHandler<USB>;
+});
+
+/// Devices the tree can hold, hubs included.
+const MAX_DEVICES: usize = 16;
+/// Ports handled per hub.
+const MAX_PORTS: usize = 8;
+/// Room for one configuration descriptor and everything nested in it.
+const CONFIG_BUF: usize = 512;
+
+/// Hub class code (USB 2.0 §11.23.1). A hub declares this at the device level, unlike every
+/// other class here, which lives on an interface.
+const CLASS_HUB: u8 = 0x09;
+
+/// How many hubs may be chained below the host.
+///
+/// USB 2.0 §4.1.1 allows seven tiers. The host is tier 1 and a device occupies the last
+/// tier, which leaves five for cascaded hubs. A deeper hub is out of spec, so it is
+/// reported and left unscanned rather than descended into.
+const MAX_HUB_DEPTH: u8 = 5;
+
+/// A hub reports its populated ports one after another once registered. When nothing new
+/// has arrived for this long, take the hub as having reported everything it has.
+const PORT_QUIET: Duration = Duration::from_millis(1500);
+/// Upper bound on one hub's scan, in case events keep trickling in.
+const PORT_SCAN_MAX: Duration = Duration::from_secs(6);
+
+/// What a device turned out to be.
+#[derive(Clone, Copy, Format)]
+enum Kind {
+    Hub,
+    Hid {
+        report_len: u16,
+    },
+    MassStorage,
+    CdcAcm,
+    Cp210x,
+    Gip,
+    Audio,
+    /// Nothing claimed it; the device's own class code is shown for triage.
+    Unknown {
+        class: u8,
+    },
+}
+
+/// One enumerated device, and where it hangs.
+///
+/// The position is tracked here rather than read back out of [`EnumerationInfo::route`],
+/// which cannot answer it. A `BusRoute` only carries a hub address and port when it is
+/// `Translated`, and everything on a full-speed bus behind full-speed hubs is `Direct`.
+/// Even when it is `Translated`, the `SplitInfo` names the transaction translator -- the
+/// hub doing the speed conversion, which for a device several tiers down is not its
+/// parent. The route describes how to talk to a device, not where it sits.
+#[derive(Clone, Copy)]
+struct Node {
+    info: EnumerationInfo,
+    /// Index of the hub this sits on, or `None` for the device on the root port.
+    parent: Option<u8>,
+    /// Port on that hub, as the hub numbers them.
+    port: u8,
+    kind: Kind,
+}
+
+#[embassy_executor::main(executor = "embassy_rp::executor::Executor", entry = "cortex_m_rt::entry")]
+async fn main(_spawner: Spawner) {
+    let p = embassy_rp::init(Default::default());
+    let driver = embassy_rp::usb::host::Driver::new(p.USB, Irqs);
+
+    static BUS_STATE: BusState = BusState::new();
+    let (mut bus_ctrl, bus) = embassy_usb_host::bus(driver, &BUS_STATE);
+
+    info!("waiting for a device on the root port ...");
+    // Drives the bus reset and returns the speed the device settled on.
+    let speed = bus_ctrl.wait_for_connection().await;
+
+    let mut nodes: Vec<Node, MAX_DEVICES> = Vec::new();
+    let mut config_buf = [0u8; CONFIG_BUF];
+
+    match bus.enumerate(BusRoute::Direct(speed), &mut config_buf).await {
+        Ok((info, len)) => {
+            let kind = classify(&info.device_desc, &config_buf[..len]);
+            // The table is empty here, so this cannot fail.
+            nodes
+                .push(Node {
+                    info,
+                    parent: None,
+                    port: 0,
+                    kind,
+                })
+                .ok();
+        }
+        Err(e) => {
+            error!("root port enumeration failed: {:?}", e);
+            idle().await
+        }
+    }
+
+    // Breadth-first: children are appended as they are found, so walking `nodes` in order
+    // reaches every hub exactly once and needs no separate queue.
+    let mut next = 0;
+    while next < nodes.len() {
+        let node = nodes[next];
+        let index = next as u8;
+        next += 1;
+
+        if !matches!(node.kind, Kind::Hub) {
+            continue;
+        }
+        let depth = depth_of(&nodes, index);
+        if depth >= MAX_HUB_DEPTH {
+            warn!(
+                "hub at address {} is {} hubs deep, past the {} USB allows - not descending",
+                node.info.device_address, depth, MAX_HUB_DEPTH
+            );
+            continue;
+        }
+
+        scan_hub(&bus, &node.info, index, &mut nodes).await;
+    }
+
+    info!("");
+    info!("=== USB device tree ===");
+    print_children(&nodes, None, 0);
+    info!("{} devices total", nodes.len());
+
+    idle().await
+}
+
+/// How many hubs sit between `index` and the host, by walking up the parent chain.
+fn depth_of(nodes: &[Node], index: u8) -> u8 {
+    let mut node = &nodes[index as usize];
+    let mut depth = 0;
+    while let Some(parent) = node.parent {
+        depth += 1;
+        node = &nodes[parent as usize];
+    }
+    depth
+}
+
+/// Register one hub and enumerate whatever is on its ports, appending each to `nodes`.
+async fn scan_hub<'d, A: UsbHostAllocator<'d>>(
+    bus: &BusHandle<'d, A>,
+    hub_info: &EnumerationInfo,
+    parent: u8,
+    nodes: &mut Vec<Node, MAX_DEVICES>,
+) {
+    // Dropped at the end of the scan, which releases the pipes it holds for the next hub.
+    let mut hub = match HubHandler::<_, MAX_PORTS>::try_register(bus, hub_info).await {
+        Ok(hub) => hub,
+        Err(e) => {
+            warn!("address {}: hub registration failed: {:?}", hub_info.device_address, e);
+            return;
+        }
+    };
+
+    let mut cap = Timer::at(Instant::now() + PORT_SCAN_MAX);
+
+    loop {
+        // `PORT_QUIET` restarts on every iteration, so it measures the gap since the last
+        // event rather than the length of the scan; `cap` bounds the scan as a whole.
+        let event = match select3(hub.wait_for_event(), Timer::after(PORT_QUIET), &mut cap).await {
+            Either3::First(Ok(event)) => event,
+            Either3::First(Err(e)) => {
+                warn!("hub event failed: {:?}", e);
+                return;
+            }
+            // Nothing new for a while: the hub has reported everything attached to it.
+            Either3::Second(_) => return,
+            Either3::Third(_) => {
+                warn!("hub scan hit its {} s cap", PORT_SCAN_MAX.as_secs());
+                return;
+            }
+        };
+
+        let HandlerEvent::HandlerEvent(HubEvent::DeviceDetected { port, speed }) = event else {
+            continue;
+        };
+
+        let mut config_buf = [0u8; CONFIG_BUF];
+        match hub.enumerate_port(&mut config_buf, port, speed).await {
+            Ok((info, len)) => {
+                let kind = classify(&info.device_desc, &config_buf[..len]);
+                let node = Node {
+                    info,
+                    parent: Some(parent),
+                    port,
+                    kind,
+                };
+                if nodes.push(node).is_err() {
+                    warn!("device table full at {} entries - stopping the walk", MAX_DEVICES);
+                    return;
+                }
+            }
+            Err(e) => warn!("port {}: enumeration failed: {:?}", port, e),
+        }
+    }
+}
+
+/// Work out what a device is, by asking the class drivers that would claim it.
+///
+/// Order matters where classes overlap, and the overlaps are called out below.
+fn classify(dev: &DeviceDescriptor, config: &[u8]) -> Kind {
+    // Hubs are the one class declared on the device descriptor rather than an interface.
+    if dev.device_class == CLASS_HUB {
+        return Kind::Hub;
+    }
+
+    if let Some(hid) = find_hid(config) {
+        return Kind::Hid {
+            report_len: hid.report_descriptor_len,
+        };
+    }
+    if find_msc(config).is_some() {
+        return Kind::MassStorage;
+    }
+    if find_cdc_acm(config).is_some() {
+        return Kind::CdcAcm;
+    }
+    // Vendor-specific, so it is identified by VID/PID rather than by class.
+    if dev.vendor_id == id::VID_SILABS && find_cp210x(config, 0).is_some() {
+        return Kind::Cp210x;
+    }
+    if find_gip(config).is_some() {
+        return Kind::Gip;
+    }
+    if let Ok(cfg) = ConfigurationDescriptorChain::try_from_slice(config) {
+        if AudioInterfaceCollection::try_from_configuration(&cfg).is_ok() {
+            return Kind::Audio;
+        }
+    }
+
+    // A composite device declares class 0 at the device level and puts the real class on
+    // each interface, so the first interface's class is the one worth showing.
+    let class = ConfigurationDescriptorChain::try_from_slice(config)
+        .ok()
+        .and_then(|cfg| cfg.iter_interface().next().map(|iface| iface.interface_class))
+        .unwrap_or(dev.device_class);
+
+    Kind::Unknown { class }
+}
+
+/// Print every child of `parent`, then each of their children, indented by depth.
+fn print_children(nodes: &[Node], parent: Option<u8>, depth: usize) {
+    const INDENT: &str = "                                ";
+
+    for (i, node) in nodes.iter().enumerate() {
+        if node.parent != parent {
+            continue;
+        }
+
+        let pad = &INDENT[..(depth * 2).min(INDENT.len())];
+        let desc = &node.info.device_desc;
+        if node.parent.is_none() {
+            info!(
+                "{}root port: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        } else {
+            info!(
+                "{}port {}: {:04x}:{:04x} addr {} {} {}",
+                pad,
+                node.port,
+                desc.vendor_id,
+                desc.product_id,
+                node.info.device_address,
+                Sp(node.info.speed()),
+                node.kind
+            );
+        }
+
+        print_children(nodes, Some(i as u8), depth + 1);
+    }
+}
+
+/// [`Speed`] prints as its enum name; this shortens it for the tree.
+struct Sp(Speed);
+
+impl Format for Sp {
+    fn format(&self, f: defmt::Formatter) {
+        match self.0 {
+            Speed::Low => defmt::write!(f, "LS"),
+            Speed::Full => defmt::write!(f, "FS"),
+            Speed::High => defmt::write!(f, "HS"),
+        }
+    }
+}
+
+async fn idle() -> ! {
+    loop {
+        Timer::after(Duration::from_secs(1)).await;
+    }
+}


### PR DESCRIPTION
Current impl uses one single buffer for all control/bulk transfers, so a parked transfer can overwrite another's buffer. Also EPX pipes are never freed. 

PR allocates separate buffer per pipe, sized to its `max_packet_size` and its own `Waker` so completion wakes the pipe and not the usb-stack. `Drop` now recycles the buffer and waker.

Tested with a stress tester, 9 devices (incl. 2 hubs) over 200 pipes create/release, 1400 allocations and cancellations.

Does not fairly arbitrate. A pipe holding or stalling on single EPX h/w can starve other pipes. Next PR will fix this.

Stacks on PR#6768. Should rebase once that lands.

Done and tested with assistance from Claude and Codex.