### PR TITLE
fix(embassy-usb-host): Usb host descriptor fixes, remove default-features from embassy-usb dependency

### DIFF
--- a/embassy-usb-host/Cargo.toml
+++ b/embassy-usb-host/Cargo.toml
@@ -19,7 +19,7 @@ target = "thumbv7em-none-eabi"
 features = ["defmt"]
 
 [dependencies]
-embassy-usb = { version = "0.6.0", path = "../embassy-usb" }
+embassy-usb = { version = "0.6.0", path = "../embassy-usb", default-features = false }
 embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-sync = { version = "0.8.0", path = "../embassy-sync" }
 embassy-time = { version = "0.5.1", path = "../embassy-time" }

--- a/embassy-usb-host/src/class/hid.rs
+++ b/embassy-usb-host/src/class/hid.rs
@@ -177,8 +177,8 @@ pub fn find_hid(config_desc: &[u8]) -> Option<HidInfo> {
         let report_desc_len = iface
             .iter_descriptors()
             .find_map(|(_, data)| {
-                if data.len() >= 7 && data[1] == DESC_HID {
-                    Some(u16::from_le_bytes([data[5], data[6]]))
+                if data.len() >= 9 && data[1] == DESC_HID {
+                    Some(u16::from_le_bytes([data[7], data[8]]))
                 } else {
                     None
                 }
@@ -381,5 +381,25 @@ impl<'d, A: UsbHostAllocator<'d>> HidHost<'d, A> {
         let setup = SetupPacket::class_interface_out(SET_REPORT, value, self.interface as u16, buf.len() as u16);
         self.ctrl_ch.control_out(&setup.to_bytes(), buf).await?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// A real HID class descriptor, whose report length (0x0034) sits at bytes 7-8.
+    const HID_CONFIG: [u8; 34] = [
+        9, 2, 34, 0, 1, 1, 0, 0x80, 50, // configuration
+        9, 4, 0, 0, 1, 0x03, 0x01, 0x01, 0, // interface, HID boot keyboard
+        9, 0x21, 0x11, 0x01, 0, 1, 0x22, 0x34, 0x00, // HID, report descriptor is 52 bytes
+        7, 5, 0x81, 0x03, 8, 0, 10, // endpoint, interrupt IN
+    ];
+
+    #[test]
+    fn reads_report_descriptor_length() {
+        let info = find_hid(&HID_CONFIG).expect("HID interface is found");
+        assert_eq!(info.report_descriptor_len, 0x0034);
+        assert_eq!(info.interrupt_in_ep, 0x81);
     }
 }

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -892,6 +892,9 @@ impl Iterator for EndpointIterator<'_> {
         }
         while self.buffer_idx + 7 <= self.iface_desc.buffer.len() {
             let working = &self.iface_desc.buffer[self.buffer_idx..];
+            if working[0] == 0 {
+                return None;
+            }
             self.buffer_idx += working[0] as usize;
             if let Ok(d) = EndpointDescriptor::try_from_bytes(working) {
                 self.index += 1;
@@ -1596,5 +1599,18 @@ mod test {
         const BUF: [u8; 10] = [9, 2, 10, 0, 1, 1, 0, 0x80, 50, 0x01];
         let cfg = ConfigurationDescriptorChain::try_from_slice(&BUF).expect("configuration parses");
         assert_eq!(cfg.iter_interface().count(), 0);
+    }
+
+    /// A zero-length descriptor must end the walk instead of stalling it.
+    #[test]
+    fn iter_endpoints_stops_at_zero_length_descriptor() {
+        const BUF: [u8; 25] = [
+            9, 2, 25, 0, 1, 1, 0, 0x80, 50, // configuration
+            9, 4, 0, 0, 1, 0, 0, 0, 0, // interface declaring one endpoint
+            0, 0, 0, 0, 0, 0, 0, // zero-length descriptor
+        ];
+        let cfg = ConfigurationDescriptorChain::try_from_slice(&BUF).expect("configuration parses");
+        let iface = cfg.iter_interface().next().expect("one interface");
+        assert_eq!(iface.iter_endpoints().count(), 0);
     }
 }

--- a/embassy-usb-host/src/descriptor.rs
+++ b/embassy-usb-host/src/descriptor.rs
@@ -592,7 +592,7 @@ impl<'a> ConfigurationDescriptorChain<'a> {
         let first_interface_offset = self
             .iter_descriptors()
             .find_map(|(offset, bytes)| {
-                if bytes[1] == descriptor_type::INTERFACE {
+                if bytes.get(1) == Some(&descriptor_type::INTERFACE) {
                     Some(offset)
                 } else {
                     None
@@ -1588,5 +1588,13 @@ mod test {
             assert_eq!(descriptor.write_to_bytes(&mut bytes), Ok(2 + 2 * n));
             assert_eq!(StringDescriptor::try_from_bytes(&bytes), Ok(descriptor));
         }
+    }
+
+    /// A 1-byte descriptor must not be indexed past its end.
+    #[test]
+    fn iter_interface_skips_short_descriptors() {
+        const BUF: [u8; 10] = [9, 2, 10, 0, 1, 1, 0, 0x80, 50, 0x01];
+        let cfg = ConfigurationDescriptorChain::try_from_slice(&BUF).expect("configuration parses");
+        assert_eq!(cfg.iter_interface().count(), 0);
     }
 }


### PR DESCRIPTION
Correcting a few subtle errors

1) HID Reports - length begins at [7], as per (https://www.usb.org/sites/default/files/hid1_11.pdf), pg.22
2) Invalid 0-length descriptor iterates for-ever
3) Invalid 1-byte descriptor panics iterator
4) Remove default-features on `embassy-usb` dependency - bringing in unnecessary sub-dependencies

Audit and corrections with help from Codex