### PR TITLE
[rp235x] fix incorrect pin naming in i2c_slave

### DIFF
--- a/examples/rp235x/src/bin/i2c_slave.rs
+++ b/examples/rp235x/src/bin/i2c_slave.rs
@@ -100,19 +100,19 @@ async fn main(spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
 
-    let d_sda = p.PIN_3;
-    let d_scl = p.PIN_2;
+    let d_sda = p.PIN_2;
+    let d_scl = p.PIN_3;
     let mut config = i2c_slave::Config::default();
     config.addr = DEV_ADDR as u16;
-    let device = i2c_slave::I2cSlave::new(p.I2C1, d_sda, d_scl, Irqs, config);
+    let device = i2c_slave::I2cSlave::new(p.I2C1, d_scl, d_sda, Irqs, config);
 
     spawner.spawn(unwrap!(device_task(device)));
 
-    let c_sda = p.PIN_1;
-    let c_scl = p.PIN_0;
+    let c_sda = p.PIN_0;
+    let c_scl = p.PIN_1;
     let mut config = i2c::Config::default();
     config.frequency = 1_000_000;
-    let controller = i2c::I2c::new_async(p.I2C0, c_sda, c_scl, Irqs, config);
+    let controller = i2c::I2c::new_async(p.I2C0, c_scl, c_sda, Irqs, config);
 
     spawner.spawn(unwrap!(controller_task(controller)));
 }


### PR DESCRIPTION
For some reason examples/rp235x and examples/rp were not the same file; rp235x had (c/d)(_sda/_scl) swapped incorrectly; e.g. it assigned GP0 (I2C0 SDA) as c_SCL, which is not a supported function. 