### PR TITLE
executor: add `idle` trace hook.

### DIFF
--- a/embassy-executor/CHANGELOG.md
+++ b/embassy-executor/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added trace callbacks for when the task metadata (name, priority, deadline) changes.
 - Added `TaskId` and `ExecutorId` types.
 - Removed the `rtos-trace` feature.
+- Added `idle` trace callback (`_embassy_trace_v2_idle`), called by thread-mode executors right before sleeping.
+- Added `embassy_executor::trace_idle()` for custom thread-mode executors to emit the `idle` trace callback.
 
 ## 0.10.0 - 2026-03-10
 

--- a/embassy-executor/src/lib.rs
+++ b/embassy-executor/src/lib.rs
@@ -60,6 +60,23 @@ pub use platform::*;
 
 pub mod raw;
 
+/// Signal to the tracing system that the current thread/core is about to go idle.
+///
+/// Thread-mode executor implementations must call this right before putting the
+/// current thread/core to sleep (e.g. `wfe`/`wfi`). Do NOT call it from an
+/// interrupt executor, which returns to a preempted context after polling and
+/// is therefore not idle.
+///
+/// Note in multi-core chips, or when using threads under std or an RTOS, this
+/// doesn't mean the entire system is idle, it only means the current core/thread is.
+///
+/// This is a no-op unless the `trace` feature is enabled.
+#[inline]
+pub fn trace_idle() {
+    #[cfg(feature = "trace")]
+    raw::trace::idle();
+}
+
 mod spawner;
 pub use spawner::*;
 

--- a/embassy-executor/src/platform/aarch32.rs
+++ b/embassy-executor/src/platform/aarch32.rs
@@ -91,6 +91,7 @@ mod thread {
                 unsafe {
                     self.inner.poll();
                 }
+                crate::trace_idle();
                 wfe();
             }
         }

--- a/embassy-executor/src/platform/avr.rs
+++ b/embassy-executor/src/platform/avr.rs
@@ -65,6 +65,7 @@ mod thread {
                     avr_device::interrupt::disable();
                     if !SIGNAL_WORK_THREAD_MODE.swap(false, Ordering::SeqCst) {
                         avr_device::interrupt::enable();
+                        crate::trace_idle();
                         avr_device::asm::sleep();
                     } else {
                         avr_device::interrupt::enable();

--- a/embassy-executor/src/platform/cortex_m.rs
+++ b/embassy-executor/src/platform/cortex_m.rs
@@ -110,6 +110,7 @@ mod thread {
             loop {
                 unsafe {
                     self.inner.poll();
+                    crate::trace_idle();
                     asm!("wfe");
                 };
             }

--- a/embassy-executor/src/platform/riscv.rs
+++ b/embassy-executor/src/platform/riscv.rs
@@ -78,6 +78,7 @@ mod thread {
                             //
                             // Calling this inside the CS also prevents the corner case that an
                             // interrupt fires between exiting the CS and then calling WFI outside of it.
+                            crate::trace_idle();
                             core::arch::asm!("wfi");
                         }
                     });

--- a/embassy-executor/src/platform/std.rs
+++ b/embassy-executor/src/platform/std.rs
@@ -77,6 +77,7 @@ mod thread {
                     break;
                 }
 
+                crate::trace_idle();
                 self.signaler.wait();
             }
         }

--- a/embassy-executor/src/raw/trace.rs
+++ b/embassy-executor/src/raw/trace.rs
@@ -67,6 +67,16 @@
 //! 3. The executor has decided a task to poll. `task_exec_begin` is called
 //! 4. The executor finishes polling the task. `task_exec_end` is called
 //! 5. The executor has finished polling tasks. `executor_idle` is called
+//!
+//! ## Idle
+//!
+//! `executor_idle` only means that a single executor has run out of work. With
+//! multiple executors (e.g. a thread-mode executor plus one or more interrupt
+//! executors), an interrupt executor going idle returns to the preempted
+//! lower-priority context, which keeps running. The current thread/core is only
+//! idle when its thread-mode executor reaches its sleep site, at which point
+//! `idle` is called. In multi-core chips, or when using threads under std or an
+//! RTOS, this does not mean the entire system is idle.
 
 use crate::ExecutorId;
 use crate::raw::TaskRef;
@@ -143,6 +153,18 @@ unitrait::unitrait! {
         /// This marks the EXECUTOR state transition from SCHEDULING -> IDLE
         #[symbol = "_embassy_trace_v2_executor_idle"]
         pub(crate) fn executor_idle(executor: ExecutorId);
+
+        /// This callback is called right before the thread-mode executor puts the
+        /// current thread/core to sleep (e.g. `wfe`/`wfi`).
+        ///
+        /// Unlike `executor_idle`, this is never called by interrupt executors,
+        /// since they return to a preempted context after polling and the system
+        /// keeps running.
+        ///
+        /// Note in multi-core chips, or when using threads under std or an RTOS, this
+        /// doesn't mean the entire system is idle, it only means the current core/thread is.
+        #[symbol = "_embassy_trace_v2_idle"]
+        pub(crate) fn idle();
 
         /// This callback is called AFTER the name of a task is set.
         ///

--- a/embassy-mcxa/src/executor.rs
+++ b/embassy-mcxa/src/executor.rs
@@ -109,6 +109,7 @@ impl Executor {
                 if let Some(s) = sleep {
                     break s;
                 }
+                embassy_executor::trace_idle();
                 debug_lo();
                 do_wfe();
                 debug_hi();
@@ -128,6 +129,7 @@ impl Executor {
                         continue;
                     }
 
+                    embassy_executor::trace_idle();
                     debug_lo();
                     do_wfe();
                     debug_hi();
@@ -149,6 +151,7 @@ impl Executor {
                     //
                     // We STAY in the CS for the deep sleep to ensure that we handle wake-up
                     // completely BEFORE yielding control flow back to interrupts.
+                    embassy_executor::trace_idle();
                     debug_lo();
                     let do_wfe_sleep = critical_section::with(|cs| {
                         let did_deep_sleep = crate::clocks::deep_sleep_if_possible(&cs);

--- a/embassy-mspm0/src/executor.rs
+++ b/embassy-mspm0/src/executor.rs
@@ -119,6 +119,7 @@ mod thread {
                         if SIGNAL_WORK_THREAD_MODE.load(Ordering::SeqCst) {
                             SIGNAL_WORK_THREAD_MODE.store(false, Ordering::SeqCst);
                         } else {
+                            embassy_executor::trace_idle();
                             crate::low_power::sleep(cs);
                         }
                     });

--- a/embassy-rp/src/executor.rs
+++ b/embassy-rp/src/executor.rs
@@ -130,6 +130,7 @@ mod thread {
             loop {
                 unsafe {
                     self.inner.poll();
+                    embassy_executor::trace_idle();
                     asm!("wfe");
                 };
             }

--- a/embassy-stm32/src/executor.rs
+++ b/embassy-stm32/src/executor.rs
@@ -149,6 +149,7 @@ mod thread {
                             SIGNAL_WORK_THREAD_MODE.store(false, core::sync::atomic::Ordering::SeqCst);
                         } else {
                             // if not, sleep waiting for interrupt
+                            embassy_executor::trace_idle();
                             crate::low_power::sleep(cs);
                         }
                     });


### PR DESCRIPTION
this is a reworked version of #6502. While we've removed rtos-trace the problem also affects
the embassy-native trace.

Changes I've made:
- Renamed `system_idle` to `idle`. In multicore/multithreading envs it means just the current core/thread is idle, not the whole system. This solves @bugadani's concern.
- moved `trace_idle()` from `Executor` method to free function. It doesn't need access to the executor, so a free function is easier to use.

