### PR TITLE
stm32: adc: f1: fix triggered DMA usage and add examples

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -215,11 +215,11 @@ heapless = "0.9.3"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-bbb4dc22cd1d257733291e21c8532d406b5a4873" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-acdae7e49440d2a61573a1da0dc6ff5a98b952ce" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-bbb4dc22cd1d257733291e21c8532d406b5a4873" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-acdae7e49440d2a61573a1da0dc6ff5a98b952ce" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.107"
 quote = "1.0.47"

--- a/embassy-stm32/src/adc/f1.rs
+++ b/embassy-stm32/src/adc/f1.rs
@@ -13,6 +13,8 @@ pub const VDDA_CALIB_MV: u32 = 3300;
 pub const ADC_MAX: u32 = (1 << 12) - 1;
 // No calibration data for F103, voltage should be 1.2v
 pub const VREF_INT: u32 = 1200;
+// `CR2.EXTSEL` value selecting the software trigger for the regular group.
+const EXTSEL_SWSTART: u8 = 0b111;
 
 /// Interrupt handler.
 pub struct InterruptHandler<T: Instance> {
@@ -42,11 +44,19 @@ impl AdcRegs for crate::pac::adc::Adc {
     }
 
     fn enable(&self) {
-        self.cr2().modify(|reg| {
-            reg.set_adon(true);
-        });
+        // 11.3.1: "Conversion starts when ADON bit is set for a second time by
+        // software after ADC power-up". `Adc::new()` already sets ADON once, so
+        // writing it again here would spuriously kick off a conversion of whatever
+        // sequence/mode happens to be configured at that moment -- before the caller
+        // has finished configuring DMA/triggers for the real one. Only pulse ADON
+        // when it is genuinely off.
+        if !self.cr2().read().adon() {
+            self.cr2().modify(|reg| {
+                reg.set_adon(true);
+            });
 
-        block_for_us(3);
+            block_for_us(3);
+        }
     }
 
     fn start(&self) {
@@ -87,8 +97,9 @@ impl AdcRegs for crate::pac::adc::Adc {
         });
 
         self.cr1().modify(|w| {
-            // Enable end of conversion interrupt only in repeated mode.
-            w.set_eocie(true);
+            // Enable end-of-conversion interrupt only for the interrupt-driven
+            // single conversion
+            w.set_eocie(matches!(conversion_mode, ConversionMode::NoDma));
             // Scanning conversions of multiple channels.
             w.set_scan(true);
             // Disable discontinuous mode.
@@ -98,8 +109,14 @@ impl AdcRegs for crate::pac::adc::Adc {
         self.cr2().modify(|w| {
             // Enable DMA mode
             w.set_dma(!matches!(conversion_mode, ConversionMode::NoDma));
-            // EOC flag is set at the end of each conversion.
-            w.set_cont(false);
+            // Free-running only when repeating without an external trigger.
+            w.set_cont(matches!(conversion_mode, ConversionMode::Repeated(None)));
+            // Select the trigger
+            match conversion_mode {
+                ConversionMode::Repeated(Some((trigger, _edge))) => w.set_extsel(trigger),
+                _ => w.set_extsel(EXTSEL_SWSTART),
+            }
+            w.set_exttrig(true);
         });
     }
 

--- a/examples/stm32f1/src/bin/adc_dma.rs
+++ b/examples/stm32f1/src/bin/adc_dma.rs
@@ -1,0 +1,75 @@
+//! ADC with DMA ring buffer.
+//!
+//! The ADC scans a sequence of channels continuously and DMA writes the
+//! results into a circular buffer with no CPU involvement -- the CPU
+//! only drains the buffer.
+
+#![no_std]
+#![no_main]
+
+use cortex_m::singleton;
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{Adc, AdcChannel, RingBufferedAdc, SampleTime};
+use embassy_stm32::{bind_interrupts, dma, peripherals};
+use embassy_time::Instant;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    DMA1_CHANNEL1 => dma::InterruptHandler<peripherals::DMA1_CH1>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = embassy_stm32::init(Default::default());
+    info!("ADC ring buffered on STM32F1");
+
+    const ADC_BUF_SIZE: usize = 1024;
+    let adc_data: &mut [u16; ADC_BUF_SIZE] = singleton!(ADCDAT : [u16; ADC_BUF_SIZE] = [0u16; ADC_BUF_SIZE]).unwrap();
+
+    let adc = Adc::new(p.ADC1);
+
+    let mut adc: RingBufferedAdc<_> = adc.into_ring_buffered(
+        p.DMA1_CH1,
+        adc_data,
+        Irqs,
+        [
+            (p.PA0.reborrow_adc(), SampleTime::Cycles135),
+            (p.PA1.reborrow_adc(), SampleTime::Cycles135),
+        ]
+        .into_iter(),
+        None,
+    );
+
+    // Note that overrun is a big consideration in this implementation. Whatever task is running the adc.read() calls absolutely must circle back around
+    // to the adc.read() call before the DMA buffer is wrapped around > 1 time. At this point, the overrun is so significant that the context of
+    // what channel is at what index is lost. The buffer must be cleared and reset. This *is* handled here, but allowing this to happen will cause
+    // a reduction of performance as each time the buffer is reset, the adc & dma buffer must be restarted.
+
+    // An interrupt executor with a higher priority than other tasks may be a good approach here, allowing this task to wake and read the buffer most
+    // frequently.
+    let mut tic = Instant::now();
+    let mut buffer = [0u16; 512];
+    adc.start();
+
+    loop {
+        match adc.read(&mut buffer).await {
+            Ok(_data) => {
+                let toc = Instant::now();
+                info!(
+                    "\n adc: {} dt = {}, n = {}",
+                    buffer[0..16],
+                    (toc - tic).as_micros(),
+                    _data
+                );
+                tic = toc;
+            }
+            Err(e) => {
+                warn!("Error: {:?}", e);
+                buffer = [0u16; 512];
+                adc.start();
+            }
+        }
+    }
+}

--- a/examples/stm32f1/src/bin/adc_ring_buffered_timer.rs
+++ b/examples/stm32f1/src/bin/adc_ring_buffered_timer.rs
@@ -1,0 +1,101 @@
+//! ADC with DMA ring buffer triggered by a timer.
+//!
+//! The ADC scans a sequence of channels on every timer event and DMA writes the
+//! results into a circular buffer, so sampling runs at a hardware-defined rate
+//! with no CPU involvement -- the CPU only drains the buffer.
+
+#![no_std]
+#![no_main]
+
+use defmt::*;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::adc::{ADC_MAX, Adc, AdcChannel as _, Exten, RegularAdcTrigger, SampleTime, VREF_INT};
+use embassy_stm32::peripherals::DMA1_CH1;
+use embassy_stm32::time::Hertz;
+use embassy_stm32::timer::low_level::{MasterMode, RoundTo, Timer as LowLevelTimer};
+use embassy_stm32::triggers::TIM3_TRGO;
+use embassy_stm32::{bind_interrupts, dma};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    DMA1_CHANNEL1 => dma::InterruptHandler<DMA1_CH1>;
+});
+
+/// Channels per scan: VrefInt, temperature, PA0.
+const SEQUENCE_LEN: usize = 3;
+/// Scans per half-buffer. `read` returns once the DMA has filled a half.
+const SCANS_PER_HALF: usize = 4;
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let mut p = embassy_stm32::init(Default::default());
+
+    info!("ADC ring buffer with timer trigger, STM32F1");
+
+    // Configure TIM3 to generate TRGO events at 4 Hz
+    // This will trigger ADC conversions periodically
+    // Configured now, but not started yet -- it must not fire before the DMA
+    // ring buffer is armed, or the first captured sample won't be the first
+    // channel of the sequence and every slot will stay rotated from then on.
+    let timer = LowLevelTimer::new(p.TIM3);
+    timer.set_frequency(Hertz::hz(4), RoundTo::Slower);
+    timer.set_master_mode(MasterMode::Update);
+
+    let mut adc = Adc::new(p.ADC1);
+    let mut vrefint = adc.enable_vref();
+    let mut temperature = adc.enable_temperature();
+
+    // The temperature sensor and VrefInt need a long sample time (>17.1 us on F1).
+    let sequence = [
+        (vrefint.reborrow_adc(), SampleTime::Cycles715),
+        (temperature.reborrow_adc(), SampleTime::Cycles715),
+        (p.PA0.reborrow_adc(), SampleTime::Cycles135),
+    ]
+    .into_iter();
+
+    // Double-sized so the CPU can drain one half while DMA fills the other.
+    let mut dma_buf = [0u16; SEQUENCE_LEN * SCANS_PER_HALF * 2];
+
+    let mut ring_buffered_adc = adc.into_ring_buffered(
+        p.DMA1_CH1,
+        &mut dma_buf,
+        Irqs,
+        sequence,
+        RegularAdcTrigger::from(TIM3_TRGO, Exten),
+    );
+
+    // Arm the DMA before the first trigger, so the scan lands at buffer index 0
+    // and each channel keeps a fixed position within the sequence.
+    ring_buffered_adc.start();
+    timer.start();
+
+    // Buffer to read samples - must be half the size of dma_buf
+    let mut data = [0u16; SEQUENCE_LEN * SCANS_PER_HALF];
+
+    loop {
+        match ring_buffered_adc.read(&mut data).await {
+            Ok(_) => {
+                info!("RAW data = {}", data);
+                // Samples are interleaved: [vref, temp, pa0, vref, temp, pa0, ...]
+                for (i, scan) in data.chunks_exact(SEQUENCE_LEN).enumerate() {
+                    let (vrefint_sample, temperature_sample, pa0) = (scan[0], scan[1], scan[2]);
+
+                    // VrefInt is a known 1.20 V, so it calibrates VDDA and lets the
+                    // other channels be converted without assuming a 3.3 V rail.
+                    let vdda_mv = VREF_INT * ADC_MAX / vrefint_sample.max(1) as u32;
+                    let pa0_mv = pa0 as u32 * vdda_mv / ADC_MAX;
+
+                    info!(
+                        "scan {}: vrefint={} temp={} pa0={} ({} mV, VDDA {} mV)",
+                        i, vrefint_sample, temperature_sample, pa0, pa0_mv, vdda_mv
+                    );
+                }
+            }
+            Err(e) => {
+                error!("ADC ring buffer overrun: {:?}", e);
+                ring_buffered_adc.clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
- adc_dma.rs is inspired from the stm32f4 example
- adc_ring_buffered_timer is inspired from the stm32c0 example

Needs https://github.com/embassy-rs/stm32-data/pull/904 to be merged before so setting as draft for now.

All 3 ADC examples tested on stm32f103c8t6.