### PR TITLE
usb-host: add get_string_descriptor so a STRING request can carry a LANGID

### DIFF
--- a/embassy-usb-host/src/control.rs
+++ b/embassy-usb-host/src/control.rs
@@ -203,6 +203,31 @@ impl SetupPacket {
         Self::get_descriptor(false, descriptor_type::CONFIGURATION, index, max_len)
     }
 
+    /// Build a GET_DESCRIPTOR(String) SETUP packet.
+    ///
+    /// String descriptors are the one case where `wIndex` is not unused: USB 2.0
+    /// spec §9.4.3 defines it as the LANGID, so it cannot go through
+    /// [`SetupPacket::get_descriptor`], which always sends zero there.
+    ///
+    /// Index 0 returns the device's supported LANGIDs (see
+    /// [`StringDescriptorZero`]) and is the one request for which `lang_id: 0`
+    /// is correct. Any other index needs a LANGID the device listed there.
+    ///
+    /// [`StringDescriptorZero`]: crate::descriptor::StringDescriptorZero
+    pub const fn get_string_descriptor(index: u8, lang_id: u16, max_len: u16) -> Self {
+        Self {
+            request_type: RequestType {
+                direction: Direction::In,
+                control_type: ControlType::Standard,
+                recipient: Recipient::Device,
+            },
+            request: Request::GET_DESCRIPTOR,
+            value: ((descriptor_type::STRING as u16) << 8) | index as u16,
+            index: lang_id,
+            length: max_len,
+        }
+    }
+
     /// Build a standard GET_DESCRIPTOR SETUP packet delivered to an Interface recipient.
     ///
     /// Used for interface-owned descriptors such as the HID Report Descriptor.


### PR DESCRIPTION
`SetupPacket::get_descriptor` (`embassy-usb-host/src/control.rs:178`) hardcodes `index: 0` for the SETUP packet's `wIndex`, whatever its own `index: u8` parameter is — that one goes into `wValue` as the descriptor index. Correct for DEVICE and CONFIGURATION, where `wIndex` is unused, but USB 2.0 §9.4.3 defines `wIndex` as the LANGID for `GET_DESCRIPTOR(STRING)`, so there's currently no way to build a conformant request for a string index other than 0.

```
SetupPacket::get_descriptor(false, descriptor_type::STRING, 1, 255).to_bytes()
// [80, 06, 01, 03, 00, 00, FF, 00]
//                   wIndex ^^^^^^ always 0, never a LANGID
```

`request_descriptor` and `request_descriptor_bytes` both build through `get_descriptor`, so they inherit it. Nothing in-tree asks for a string descriptor today, so nothing is broken — but #6110 added `StringDescriptorZero`/`StringDescriptor` and the `lang_id` module to model exactly this data, so the parsing side is there and the request side isn't.

This adds `get_string_descriptor(index, lang_id, max_len)` beside `get_descriptor`, mirroring how `get_interface_descriptor` already sits there to give the Interface-recipient case its own `wIndex`-carrying signature. No existing caller changes.

I hit this reading a printer's serial number, and worked around it by hand-building the packet — easy, since the fields are public, so this is a papercut rather than a blocker. I haven't surveyed how widely devices tolerate a zero LANGID; ours didn't fail hard. The request is non-conformant either way.

Happy to close this for a different shape. Adding a `lang_id` parameter to `get_descriptor` was the alternative, but it makes four existing call sites pass an always-zero argument. A `ControlPipeExt::request_string_descriptor` could sit on top of this later; left out to keep the change small.

I checked the emitted bytes but haven't run nightly rustfmt here, so I'll watch CI.

Thanks for the crate — the enumeration path handles a lot of awkward cases carefully.
