### PR TITLE
fix(usb-host): acknowledge unhandled hub and port status changes

### DIFF
--- a/embassy-usb-host/src/class/hub.rs
+++ b/embassy-usb-host/src/class/hub.rs
@@ -145,11 +145,22 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
             if hub_changes.take_hub_change() {
                 trace!("HUB {}: hub changed, requesting status", self.device_address);
 
-                let (status, change) = self.get_hub_status().await?;
+                let (status, mut change) = self.get_hub_status().await?;
                 debug!(
                     "HUB {}: hub status: {:?} change: {:?}",
                     self.device_address, status, change
                 );
+
+                if change.contains(HubStatusChange::LOCAL_POWER) {
+                    change.toggle(HubStatusChange::LOCAL_POWER);
+                    self.hub_feature(false, HubFeature::ChangeHubLocalPower).await?;
+                }
+
+                if change.contains(HubStatusChange::OVERCURRENT) {
+                    change.toggle(HubStatusChange::OVERCURRENT);
+                    self.hub_feature(false, HubFeature::ChangeHubOverCurrent).await?;
+                    warn!("HUB {}: hub over-current", self.device_address);
+                }
 
                 if !change.is_empty() {
                     return Err(HostError::Other("Unhandled hub status change"));
@@ -167,6 +178,23 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
                 if change.contains(PortStatusChange::RESET) {
                     change.toggle(PortStatusChange::RESET);
                     self.port_feature(false, PortFeature::ChangeReset, port, 0).await?;
+                }
+
+                if change.contains(PortStatusChange::ENABLE) {
+                    change.toggle(PortStatusChange::ENABLE);
+                    self.port_feature(false, PortFeature::ChangeEnable, port, 0).await?;
+                }
+
+                if change.contains(PortStatusChange::SUSPEND) {
+                    change.toggle(PortStatusChange::SUSPEND);
+                    self.port_feature(false, PortFeature::ChangeSuspend, port, 0).await?;
+                }
+
+                if change.contains(PortStatusChange::OVERCURRENT) {
+                    change.toggle(PortStatusChange::OVERCURRENT);
+                    self.port_feature(false, PortFeature::ChangeOverCurrent, port, 0)
+                        .await?;
+                    warn!("HUB {}: over-current on port {}", self.device_address, port);
                 }
 
                 if change.contains(PortStatusChange::CONNECT) {
@@ -199,7 +227,6 @@ impl<'d, A: UsbHostAllocator<'d>, const MAX_PORTS: usize> HubHandler<'d, A, MAX_
         }
     }
 
-    #[allow(dead_code)]
     async fn hub_feature(&mut self, set: bool, feature: HubFeature) -> Result<(), HostError> {
         let setup = SetupPacket {
             request_type: RequestType {


### PR DESCRIPTION
`wait_for_event` from hub currently handles only CONNECT and RESET, but hubs may also send port reports like ENABLE, SUSPEND and OVERCURRENT, which return errors that are never cleared, causing repeated reporting and wedging of the hub. Hub-level LOCAL_POWER and OVERCURRENT behave the same, and hub_feature(), which would clear them, was dead code.

PR introduces acknowledgements to all five port changes and both hub changes, and warns on over-current. The three port bits are new cleared before the CONNECT branch, which returns early, so a combined CONNECT|OVERCURRENT no longer wedges on the following event.

Reviews: Verified on an RP2040 with a 5-device hub tree, forcing PORT_SUSPEND then clearing it. Was not able to provoke other paths, but they are visually similar. Code could be simplified, but preferred to follow existing style.

Two other reports are unhandled, since they imply breaking changes, a DISABLED port should probably emit a `HubEvent`, to allow recycling of address, as should overcurrent.
 
History: Found this when testing RP usb-host with 2 hubs and hot-plugging/unplugging devices - hanging the host driver. Then got Codex to diagnose it, code looks fine, some testing done and haven't had any hangs since.

Impl and tested with help from Claude.