### PR TITLE
net: return error instead of panicking if socket/listener/iface slab is full.

### DIFF
--- a/embassy-net-driver-channel/Cargo.toml
+++ b/embassy-net-driver-channel/Cargo.toml
@@ -27,7 +27,7 @@ log = { version = "0.4.14", optional = true }
 
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
-xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", features = ["async"] }
+xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", features = ["async"] }
 
 [features]
 defmt = ["dep:defmt", "xarxa-driver/defmt"]

--- a/embassy-net-enc28j60/Cargo.toml
+++ b/embassy-net-enc28j60/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.embassy.dev/embassy-net-enc28j60"
 [dependencies]
 embedded-hal = { version = "1.0" }
 embedded-hal-async = { version = "1.0" }
-xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", features = ["async"] }
+xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", features = ["async"] }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 

--- a/embassy-net-tuntap/Cargo.toml
+++ b/embassy-net-tuntap/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/embassy-rs/embassy"
 documentation = "https://docs.embassy.dev/embassy-net-tuntap"
 
 [dependencies]
-xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", features = ["async"] }
+xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", features = ["async"] }
 async-io = "2.6.0"
 log = "0.4.14"
 libc = "0.2.101"

--- a/embassy-net/CHANGELOG.md
+++ b/embassy-net/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `IcmpSocket` is gone.
   - ICMP errors related to sent packets can be retrieved from sockets (feature `icmp-errors`).
   - For other ICMP uses (e.g. pings) use a raw socket instead.
+- Socket and listener constructors no longer panic when the stack is out of slots, they return `Err(Full)` instead.
 - Added APIs to access and edit the route table
 - Added APIs to access and edit the neighbor cache
 - Feature `proto-ipv4`/`proto-ipv6` renamed to `ipv4`/`ipv6`.

--- a/embassy-net/Cargo.toml
+++ b/embassy-net/Cargo.toml
@@ -136,7 +136,7 @@ packet-log = ["xarxa/packet-log"]
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
-xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", default-features = false, features = ["async"] }
+xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", default-features = false, features = ["async"] }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }

--- a/embassy-net/src/lib.rs
+++ b/embassy-net/src/lib.rs
@@ -130,7 +130,12 @@ impl<'d> Stack<'d> {
         let mut stack = xarxa::Stack::new(random_seed);
 
         #[cfg(feature = "dns")]
-        let dns = unwrap!(xarxa::dns::DnsClient::new(&mut stack, &[]).ok());
+        // The stack is brand new, so its UDP socket table can only be full if it
+        // has no slots at all.
+        let dns = unwrap!(
+            xarxa::dns::DnsClient::new(&mut stack, &[]).ok(),
+            "the DNS client needs a UDP socket, raise the `udp-socket-count-N` feature of xarxa"
+        );
 
         let inner = Inner {
             stack,

--- a/embassy-net/src/raw.rs
+++ b/embassy-net/src/raw.rs
@@ -14,7 +14,7 @@ pub use xarxa::wire::EthernetProtocol;
 #[cfg(feature = "raw-ip")]
 pub use xarxa::wire::{IpProtocol, IpVersion};
 
-use crate::{Stack, TryError};
+use crate::{Full, Stack, TryError};
 
 /// Error returned by [`RawSocket::bind`].
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -62,12 +62,13 @@ impl<'d> RawSocket<'d> {
     /// Create a new raw socket using the provided stack, receiving IP packets
     /// of the given version and protocol (`None` for any).
     ///
-    /// # Panics
-    /// Panics if the stack has no room for another raw socket. The limit is set
-    /// by the `raw-socket-count-N` feature of `xarxa`.
+    /// Errors:
+    /// - `Full` if the stack has no room for another raw socket. The limit is set
+    ///   by the `raw-socket-count-N` feature of `xarxa`.
     #[cfg(feature = "raw-ip")]
-    pub fn new(stack: Stack<'d>, ip_version: Option<IpVersion>, ip_protocol: Option<IpProtocol>) -> Self {
-        let mut this = Self::new_unbound(stack);
+    pub fn new(stack: Stack<'d>, ip_version: Option<IpVersion>, ip_protocol: Option<IpProtocol>) -> Result<Self, Full> {
+        let mut this = Self::new_unbound(stack)?;
+        // The socket was just created, so it is unbound and cannot fail to bind.
         unwrap!(
             this.bind(RawMode::Ip {
                 version: ip_version,
@@ -75,22 +76,17 @@ impl<'d> RawSocket<'d> {
             })
             .ok()
         );
-        this
+        Ok(this)
     }
 
     /// Create a new raw socket using the provided stack, without binding it.
     ///
-    /// # Panics
-    /// Panics if the stack has no room for another raw socket. The limit is set
-    /// by the `raw-socket-count-N` feature of `xarxa`.
-    pub fn new_unbound(stack: Stack<'d>) -> Self {
-        let handle = stack.with(|i| {
-            unwrap!(
-                i.stack.add_raw_socket().ok(),
-                "too many raw sockets, raise the `raw-socket-count-N` feature of xarxa"
-            )
-        });
-        Self { stack, handle }
+    /// Errors:
+    /// - `Full` if the stack has no room for another raw socket. The limit is set
+    ///   by the `raw-socket-count-N` feature of `xarxa`.
+    pub fn new_unbound(stack: Stack<'d>) -> Result<Self, Full> {
+        let handle = stack.with(|i| i.stack.add_raw_socket())?;
+        Ok(Self { stack, handle })
     }
 
     /// Bind the socket to the given mode.

--- a/embassy-net/src/tcp.rs
+++ b/embassy-net/src/tcp.rs
@@ -15,7 +15,7 @@ use xarxa::tcp::{self, TcpHandle};
 use xarxa::wire::{IpEndpoint, IpListenEndpoint};
 
 use crate::time::duration_to_xarxa;
-use crate::{Stack, TryError};
+use crate::{Full, Stack, TryError};
 
 /// Error returned by TcpSocket read/write functions.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -66,6 +66,9 @@ pub enum ListenError {
 pub enum AcceptError {
     /// The listener is not listening.
     InvalidState,
+    /// The stack has no room for another TCP socket. The limit is set by the
+    /// `tcp-socket-count-N` feature of `xarxa`.
+    Full,
 }
 
 /// A TCP socket.
@@ -284,23 +287,20 @@ impl<'a, 'd> TcpWriter<'a, 'd> {
 impl<'a, 'd> TcpSocket<'a, 'd> {
     /// Create a new TCP socket on the given stack, with the given buffers.
     ///
-    /// # Panics
-    /// Panics if the stack has no room for another TCP socket. The limit is set
-    /// by the `tcp-socket-count-N` feature of `xarxa`.
-    pub fn new(stack: Stack<'d>, rx_buffer: &'a mut [u8], tx_buffer: &'a mut [u8]) -> Self {
+    /// Errors:
+    /// - `Full` if the stack has no room for another TCP socket. The limit is set
+    ///   by the `tcp-socket-count-N` feature of `xarxa`.
+    pub fn new(stack: Stack<'d>, rx_buffer: &'a mut [u8], tx_buffer: &'a mut [u8]) -> Result<Self, Full> {
         let handle = stack.with(|i| {
             let rx_buffer: &'d mut [u8] = unsafe { mem::transmute(rx_buffer) };
             let tx_buffer: &'d mut [u8] = unsafe { mem::transmute(tx_buffer) };
-            unwrap!(
-                i.stack.add_tcp_socket_with_bufs(rx_buffer, tx_buffer).ok(),
-                "too many TCP sockets, raise the `tcp-socket-count-N` feature of xarxa"
-            )
-        });
+            i.stack.add_tcp_socket_with_bufs(rx_buffer, tx_buffer)
+        })?;
 
-        Self {
+        Ok(Self {
             io: TcpIo { stack, handle },
             bufs: PhantomData,
-        }
+        })
     }
 
     /// Return the maximum number of bytes inside the recv buffer.
@@ -709,18 +709,13 @@ impl<'d> TcpListener<'d> {
     ///
     /// The listener starts closed. Call [`listen`](Self::listen) to start listening.
     ///
-    /// # Panics
-    /// Panics if the stack has no room for another TCP listener. The limit is set
-    /// by the `tcp-listener-count-N` feature of `xarxa`.
-    pub fn new(stack: Stack<'d>) -> Self {
-        let handle = stack.with(|i| {
-            unwrap!(
-                i.stack.add_tcp_listener().ok(),
-                "too many TCP listeners, raise the `tcp-listener-count-N` feature of xarxa"
-            )
-        });
+    /// Errors:
+    /// - `Full` if the stack has no room for another TCP listener. The limit is set
+    ///   by the `tcp-listener-count-N` feature of `xarxa`.
+    pub fn new(stack: Stack<'d>) -> Result<Self, Full> {
+        let handle = stack.with(|i| i.stack.add_tcp_listener())?;
 
-        Self { stack, handle }
+        Ok(Self { stack, handle })
     }
 
     fn with<R>(&self, f: impl FnOnce(&mut tcp::TcpListener<'_, 'd>) -> R) -> R {
@@ -829,15 +824,15 @@ impl<'d> TcpListener<'d> {
     /// If the returned future is dropped before it completes, the accepted connection attempt, if
     /// any, is reset.
     ///
-    /// # Panics
-    /// Panics if the stack has no room for another TCP socket. The limit is set
-    /// by the `tcp-socket-count-N` feature of `xarxa`.
+    /// Errors:
+    /// - `Full` if the stack has no room for another TCP socket. The limit is set
+    ///   by the `tcp-socket-count-N` feature of `xarxa`.
     pub async fn accept<'a>(
         &mut self,
         rx_buffer: &'a mut [u8],
         tx_buffer: &'a mut [u8],
     ) -> Result<TcpSocket<'a, 'd>, AcceptError> {
-        let mut socket = TcpSocket::new(self.stack, rx_buffer, tx_buffer);
+        let mut socket = TcpSocket::new(self.stack, rx_buffer, tx_buffer).map_err(|Full| AcceptError::Full)?;
         poll_fn(|cx| self.poll_accept(&mut socket, cx)).await?;
         Ok(socket)
     }
@@ -1266,6 +1261,7 @@ impl core::fmt::Display for AcceptError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::InvalidState => f.write_str("InvalidState"),
+            Self::Full => f.write_str("Full"),
         }
     }
 }
@@ -1367,11 +1363,15 @@ pub mod client {
     impl<'a, 'd, const N: usize, const TX_SZ: usize, const RX_SZ: usize> TcpConnection<'a, 'd, N, TX_SZ, RX_SZ> {
         fn new(stack: Stack<'d>, state: &'a TcpClientState<N, TX_SZ, RX_SZ>) -> Result<Self, Error> {
             let mut bufs = state.pool.alloc().ok_or(Error::ConnectionReset)?;
-            Ok(Self {
-                socket: unsafe { TcpSocket::new(stack, &mut bufs.as_mut().1, &mut bufs.as_mut().0) },
-                state,
-                bufs,
-            })
+            let socket = unsafe { TcpSocket::new(stack, &mut bufs.as_mut().1, &mut bufs.as_mut().0) };
+            let socket = match socket {
+                Ok(socket) => socket,
+                Err(Full) => {
+                    unsafe { state.pool.free(bufs) };
+                    return Err(Error::ConnectionReset);
+                }
+            };
+            Ok(Self { socket, state, bufs })
         }
     }
 

--- a/embassy-net/src/udp.rs
+++ b/embassy-net/src/udp.rs
@@ -11,7 +11,7 @@ pub use xarxa::udp::{RecvPacket, UdpMetadata};
 use xarxa::wire::IpListenEndpoint;
 
 use crate::wire::IpEndpoint;
-use crate::{Stack, TryError};
+use crate::{Full, Stack, TryError};
 
 /// Error returned by [`UdpSocket::bind`].
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -70,18 +70,13 @@ pub struct UdpSocket<'d> {
 impl<'d> UdpSocket<'d> {
     /// Create a new UDP socket using the provided stack.
     ///
-    /// # Panics
-    /// Panics if the stack has no room for another UDP socket. The limit is set
-    /// by the `udp-socket-count-N` feature of `xarxa`.
-    pub fn new(stack: Stack<'d>) -> Self {
-        let handle = stack.with(|i| {
-            unwrap!(
-                i.stack.add_udp_socket().ok(),
-                "too many UDP sockets, raise the `udp-socket-count-N` feature of xarxa"
-            )
-        });
+    /// Errors:
+    /// - `Full` if the stack has no room for another UDP socket. The limit is set
+    ///   by the `udp-socket-count-N` feature of `xarxa`.
+    pub fn new(stack: Stack<'d>) -> Result<Self, Full> {
+        let handle = stack.with(|i| i.stack.add_udp_socket())?;
 
-        Self { stack, handle }
+        Ok(Self { stack, handle })
     }
 
     /// Bind the socket to a local endpoint.

--- a/embassy-stm32-wpan/Cargo.toml
+++ b/embassy-stm32-wpan/Cargo.toml
@@ -35,7 +35,7 @@ embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal" }
 embassy-net-driver-channel = { version = "0.4.0", path = "../embassy-net-driver-channel", optional=true}
 stm32-bindings = { version = "0.2.2", optional=true, default-features = false }
 
-xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", optional = true, default-features = false }
+xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", optional = true, default-features = false }
 
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.17", optional = true }

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -163,7 +163,7 @@ embassy-time-queue-utils = { version = "0.3.2", path = "../embassy-time-queue-ut
 embassy-futures = { version = "0.1.2", path = "../embassy-futures" }
 embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", features = ["cortex-m", "prio-bits-4"] }
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
-xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", features = ["async", "packet-buf-align-8"] }
+xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", features = ["async", "packet-buf-align-8"] }
 embassy-crypto-driver = { version = "0.1.0", path = "../embassy-crypto-driver" }
 embassy-ptp-driver = { version = "0.1.0", path = "../embassy-ptp-driver", optional = true }
 embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }

--- a/examples/ambiq/sparkfun-artemis/Cargo.toml
+++ b/examples/ambiq/sparkfun-artemis/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabihf", artifact-dir = "out/examples/ambiq" }
+  { target = "thumbv7em-none-eabihf", artifact-dir = "out/examples/ambiq/sparkfun-artemis" }
 ]
 
 [dependencies]

--- a/examples/boot/application/nrf/Cargo.toml
+++ b/examples/boot/application/nrf/Cargo.toml
@@ -37,10 +37,10 @@ nrf54 = ["embassy-nrf/time-driver-grtc"]
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["embassy-nrf/nrf52840", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/nrf52840" },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9160-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/nrf9160" },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9120-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/nrf9120" },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9151-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/nrf9151" },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9161-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/nrf9161" },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf54l15-app-s", "nrf54", "skip-include"], artifact-dir = "out/examples/boot/nrf54l15" }
+  { target = "thumbv7em-none-eabi", features = ["embassy-nrf/nrf52840", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/application/nrf/nrf52840" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9160-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/application/nrf/nrf9160" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9120-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/application/nrf/nrf9120" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9151-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/application/nrf/nrf9151" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9161-ns", "embassy-nrf/time-driver-rtc1", "skip-include"], artifact-dir = "out/examples/boot/application/nrf/nrf9161" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf54l15-app-s", "nrf54", "skip-include"], artifact-dir = "out/examples/boot/application/nrf/nrf54l15" }
 ]

--- a/examples/boot/application/rp/Cargo.toml
+++ b/examples/boot/application/rp/Cargo.toml
@@ -38,5 +38,5 @@ debug = true
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv6m-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/rp" }
+  { target = "thumbv6m-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/rp" }
 ]

--- a/examples/boot/application/rp235x/Cargo.toml
+++ b/examples/boot/application/rp235x/Cargo.toml
@@ -38,5 +38,5 @@ debug = true
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv8m.main-none-eabihf", features = ["skip-include"], artifact-dir = "out/examples/boot/rp235x" }
+  { target = "thumbv8m.main-none-eabihf", features = ["skip-include"], artifact-dir = "out/examples/boot/application/rp235x" }
 ]

--- a/examples/boot/application/stm32f3/Cargo.toml
+++ b/examples/boot/application/stm32f3/Cargo.toml
@@ -33,5 +33,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32f3" }
+  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32f3" }
 ]

--- a/examples/boot/application/stm32f7/Cargo.toml
+++ b/examples/boot/application/stm32f7/Cargo.toml
@@ -34,5 +34,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32f7" }
+  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32f7" }
 ]

--- a/examples/boot/application/stm32h7/Cargo.toml
+++ b/examples/boot/application/stm32h7/Cargo.toml
@@ -34,5 +34,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32h7" }
+  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32h7" }
 ]

--- a/examples/boot/application/stm32l0/Cargo.toml
+++ b/examples/boot/application/stm32l0/Cargo.toml
@@ -33,5 +33,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv6m-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32l0" }
+  { target = "thumbv6m-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32l0" }
 ]

--- a/examples/boot/application/stm32l1/Cargo.toml
+++ b/examples/boot/application/stm32l1/Cargo.toml
@@ -33,5 +33,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7m-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32l1" }
+  { target = "thumbv7m-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32l1" }
 ]

--- a/examples/boot/application/stm32l4/Cargo.toml
+++ b/examples/boot/application/stm32l4/Cargo.toml
@@ -33,5 +33,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32l4" }
+  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32l4" }
 ]

--- a/examples/boot/application/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/application/stm32wb-dfu/Cargo.toml
@@ -35,5 +35,5 @@ defmt = [
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", artifact-dir = "out/examples/boot/stm32wb-dfu" }
+  { target = "thumbv7em-none-eabi", artifact-dir = "out/examples/boot/application/stm32wb-dfu" }
 ]

--- a/examples/boot/application/stm32wba-dfu/Cargo.toml
+++ b/examples/boot/application/stm32wba-dfu/Cargo.toml
@@ -35,5 +35,5 @@ defmt = [
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/boot/stm32wba-dfu" }
+  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/boot/application/stm32wba-dfu" }
 ]

--- a/examples/boot/application/stm32wl/Cargo.toml
+++ b/examples/boot/application/stm32wl/Cargo.toml
@@ -33,5 +33,5 @@ skip-include = []
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/stm32wl" }
+  { target = "thumbv7em-none-eabi", features = ["skip-include"], artifact-dir = "out/examples/boot/application/stm32wl" }
 ]

--- a/examples/boot/bootloader/nrf/Cargo.toml
+++ b/examples/boot/bootloader/nrf/Cargo.toml
@@ -62,10 +62,10 @@ overflow-checks = false
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["embassy-nrf/nrf52840"] },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9160-ns"] },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9120-ns"] },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9151-ns"] },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9161-ns"] },
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf54l15-app-s", "nrf54"] }
+  { target = "thumbv7em-none-eabi", features = ["embassy-nrf/nrf52840"], artifact-dir = "out/examples/boot/bootloader/nrf/nrf52840" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9160-ns"], artifact-dir = "out/examples/boot/bootloader/nrf/nrf9160" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9120-ns"], artifact-dir = "out/examples/boot/bootloader/nrf/nrf9120" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9151-ns"], artifact-dir = "out/examples/boot/bootloader/nrf/nrf9151" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf9161-ns"], artifact-dir = "out/examples/boot/bootloader/nrf/nrf9161" },
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-nrf/nrf54l15-app-s", "nrf54"], artifact-dir = "out/examples/boot/bootloader/nrf/nrf54l15" }
 ]

--- a/examples/boot/bootloader/rp/Cargo.toml
+++ b/examples/boot/bootloader/rp/Cargo.toml
@@ -35,5 +35,5 @@ opt-level = 's'
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv6m-none-eabi" }
+  { target = "thumbv6m-none-eabi", artifact-dir = "out/examples/boot/bootloader/rp" }
 ]

--- a/examples/boot/bootloader/rp235x/Cargo.toml
+++ b/examples/boot/bootloader/rp235x/Cargo.toml
@@ -35,5 +35,5 @@ opt-level = 's'
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv8m.main-none-eabihf" }
+  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/boot/bootloader/rp235x" }
 ]

--- a/examples/boot/bootloader/stm32-dual-bank/Cargo.toml
+++ b/examples/boot/bootloader/stm32-dual-bank/Cargo.toml
@@ -58,5 +58,5 @@ overflow-checks = false
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32h743zi"] }
+  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32h743zi"], artifact-dir = "out/examples/boot/bootloader/stm32-dual-bank" }
 ]

--- a/examples/boot/bootloader/stm32/Cargo.toml
+++ b/examples/boot/bootloader/stm32/Cargo.toml
@@ -60,5 +60,5 @@ overflow-checks = false
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32l496zg"] }
+  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32l496zg"], artifact-dir = "out/examples/boot/bootloader/stm32" }
 ]

--- a/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
+++ b/examples/boot/bootloader/stm32wb-dfu/Cargo.toml
@@ -66,6 +66,6 @@ overflow-checks = false
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32wb55rg"] },
-  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32wb55rg", "verify"] }
+  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32wb55rg"], artifact-dir = "out/examples/boot/bootloader/stm32wb-dfu/plain" },
+  { target = "thumbv7em-none-eabi", features = ["embassy-stm32/stm32wb55rg", "verify"], artifact-dir = "out/examples/boot/bootloader/stm32wb-dfu/verify" }
 ]

--- a/examples/boot/bootloader/stm32wba-dfu/Cargo.toml
+++ b/examples/boot/bootloader/stm32wba-dfu/Cargo.toml
@@ -66,5 +66,5 @@ overflow-checks = false
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv8m.main-none-eabihf", features = ["embassy-stm32/stm32wba65ri", "verify"] }
+  { target = "thumbv8m.main-none-eabihf", features = ["embassy-stm32/stm32wba65ri", "verify"], artifact-dir = "out/examples/boot/bootloader/stm32wba-dfu" }
 ]

--- a/examples/nrf52840/src/bin/ethernet_enc28j60.rs
+++ b/examples/nrf52840/src/bin/ethernet_enc28j60.rs
@@ -62,7 +62,7 @@ async fn main(spawner: Spawner) {
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Enc28j60<ExclusiveDevice<Spim<'static>, Output<'static>, Delay>, Output<'static>>> =
         StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -73,7 +73,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/nrf52840/src/bin/sixlowpan.rs
+++ b/examples/nrf52840/src/bin/sixlowpan.rs
@@ -63,14 +63,14 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<net::Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     unwrap!(iface.add_ip_addr(IpCidr::Ipv6(Ipv6Cidr::new(local, 64))));
 
     spawner.spawn(unwrap!(net_task(runner)));
 
     let mut delay = Delay;
     loop {
-        let mut socket = UdpSocket::new(stack);
+        let mut socket = unwrap!(UdpSocket::new(stack));
         socket
             .bind(IpListenEndpoint {
                 addr: Some(IpAddress::Ipv6(local)),

--- a/examples/nrf52840/src/bin/usb_ethernet.rs
+++ b/examples/nrf52840/src/bin/usb_ethernet.rs
@@ -105,7 +105,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -116,7 +116,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -87,7 +87,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<hosted::NetDriver<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/nrf54l15-app/Cargo.toml
+++ b/examples/nrf54l15-app/Cargo.toml
@@ -34,5 +34,5 @@ debug = 2
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/nrf54l15" }
+  { target = "thumbv8m.main-none-eabihf", artifact-dir = "out/examples/nrf54l15-app" }
 ]

--- a/examples/nrf54l15-flpr/Cargo.toml
+++ b/examples/nrf54l15-flpr/Cargo.toml
@@ -16,5 +16,5 @@ riscv-rt = { version = "0.17.1", features = ["single-hart"] }
 
 [package.metadata.embassy]
 build = [
-    {group = "nightly", target = "riscv32emc-unknown-none-elf", "build-std" = ["core", "compiler_builtins"]}
+    {group = "nightly", target = "riscv32emc-unknown-none-elf", "build-std" = ["core", "compiler_builtins"], artifact-dir = "out/examples/nrf54l15-flpr"}
 ]

--- a/examples/nrf9160/src/bin/modem_tcp_client.rs
+++ b/examples/nrf9160/src/bin/modem_tcp_client.rs
@@ -147,7 +147,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<embassy_net_nrf91::NetDriver<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
 
     spawner.spawn(unwrap!(net_task(runner)));
 
@@ -170,7 +170,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     loop {
-        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
         socket.set_timeout(Some(Duration::from_secs(10)));
 
         info!("Connecting...");

--- a/examples/qemu-virt-riscv64/Cargo.toml
+++ b/examples/qemu-virt-riscv64/Cargo.toml
@@ -24,6 +24,6 @@ panic = "abort"
 
 [package.metadata.embassy]
 build = [
-  { target = "riscv64imac-unknown-none-elf", artifact-dir = "out/examples/qemu-virt-riscv64imac" },
-  { target = "riscv64gc-unknown-none-elf",   artifact-dir = "out/examples/qemu-virt-riscv64gc" },
+  { target = "riscv64imac-unknown-none-elf", artifact-dir = "out/examples/qemu-virt-riscv64/imac" },
+  { target = "riscv64gc-unknown-none-elf",   artifact-dir = "out/examples/qemu-virt-riscv64/gc" },
 ]

--- a/examples/rp/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_icmp.rs
@@ -78,7 +78,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -91,7 +91,7 @@ async fn main(spawner: Spawner) {
     info!("IP address: {:?}", local_addr);
 
     // Then we can use it! A raw socket receives whole IPv4 packets carrying ICMP.
-    let socket = RawSocket::new(stack, Some(IpVersion::Ipv4), Some(IpProtocol::Icmp));
+    let socket = unwrap!(RawSocket::new(stack, Some(IpVersion::Ipv4), Some(IpProtocol::Icmp)));
 
     // Identifier used to recognize our own echo replies.
     let ident = 42;
@@ -102,7 +102,7 @@ async fn main(spawner: Spawner) {
     let gateway = unwrap!(lease.router);
     let mut buf = [0u8; 64];
     {
-        let mut ip = unwrap!(Ipv4Packet::new_checked(&mut buf[..total_len]).ok());
+        let mut ip = unwrap!(Ipv4Packet::new_checked(&mut buf[..total_len]));
         ip.set_version(4);
         ip.set_header_len(IPV4_HEADER_LEN as u8);
         ip.set_dscp(0);
@@ -118,7 +118,7 @@ async fn main(spawner: Spawner) {
         ip.set_dst_addr(gateway);
         ip.fill_checksum();
 
-        let mut icmp = unwrap!(Icmpv4Packet::new_checked(ip.payload_mut()).ok());
+        let mut icmp = unwrap!(Icmpv4Packet::new_checked(ip.payload_mut()));
         icmp.set_msg_type(Icmpv4Message::EchoRequest);
         icmp.set_msg_code(0);
         icmp.set_echo_ident(ident);

--- a/examples/rp/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp/src/bin/ethernet_w5500_multisocket.rs
@@ -81,7 +81,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -103,7 +103,7 @@ async fn listen_task(stack: Stack<'static>, id: u8, port: u16) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(port));
 
     loop {

--- a/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_client.rs
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     loop {
-        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
         socket.set_timeout(Some(Duration::from_secs(10)));
 
         led.set_low();

--- a/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w5500_tcp_server.rs
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/rp/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp/src/bin/ethernet_w5500_udp.rs
@@ -80,7 +80,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -95,7 +95,7 @@ async fn main(spawner: Spawner) {
     // Then we can use it!
     let mut buf = [0; 4096];
     loop {
-        let mut socket = UdpSocket::new(stack);
+        let mut socket = unwrap!(UdpSocket::new(stack));
         socket.bind(1234).unwrap();
 
         loop {

--- a/examples/rp/src/bin/ethernet_w55rp20_tcp_server.rs
+++ b/examples/rp/src/bin/ethernet_w55rp20_tcp_server.rs
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -113,7 +113,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/rp/src/bin/usb_ethernet.rs
+++ b/examples/rp/src/bin/usb_ethernet.rs
@@ -100,7 +100,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -111,7 +111,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/rp/src/bin/wifi_ap_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_ap_tcp_server.rs
@@ -95,7 +95,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<cyw43::NetDriver<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)));
     // Static address, we're the access point.
     unwrap!(iface.add_ip_addr(IpCidr::new(Ipv4Address::new(169, 254, 1, 1).into(), 16)));
 
@@ -112,7 +112,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/rp/src/bin/wifi_tcp_server.rs
+++ b/examples/rp/src/bin/wifi_tcp_server.rs
@@ -96,7 +96,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<cyw43::NetDriver<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -121,7 +121,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/rp/src/bin/wifi_webrequest.rs
+++ b/examples/rp/src/bin/wifi_webrequest.rs
@@ -100,7 +100,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<cyw43::NetDriver<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));

--- a/examples/rp235x/src/bin/ethernet_w5500_icmp.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_icmp.rs
@@ -78,7 +78,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -91,7 +91,7 @@ async fn main(spawner: Spawner) {
     info!("IP address: {:?}", local_addr);
 
     // Then we can use it! A raw socket receives whole IPv4 packets carrying ICMP.
-    let socket = RawSocket::new(stack, Some(IpVersion::Ipv4), Some(IpProtocol::Icmp));
+    let socket = unwrap!(RawSocket::new(stack, Some(IpVersion::Ipv4), Some(IpProtocol::Icmp)));
 
     // Identifier used to recognize our own echo replies.
     let ident = 42;
@@ -102,7 +102,7 @@ async fn main(spawner: Spawner) {
     let gateway = unwrap!(lease.router);
     let mut buf = [0u8; 64];
     {
-        let mut ip = unwrap!(Ipv4Packet::new_checked(&mut buf[..total_len]).ok());
+        let mut ip = unwrap!(Ipv4Packet::new_checked(&mut buf[..total_len]));
         ip.set_version(4);
         ip.set_header_len(IPV4_HEADER_LEN as u8);
         ip.set_dscp(0);
@@ -118,7 +118,7 @@ async fn main(spawner: Spawner) {
         ip.set_dst_addr(gateway);
         ip.fill_checksum();
 
-        let mut icmp = unwrap!(Icmpv4Packet::new_checked(ip.payload_mut()).ok());
+        let mut icmp = unwrap!(Icmpv4Packet::new_checked(ip.payload_mut()));
         icmp.set_msg_type(Icmpv4Message::EchoRequest);
         icmp.set_msg_code(0);
         icmp.set_echo_ident(ident);

--- a/examples/rp235x/src/bin/ethernet_w5500_multisocket.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_multisocket.rs
@@ -81,7 +81,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -103,7 +103,7 @@ async fn listen_task(stack: Stack<'static>, id: u8, port: u16) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(port));
 
     loop {

--- a/examples/rp235x/src/bin/ethernet_w5500_tcp_client.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_tcp_client.rs
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     loop {
-        let mut socket = embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(embassy_net::tcp::TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
         socket.set_timeout(Some(Duration::from_secs(10)));
 
         led.set_low();

--- a/examples/rp235x/src/bin/ethernet_w5500_tcp_server.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_tcp_server.rs
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -98,7 +98,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/rp235x/src/bin/ethernet_w5500_udp.rs
+++ b/examples/rp235x/src/bin/ethernet_w5500_udp.rs
@@ -80,7 +80,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -95,7 +95,7 @@ async fn main(spawner: Spawner) {
     // Then we can use it!
     let mut buf = [0; 4096];
     loop {
-        let mut socket = UdpSocket::new(stack);
+        let mut socket = unwrap!(UdpSocket::new(stack));
         socket.bind(1234).unwrap();
 
         loop {

--- a/examples/rp235x/src/bin/ethernet_w6300_udp.rs
+++ b/examples/rp235x/src/bin/ethernet_w6300_udp.rs
@@ -90,7 +90,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -105,7 +105,7 @@ async fn main(spawner: Spawner) {
     // Then we can use it!
     let mut buf = [0; 4096];
     loop {
-        let mut socket = UdpSocket::new(stack);
+        let mut socket = unwrap!(UdpSocket::new(stack));
         socket.bind(1234).unwrap();
 
         loop {

--- a/examples/std/src/bin/net.rs
+++ b/examples/std/src/bin/net.rs
@@ -67,7 +67,7 @@ async fn main_task(spawner: Spawner) {
     // Then we can use it!
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
-    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer).unwrap();
 
     socket.set_timeout(Some(Duration::from_secs(10)));
 

--- a/examples/std/src/bin/net_ppp.rs
+++ b/examples/std/src/bin/net_ppp.rs
@@ -109,7 +109,7 @@ async fn main_task(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = TcpListener::new(stack).unwrap();
     listener.listen(1234).unwrap();
 
     loop {

--- a/examples/std/src/bin/net_udp.rs
+++ b/examples/std/src/bin/net_udp.rs
@@ -63,7 +63,7 @@ async fn main_task(spawner: Spawner) {
     // Then we can use it!
     let mut buf = [0; 4096];
 
-    let mut socket = UdpSocket::new(stack);
+    let mut socket = UdpSocket::new(stack).unwrap();
     socket.bind(9400).unwrap();
 
     loop {

--- a/examples/std/src/bin/tcp_accept.rs
+++ b/examples/std/src/bin/tcp_accept.rs
@@ -66,7 +66,7 @@ async fn main_task(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = TcpListener::new(stack).unwrap();
     listener.listen(9999).unwrap();
 
     loop {

--- a/examples/stm32c5/src/bin/eth.rs
+++ b/examples/stm32c5/src/bin/eth.rs
@@ -78,7 +78,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -94,7 +94,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 1024];
 
     loop {
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32f072/Cargo.toml
+++ b/examples/stm32f072/Cargo.toml
@@ -26,5 +26,5 @@ debug = 2
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv6m-none-eabi", artifact-dir = "out/examples/stm32f0" }
+  { target = "thumbv6m-none-eabi", artifact-dir = "out/examples/stm32f072" }
 ]

--- a/examples/stm32f107/src/bin/eth.rs
+++ b/examples/stm32f107/src/bin/eth.rs
@@ -73,7 +73,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
     spawner.spawn(unwrap!(net_task(runner)));
     iface.wait_config_up().await;
@@ -83,7 +83,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut rx_buffer = [0; 1024];
     let mut tx_buffer = [0; 1024];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(IpListenEndpoint { addr: None, port: 80 }));
 
     loop {

--- a/examples/stm32f4/src/bin/eth.rs
+++ b/examples/stm32f4/src/bin/eth.rs
@@ -87,7 +87,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -103,7 +103,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 4096];
 
     loop {
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32f4/src/bin/eth_w5500.rs
+++ b/examples/stm32f4/src/bin/eth_w5500.rs
@@ -96,7 +96,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -112,7 +112,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 1024];
 
     loop {
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32f4/src/bin/usb_ethernet.rs
+++ b/examples/stm32f4/src/bin/usb_ethernet.rs
@@ -137,7 +137,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -148,7 +148,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/stm32f7/src/bin/eth.rs
+++ b/examples/stm32f7/src/bin/eth.rs
@@ -87,7 +87,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -103,7 +103,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 4096];
 
     loop {
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32h5/src/bin/eth.rs
+++ b/examples/stm32h5/src/bin/eth.rs
@@ -90,7 +90,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -106,7 +106,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 1024];
 
     loop {
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32h7/src/bin/eth.rs
+++ b/examples/stm32h7/src/bin/eth.rs
@@ -90,7 +90,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task
@@ -106,7 +106,7 @@ async fn main(spawner: Spawner) -> ! {
     let mut tx_buffer = [0; 1024];
 
     loop {
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
 
         socket.set_timeout(Some(embassy_time::Duration::from_secs(10)));
 

--- a/examples/stm32h7/src/bin/eth_client.rs
+++ b/examples/stm32h7/src/bin/eth_client.rs
@@ -91,7 +91,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task

--- a/examples/stm32h7/src/bin/eth_client_mii.rs
+++ b/examples/stm32h7/src/bin/eth_client_mii.rs
@@ -97,7 +97,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     // Launch network task

--- a/examples/stm32h7rs/src/bin/eth.rs
+++ b/examples/stm32h7rs/src/bin/eth.rs
@@ -89,7 +89,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     unwrap!(iface.add_ip_addr(IpCidr::new(Ipv4Address::new(10, 42, 0, 61).into(), 24)));
     unwrap!(
         stack
@@ -108,7 +108,7 @@ async fn main(spawner: Spawner) -> ! {
     // Then we can use it!
 
     let remote_endpoint = (Ipv4Address::new(10, 42, 0, 1), 8000);
-    let socket = UdpSocket::new(stack);
+    let socket = unwrap!(UdpSocket::new(stack));
     loop {
         // You need to start a server on the host machine, for example: `nc -lu 8000`
         socket

--- a/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
+++ b/examples/stm32l4/src/bin/spe_adin1110_http_server.rs
@@ -206,7 +206,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     if uc_cfg0.is_low() {
         println!("Waiting for DHCP...");
         iface.set_dhcpv4(Some(Default::default()));
@@ -224,7 +224,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut mb_buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(HTTP_LISTEN_PORT));
 
     loop {

--- a/examples/stm32l5/src/bin/usb_ethernet.rs
+++ b/examples/stm32l5/src/bin/usb_ethernet.rs
@@ -113,7 +113,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));
@@ -124,7 +124,7 @@ async fn main(spawner: Spawner) {
     let mut tx_buffer = [0; 4096];
     let mut buf = [0; 4096];
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(1234));
 
     loop {

--- a/examples/stm32n6/src/bin/eth_speedtest.rs
+++ b/examples/stm32n6/src/bin/eth_speedtest.rs
@@ -241,7 +241,7 @@ async fn main(spawner: Spawner) -> ! {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     unwrap!(iface.add_ip_addr(IpCidr::Ipv4(Ipv4Cidr::new(LOCAL_IP, 24))));
     unwrap!(stack.routes().add_default_ipv4_route(GATEWAY, iface.handle()));
 
@@ -258,7 +258,7 @@ async fn main(spawner: Spawner) -> ! {
     let rx_buf = RX_BUF.init([0; TCP_BUFFER_SIZE]);
     let tx_buf = TX_BUF.init([0; TCP_BUFFER_SIZE]);
 
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(PORT));
 
     loop {

--- a/examples/stm32u575/src/bin/spe_adin2111_http_server.rs
+++ b/examples/stm32u575/src/bin/spe_adin2111_http_server.rs
@@ -246,7 +246,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     unwrap!(iface.add_ip_addr(IpCidr::Ipv6(ip_address)));
 
     // Launch network task
@@ -263,7 +263,7 @@ async fn main(spawner: Spawner) {
     let mut rx_buffer = [0; 4096];
     let mut tx_buffer = [0; 4096];
     let mut mb_buf = [0; 4096];
-    let mut listener = TcpListener::new(stack);
+    let mut listener = unwrap!(TcpListener::new(stack));
     unwrap!(listener.listen(HTTP_LISTEN_PORT));
 
     loop {
@@ -377,7 +377,7 @@ async fn discovery_task(iface: Iface<'static>, my_node_id: u64) -> ! {
         error!("Discovery: could not join {}: {:?}", DISCOVERY_GROUP, e);
     }
 
-    let mut socket = UdpSocket::new(stack);
+    let mut socket = unwrap!(UdpSocket::new(stack));
     unwrap!(socket.bind(DISCOVERY_PORT));
 
     let group = IpEndpoint::new(IpAddress::Ipv6(DISCOVERY_GROUP), DISCOVERY_PORT);
@@ -459,7 +459,7 @@ async fn neighbor_fetch_task(stack: Stack<'static>) -> ! {
         let remote = IpEndpoint::new(IpAddress::Ipv6(neighbor_ip), HTTP_LISTEN_PORT);
 
         let started = embassy_time::Instant::now();
-        let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+        let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
         socket.set_timeout(Some(NEIGHBOR_FETCH_TIMEOUT));
 
         info!("Fetch #{}: connecting to {}...", seq, remote);

--- a/examples/stm32wb/src/bin/mac_ffd_net.rs
+++ b/examples/stm32wb/src/bin/mac_ffd_net.rs
@@ -113,7 +113,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(driver)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(driver)));
     unwrap!(iface.add_ip_addr(IpCidr::Ipv6(Ipv6Cidr::new(ipv6_addr, 104))));
 
     // wpan runner
@@ -137,7 +137,7 @@ async fn main(spawner: Spawner) {
 
     // Then we can use it!
 
-    let mut socket = UdpSocket::new(stack);
+    let mut socket = unwrap!(UdpSocket::new(stack));
 
     let remote_endpoint = (Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0xc00a, 0x2fb), 8000);
 

--- a/examples/stm32wl55cm4/Cargo.toml
+++ b/examples/stm32wl55cm4/Cargo.toml
@@ -65,5 +65,5 @@ overflow-checks = false # <-
 
 [package.metadata.embassy]
 build = [
-  { target = "thumbv7em-none-eabi", artifact-dir = "out/examples/stm32h755cm4" }
+  { target = "thumbv7em-none-eabi", artifact-dir = "out/examples/stm32wl55cm4" }
 ]

--- a/tests/nrf/Cargo.toml
+++ b/tests/nrf/Cargo.toml
@@ -18,7 +18,7 @@ embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defm
 embassy-net-esp-hosted = { version = "0.3.0", path = "../../embassy-net-esp-hosted", features = ["defmt", "esp-hosted-fg"] }
 embassy-net-enc28j60 = { version = "0.3.0", path = "../../embassy-net-enc28j60", features = ["defmt"] }
 # Shrink the packet pool: the tests link everything into RAM, and the default 16 buffers don't fit.
-xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", features = ["packet-buf-count-8"] }
+xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", features = ["packet-buf-count-8"] }
 embedded-hal-async = { version = "1.0" }
 embedded-hal-bus = { version = "0.1", features = ["async"] }
 static_cell = "2"

--- a/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
+++ b/tests/nrf/src/bin/ethernet_enc28j60_perf.rs
@@ -64,7 +64,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<MyDriver> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -92,7 +92,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<MyDriver> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));

--- a/tests/perf-client/src/lib.rs
+++ b/tests/perf-client/src/lib.rs
@@ -43,7 +43,7 @@ async fn test_download(stack: Stack<'_>) -> usize {
 
     let mut rx_buffer = [0; RX_BUFFER_SIZE];
     let mut tx_buffer = [0; TX_BUFFER_SIZE];
-    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
     socket.set_timeout(Some(Duration::from_secs(10)));
 
     info!("connecting to {:?}:{}...", SERVER_ADDRESS, DOWNLOAD_PORT);
@@ -83,7 +83,7 @@ async fn test_upload(stack: Stack<'_>) -> usize {
 
     let mut rx_buffer = [0; RX_BUFFER_SIZE];
     let mut tx_buffer = [0; TX_BUFFER_SIZE];
-    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
     socket.set_timeout(Some(Duration::from_secs(10)));
 
     info!("connecting to {:?}:{}...", SERVER_ADDRESS, UPLOAD_PORT);
@@ -123,7 +123,7 @@ async fn test_upload_download(stack: Stack<'_>) -> usize {
 
     let mut rx_buffer = [0; RX_BUFFER_SIZE];
     let mut tx_buffer = [0; TX_BUFFER_SIZE];
-    let mut socket = TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer);
+    let mut socket = unwrap!(TcpSocket::new(stack, &mut rx_buffer, &mut tx_buffer));
     socket.set_timeout(Some(Duration::from_secs(10)));
 
     info!("connecting to {:?}:{}...", SERVER_ADDRESS, UPLOAD_DOWNLOAD_PORT);

--- a/tests/rp/src/bin/cyw43-perf.rs
+++ b/tests/rp/src/bin/cyw43-perf.rs
@@ -94,7 +94,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<cyw43::NetDriver<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(net_device)));
     iface.set_dhcpv4(Some(Default::default()));
 
     spawner.spawn(unwrap!(net_task(runner)));

--- a/tests/rp/src/bin/ethernet_w5100s_perf.rs
+++ b/tests/rp/src/bin/ethernet_w5100s_perf.rs
@@ -77,7 +77,7 @@ async fn main(spawner: Spawner) {
 
     // Add the network interface to the stack.
     static DEVICE: StaticCell<Device<'static>> = StaticCell::new();
-    let iface = unwrap!(stack.add_iface(DEVICE.init(device)).ok());
+    let iface = unwrap!(stack.add_iface(DEVICE.init(device)));
     // Get an address over DHCP.
     iface.set_dhcpv4(Some(Default::default()));
 

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -84,8 +84,8 @@ embassy-futures = { version = "0.1.2", path = "../../embassy-futures" }
 embassy-stm32-wpan = { version = "0.1.0", path = "../../embassy-stm32-wpan", optional = true, features = ["defmt"] }
 embassy-net = { version = "0.9.1", path = "../../embassy-net", features = ["defmt",  "tcp", "udp", "dhcpv4", "medium-ethernet"] }
 perf-client = { path = "../perf-client" }
-xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488", default-features = false }
-xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "8e3d55c1c8351ee7728a0cbe3a504a4223c81488" }
+xarxa = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47", default-features = false }
+xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "5923ce43a5540e07b887646e2627ddc0a29c5b47" }
 
 defmt = "1.1.1"
 defmt-rtt = "1.3.0"

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -103,7 +103,7 @@ async fn main(spawner: Spawner) {
 
     // Add the ethernet interface to the stack.
     static ETH: StaticCell<Device> = StaticCell::new();
-    let eth = unwrap!(stack.add_iface(ETH.init(device)).ok());
+    let eth = unwrap!(stack.add_iface(ETH.init(device)));
 
     // Get an address over DHCP.
     eth.set_dhcpv4(Some(Default::default()));


### PR DESCRIPTION
- **build: make sure artifact-dir always matches with the example dir name.**
- **net: return error instead of panicking if socket/listener/iface slab is full.**
- **net: update xarxa**
