### PR TITLE
nrf: add UARTE_DMA_SIZE

### DIFF
--- a/embassy-nrf/src/chips/nrf52805.rs
+++ b/embassy-nrf/src/chips/nrf52805.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 14) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = (1 << 10) - 1;
+
 pub const FLASH_SIZE: usize = 192 * 1024;
 
 pub const RESET_PIN: u32 = 21;

--- a/embassy-nrf/src/chips/nrf52810.rs
+++ b/embassy-nrf/src/chips/nrf52810.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 10) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 192 * 1024;
 
 pub const RESET_PIN: u32 = 21;

--- a/embassy-nrf/src/chips/nrf52811.rs
+++ b/embassy-nrf/src/chips/nrf52811.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 14) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = (1 << 10) - 1;
+
 pub const FLASH_SIZE: usize = 192 * 1024;
 
 pub const RESET_PIN: u32 = 21;

--- a/embassy-nrf/src/chips/nrf52820.rs
+++ b/embassy-nrf/src/chips/nrf52820.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 15) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 256 * 1024;
 
 pub const RESET_PIN: u32 = 18;

--- a/embassy-nrf/src/chips/nrf52832.rs
+++ b/embassy-nrf/src/chips/nrf52832.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 8) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 255;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 // There are two variants. We set the higher size to make the entire flash
 // usable in xxAA, but we'll probably split this in two cargi features later.
 // nrf52832xxAA = 512kb

--- a/embassy-nrf/src/chips/nrf52833.rs
+++ b/embassy-nrf/src/chips/nrf52833.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 512 * 1024;
 
 pub const RESET_PIN: u32 = 18;

--- a/embassy-nrf/src/chips/nrf52840.rs
+++ b/embassy-nrf/src/chips/nrf52840.rs
@@ -4,6 +4,10 @@ pub use nrf_pac as pac;
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 1024 * 1024;
 
 pub const RESET_PIN: u32 = 18;

--- a/embassy-nrf/src/chips/nrf5340_app.rs
+++ b/embassy-nrf/src/chips/nrf5340_app.rs
@@ -162,6 +162,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 1024 * 1024;
 
 embassy_hal_internal::peripherals! {

--- a/embassy-nrf/src/chips/nrf5340_net.rs
+++ b/embassy-nrf/src/chips/nrf5340_net.rs
@@ -54,6 +54,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 256 * 1024;
 
 embassy_hal_internal::peripherals! {

--- a/embassy-nrf/src/chips/nrf54l05_app.rs
+++ b/embassy-nrf/src/chips/nrf54l05_app.rs
@@ -198,6 +198,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 // 1.5 MB NVM
 #[allow(unused)]
 pub const FLASH_SIZE: usize = 1524 * 1024;

--- a/embassy-nrf/src/chips/nrf54l10_app.rs
+++ b/embassy-nrf/src/chips/nrf54l10_app.rs
@@ -198,6 +198,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 // 1.5 MB NVM
 #[allow(unused)]
 pub const FLASH_SIZE: usize = 1524 * 1024;

--- a/embassy-nrf/src/chips/nrf54l15_app.rs
+++ b/embassy-nrf/src/chips/nrf54l15_app.rs
@@ -198,6 +198,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 // 1.5 MB NVM
 #[allow(unused)]
 pub const FLASH_SIZE: usize = 1524 * 1024;

--- a/embassy-nrf/src/chips/nrf54lm20_app.rs
+++ b/embassy-nrf/src/chips/nrf54lm20_app.rs
@@ -205,6 +205,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 // 2 MB NVM
 #[allow(unused)]
 pub const FLASH_SIZE: usize = 2048 * 1024;

--- a/embassy-nrf/src/chips/nrf9120.rs
+++ b/embassy-nrf/src/chips/nrf9120.rs
@@ -127,6 +127,10 @@ pub mod pac {
 pub const EASY_DMA_SIZE: usize = (1 << 13) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FLASH_SIZE: usize = 1024 * 1024;
 
 embassy_hal_internal::peripherals! {

--- a/embassy-nrf/src/chips/nrf9160.rs
+++ b/embassy-nrf/src/chips/nrf9160.rs
@@ -125,6 +125,11 @@ pub mod pac {
 
 /// The maximum buffer size that the EasyDMA can send/recv in one operation.
 pub const EASY_DMA_SIZE: usize = (1 << 13) - 1;
+
+/// The maximum buffer size that the EasyDMA on UARTE can send/recv in one operation.
+/// This value is derived from the bit-width of the UARTE.{RXD, TXD} registers.
+pub const UARTE_DMA_SIZE: usize = EASY_DMA_SIZE;
+
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 pub const FLASH_SIZE: usize = 1024 * 1024;

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -331,6 +331,8 @@ macro_rules! bind_interrupts {
 
 // Reexports
 
+#[cfg(not(feature = "nrf51"))]
+pub use chip::UARTE_DMA_SIZE;
 #[cfg(feature = "unstable-pac")]
 pub use chip::pac;
 #[cfg(not(feature = "unstable-pac"))]

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -24,7 +24,7 @@ use embassy_sync::waitqueue::AtomicWaker;
 // Re-export SVD variants to allow user to directly set values.
 pub use pac::uarte::vals::{Baudrate, ConfigParity as Parity};
 
-use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
+use crate::chip::{FORCE_COPY_BUFFER_SIZE, UARTE_DMA_SIZE};
 use crate::gpio::{self, AnyPin, DISCONNECTED, Pin as GpioPin, PselBits, SealedPin as _};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
@@ -471,7 +471,7 @@ impl<'d> UarteTx<'d> {
         }
 
         slice_in_ram_or(buffer, Error::BufferNotInRAM)?;
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -541,7 +541,7 @@ impl<'d> UarteTx<'d> {
         }
 
         slice_in_ram_or(buffer, Error::BufferNotInRAM)?;
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -701,7 +701,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(());
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -769,7 +769,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(());
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -886,7 +886,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -945,7 +945,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -1059,7 +1059,7 @@ impl<'d> UarteRxWithIdle<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -1133,7 +1133,7 @@ impl<'d> UarteRxWithIdle<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > UARTE_DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 


### PR DESCRIPTION
The maximum size for UARTE DMA transfers is not always equal to the maximum size of EasyDMA transfers on a chip. Add a constant describing this disparity.

Fixes #6911