### PR TITLE
boot: separate verification from swapping

### DIFF
--- a/embassy-boot/CHANGELOG.md
+++ b/embassy-boot/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Add a `Verify` state for staged updates. Adding the state is semver-breaking.
+
 ## 0.7.0 - 2026-03-10
 
 - Fixed documentation and assertion of STATE partition size requirements

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -136,11 +136,11 @@ pub struct BootLoader<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash> {
     /// The state partition has the following format:
     /// All ranges are in multiples of WRITE_SIZE bytes.
     /// N = Active partition size divided by WRITE_SIZE.
-    /// | Range              | Description                                                                      |
-    /// | 0..1               | Magic indicating bootloader state.                                             |
-    /// | 1..2               | Progress validity. ERASE_VALUE means valid, !ERASE_VALUE means invalid.          |
-    /// | 2..(2 + 2N)        | Progress index used while swapping                                               |
-    /// | (2 + 2N)..(2 + 4N) | Progress index used while reverting
+    /// | Range              | Description                                                             |
+    /// | 0..1               | Magic indicating bootloader state.                                      |
+    /// | 1..2               | Progress validity. ERASE_VALUE means valid, !ERASE_VALUE means invalid. |
+    /// | 2..(2 + 2N)        | Progress index used while swapping                                      |
+    /// | (2 + 2N)..(2 + 4N) | Progress index used while reverting                                     |
     state: STATE,
 }
 

--- a/embassy-boot/src/boot_loader.rs
+++ b/embassy-boot/src/boot_loader.rs
@@ -5,7 +5,7 @@ use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embedded_storage::nor_flash::{NorFlash, NorFlashError, NorFlashErrorKind};
 
-use crate::{DFU_DETACH_MAGIC, REVERT_MAGIC, STATE_ERASE_VALUE, SWAP_MAGIC, State};
+use crate::{REVERT_MAGIC, STATE_ERASE_VALUE, State};
 
 /// Errors returned by bootloader
 #[derive(PartialEq, Eq, Debug)]
@@ -137,7 +137,7 @@ pub struct BootLoader<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash> {
     /// All ranges are in multiples of WRITE_SIZE bytes.
     /// N = Active partition size divided by WRITE_SIZE.
     /// | Range              | Description                                                                      |
-    /// | 0..1               | Magic indicating bootloader state. BOOT_MAGIC means boot, SWAP_MAGIC means swap. |
+    /// | 0..1               | Magic indicating bootloader state.                                             |
     /// | 1..2               | Progress validity. ERASE_VALUE means valid, !ERASE_VALUE means invalid.          |
     /// | 2..(2 + 2N)        | Progress index used while swapping                                               |
     /// | (2 + 2N)..(2 + 4N) | Progress index used while reverting
@@ -165,6 +165,8 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash> BootLoader<ACTIVE, DFU, S
     }
 
     /// Perform necessary boot preparations like swapping images.
+    ///
+    /// A pending [`State::Verify`] is reported without touching either image.
     ///
     /// The DFU partition is assumed to be 1 page bigger than the active partition for the swap
     /// algorithm to work correctly.
@@ -290,15 +292,7 @@ impl<ACTIVE: NorFlash, DFU: NorFlash, STATE: NorFlash> BootLoader<ACTIVE, DFU, S
         let state_word = &mut aligned_buf[..STATE::WRITE_SIZE];
         self.state.read(0, state_word)?;
 
-        if !state_word.iter().any(|&b| b != SWAP_MAGIC) {
-            Ok(State::Swap)
-        } else if !state_word.iter().any(|&b| b != DFU_DETACH_MAGIC) {
-            Ok(State::DfuDetach)
-        } else if !state_word.iter().any(|&b| b != REVERT_MAGIC) {
-            Ok(State::Revert)
-        } else {
-            Ok(State::Boot)
-        }
+        Ok(State::from(state_word))
     }
 
     fn is_swapped(&mut self, aligned_buf: &mut [u8]) -> Result<bool, BootError> {

--- a/embassy-boot/src/firmware_updater/asynch.rs
+++ b/embassy-boot/src/firmware_updater/asynch.rs
@@ -6,7 +6,7 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embedded_storage_async::nor_flash::NorFlash;
 
 use super::FirmwareUpdaterConfig;
-use crate::{BOOT_MAGIC, DFU_DETACH_MAGIC, FirmwareUpdaterError, STATE_ERASE_VALUE, SWAP_MAGIC, State};
+use crate::{BOOT_MAGIC, DFU_DETACH_MAGIC, FirmwareUpdaterError, STATE_ERASE_VALUE, SWAP_MAGIC, State, VERIFY_MAGIC};
 
 /// FirmwareUpdater is an application API for interacting with the BootLoader without the ability to
 /// 'mess up' the internal bootloader state
@@ -70,6 +70,16 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> FirmwareUpdater<'d, DFU, STATE> {
         self.state.get_state().await
     }
 
+    /// Mark a fully staged update as pending verification.
+    pub async fn mark_verify(&mut self) -> Result<(), FirmwareUpdaterError> {
+        self.state.mark_verify().await
+    }
+
+    /// Reject a pending update without modifying the staged bytes.
+    pub async fn reject_update(&mut self) -> Result<(), FirmwareUpdaterError> {
+        self.state.reject_update().await
+    }
+
     /// Verify the DFU given a public key. If there is an error then DO NOT
     /// proceed with updating the firmware as it must be signed with a
     /// corresponding private key (otherwise it could be malicious firmware).
@@ -90,7 +100,12 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> FirmwareUpdater<'d, DFU, STATE> {
     ) -> Result<(), FirmwareUpdaterError> {
         assert!(_update_len <= self.dfu.capacity() as u32);
 
-        self.state.verify_booted().await?;
+        if !matches!(
+            self.state.get_state().await?,
+            State::Verify | State::Boot | State::DfuDetach | State::Revert
+        ) {
+            return Err(FirmwareUpdaterError::BadState);
+        }
 
         #[cfg(feature = "ed25519-dalek")]
         {
@@ -332,6 +347,24 @@ impl<'d, STATE: NorFlash> FirmwareState<'d, STATE> {
     /// Mark to trigger firmware swap on next boot.
     pub async fn mark_updated(&mut self) -> Result<(), FirmwareUpdaterError> {
         self.set_magic(SWAP_MAGIC).await
+    }
+
+    /// Mark a fully staged update as pending verification.
+    pub async fn mark_verify(&mut self) -> Result<(), FirmwareUpdaterError> {
+        match self.get_state().await? {
+            State::Verify => Ok(()),
+            State::Boot | State::DfuDetach | State::Revert => self.set_magic(VERIFY_MAGIC).await,
+            State::Swap => Err(FirmwareUpdaterError::BadState),
+        }
+    }
+
+    /// Reject a pending update and return to normal boot state.
+    pub async fn reject_update(&mut self) -> Result<(), FirmwareUpdaterError> {
+        if self.get_state().await? != State::Verify {
+            return Err(FirmwareUpdaterError::BadState);
+        }
+        self.state.erase(0, self.state.capacity() as u32).await?;
+        Ok(())
     }
 
     /// Mark to trigger USB DFU on next boot.

--- a/embassy-boot/src/firmware_updater/blocking.rs
+++ b/embassy-boot/src/firmware_updater/blocking.rs
@@ -6,7 +6,7 @@ use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embedded_storage::nor_flash::NorFlash;
 
 use super::FirmwareUpdaterConfig;
-use crate::{BOOT_MAGIC, DFU_DETACH_MAGIC, FirmwareUpdaterError, STATE_ERASE_VALUE, SWAP_MAGIC, State};
+use crate::{BOOT_MAGIC, DFU_DETACH_MAGIC, FirmwareUpdaterError, STATE_ERASE_VALUE, SWAP_MAGIC, State, VERIFY_MAGIC};
 
 /// Blocking FirmwareUpdater is an application API for interacting with the BootLoader without the ability to
 /// 'mess up' the internal bootloader state
@@ -105,6 +105,16 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> BlockingFirmwareUpdater<'d, DFU, STATE>
         self.state.get_state()
     }
 
+    /// Mark a fully staged update as pending verification.
+    pub fn mark_verify(&mut self) -> Result<(), FirmwareUpdaterError> {
+        self.state.mark_verify()
+    }
+
+    /// Reject a pending update without modifying the staged bytes.
+    pub fn reject_update(&mut self) -> Result<(), FirmwareUpdaterError> {
+        self.state.reject_update()
+    }
+
     /// Verify the DFU given a public key. If there is an error then DO NOT
     /// proceed with updating the firmware as it must be signed with a
     /// corresponding private key (otherwise it could be malicious firmware).
@@ -125,7 +135,12 @@ impl<'d, DFU: NorFlash, STATE: NorFlash> BlockingFirmwareUpdater<'d, DFU, STATE>
     ) -> Result<(), FirmwareUpdaterError> {
         assert!(_update_len <= self.dfu.capacity() as u32);
 
-        self.state.verify_booted()?;
+        if !matches!(
+            self.state.get_state()?,
+            State::Verify | State::Boot | State::DfuDetach | State::Revert
+        ) {
+            return Err(FirmwareUpdaterError::BadState);
+        }
 
         #[cfg(feature = "ed25519-dalek")]
         {
@@ -357,6 +372,24 @@ impl<'d, STATE: NorFlash> BlockingFirmwareState<'d, STATE> {
     /// Mark to trigger firmware swap on next boot.
     pub fn mark_updated(&mut self) -> Result<(), FirmwareUpdaterError> {
         self.set_magic(SWAP_MAGIC)
+    }
+
+    /// Mark a fully staged update as pending verification.
+    pub fn mark_verify(&mut self) -> Result<(), FirmwareUpdaterError> {
+        match self.get_state()? {
+            State::Verify => Ok(()),
+            State::Boot | State::DfuDetach | State::Revert => self.set_magic(VERIFY_MAGIC),
+            State::Swap => Err(FirmwareUpdaterError::BadState),
+        }
+    }
+
+    /// Reject a pending update and return to normal boot state.
+    pub fn reject_update(&mut self) -> Result<(), FirmwareUpdaterError> {
+        if self.get_state()? != State::Verify {
+            return Err(FirmwareUpdaterError::BadState);
+        }
+        self.state.erase(0, self.state.capacity() as u32)?;
+        Ok(())
     }
 
     /// Mark to trigger USB DFU on next boot.

--- a/embassy-boot/src/lib.rs
+++ b/embassy-boot/src/lib.rs
@@ -34,10 +34,13 @@ pub(crate) const REVERT_MAGIC: u8 = 0xC0;
 pub(crate) const BOOT_MAGIC: u8 = 0xD0;
 pub(crate) const SWAP_MAGIC: u8 = 0xF0;
 pub(crate) const DFU_DETACH_MAGIC: u8 = 0xE0;
+// Incomparable with the other magic values under either flash polarity, so a torn write cannot authorize a swap.
+pub(crate) const VERIFY_MAGIC: u8 = 0xB1;
 
 /// The state of the bootloader after running prepare.
 #[derive(PartialEq, Eq, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[non_exhaustive]
 pub enum State {
     /// Bootloader is ready to boot the active partition.
     Boot,
@@ -47,6 +50,8 @@ pub enum State {
     Revert,
     /// Application has received a request to reboot into DFU mode to apply an update.
     DfuDetach,
+    /// An update is staged in the DFU partition but must be verified before it can be swapped.
+    Verify,
 }
 
 impl<T> From<T> for State
@@ -57,6 +62,8 @@ where
         let magic = magic.as_ref();
         if !magic.iter().any(|&b| b != SWAP_MAGIC) {
             State::Swap
+        } else if !magic.iter().any(|&b| b != VERIFY_MAGIC) {
+            State::Verify
         } else if !magic.iter().any(|&b| b != REVERT_MAGIC) {
             State::Revert
         } else if !magic.iter().any(|&b| b != DFU_DETACH_MAGIC) {
@@ -115,6 +122,14 @@ mod tests {
     */
 
     #[test]
+    fn test_verify_magic_cannot_tear_into_another_state() {
+        for magic in [BOOT_MAGIC, SWAP_MAGIC, REVERT_MAGIC, DFU_DETACH_MAGIC] {
+            assert_ne!(magic & VERIFY_MAGIC, magic);
+            assert_ne!(magic & VERIFY_MAGIC, VERIFY_MAGIC);
+        }
+    }
+
+    #[test]
     fn test_boot_state() {
         let flash = BlockingTestFlash::new(BootLoaderConfig {
             active: MemFlash::<57344, 4096, 4>::default(),
@@ -132,6 +147,24 @@ mod tests {
 
         let mut page = [0; 4096];
         assert_eq!(State::Boot, bootloader.prepare_boot(&mut page).unwrap());
+    }
+
+    #[test]
+    fn test_verify_state() {
+        let flash = BlockingTestFlash::new(BootLoaderConfig {
+            active: MemFlash::<4096, 4096, 4>::default(),
+            dfu: MemFlash::<8192, 4096, 4>::default(),
+            state: MemFlash::<4096, 4096, 4>::default(),
+        });
+        flash.state().write(0, &[VERIFY_MAGIC; 4]).unwrap();
+
+        let mut bootloader = BootLoader::new(BootLoaderConfig {
+            active: flash.active(),
+            dfu: flash.dfu(),
+            state: flash.state(),
+        });
+        let mut page = [0; 4096];
+        assert_eq!(State::Verify, bootloader.prepare_boot(&mut page).unwrap());
     }
 
     #[test]
@@ -359,6 +392,11 @@ mod tests {
             &mut aligned,
         );
 
+        block_on(updater.mark_verify()).unwrap();
+        assert_eq!(block_on(updater.get_state()).unwrap(), State::Verify);
+        block_on(updater.reject_update()).unwrap();
+        assert_eq!(block_on(updater.get_state()).unwrap(), State::Boot);
+        block_on(updater.mark_verify()).unwrap();
         assert!(
             block_on(updater.verify_and_mark_updated(
                 &public_key.to_bytes(),
@@ -367,5 +405,6 @@ mod tests {
             ))
             .is_ok()
         );
+        assert_eq!(block_on(updater.get_state()).unwrap(), State::Swap);
     }
 }

--- a/embassy-usb-dfu/CHANGELOG.md
+++ b/embassy-usb-dfu/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- Add deferred verification mode, which stages a download in the bootloader's `Verify` state.
+
 ## 0.3.0 - 2026-03-10
 
 - changed: Do not reset in the GetStatus request

--- a/embassy-usb-dfu/src/dfu.rs
+++ b/embassy-usb-dfu/src/dfu.rs
@@ -19,9 +19,15 @@ pub struct FirmwareHandler<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const
     offset: usize,
     buf: AlignedBuffer<BLOCK_SIZE>,
     reset: RST,
+    completion: Completion,
+}
 
+enum Completion {
+    Deferred,
     #[cfg(feature = "_verify")]
-    public_key: &'static [u8; 32],
+    Verify(&'static [u8; 32]),
+    #[cfg(not(feature = "_verify"))]
+    Update,
 }
 
 impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize>
@@ -38,9 +44,21 @@ impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize>
             offset: 0,
             buf: AlignedBuffer([0; BLOCK_SIZE]),
             reset,
-
             #[cfg(feature = "_verify")]
-            public_key,
+            completion: Completion::Verify(public_key),
+            #[cfg(not(feature = "_verify"))]
+            completion: Completion::Update,
+        }
+    }
+
+    /// Create a handler that leaves completed downloads pending bootloader verification.
+    pub fn new_deferred(updater: BlockingFirmwareUpdater<'d, DFU, STATE>, reset: RST) -> Self {
+        Self {
+            updater,
+            offset: 0,
+            buf: AlignedBuffer([0; BLOCK_SIZE]),
+            reset,
+            completion: Completion::Deferred,
         }
     }
 }
@@ -91,21 +109,20 @@ impl<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize> df
     fn finish(&mut self) -> Result<(), Status> {
         debug!("Receiving final transfer");
 
-        #[cfg(feature = "_verify")]
-        let update_res: Result<(), FirmwareUpdaterError> = {
-            const SIGNATURE_LEN: usize = 64;
-
-            let mut signature = [0; SIGNATURE_LEN];
-            let update_len = (self.offset - SIGNATURE_LEN) as u32;
-
-            self.updater.read_dfu(update_len, &mut signature).and_then(|_| {
+        let update_res = match self.completion {
+            Completion::Deferred => self.updater.mark_verify(),
+            #[cfg(feature = "_verify")]
+            Completion::Verify(public_key) => {
+                const SIGNATURE_LEN: usize = 64;
+                let mut signature = [0; SIGNATURE_LEN];
+                let update_len = (self.offset - SIGNATURE_LEN) as u32;
                 self.updater
-                    .verify_and_mark_updated(self.public_key, &signature, update_len)
-            })
+                    .read_dfu(update_len, &mut signature)
+                    .and_then(|_| self.updater.verify_and_mark_updated(public_key, &signature, update_len))
+            }
+            #[cfg(not(feature = "_verify"))]
+            Completion::Update => self.updater.mark_updated(),
         };
-
-        #[cfg(not(feature = "_verify"))]
-        let update_res = self.updater.mark_updated();
 
         match update_res {
             Ok(_) => {
@@ -145,6 +162,19 @@ pub fn new_state<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZ
         public_key,
     );
     DfuState::new(handler, attrs)
+}
+
+/// Create a DFU state that stages the complete download and marks it pending verification.
+///
+/// Signature parsing and policy are intentionally left to the bootloader after
+/// USB manifestation, allowing USB and non-USB transports to stage the same
+/// signed image format.
+pub fn new_state_deferred<'d, DFU: NorFlash, STATE: NorFlash, RST: Reset, const BLOCK_SIZE: usize>(
+    updater: BlockingFirmwareUpdater<'d, DFU, STATE>,
+    attrs: DfuAttributes,
+    reset: RST,
+) -> State<'d, DFU, STATE, RST, BLOCK_SIZE> {
+    DfuState::new(FirmwareHandler::new_deferred(updater, reset), attrs)
 }
 
 /// An implementation of the USB DFU 1.1 protocol

--- a/embassy-usb-dfu/tests/usb_dfu_test.rs
+++ b/embassy-usb-dfu/tests/usb_dfu_test.rs
@@ -2,13 +2,19 @@ use core::cell::RefCell;
 use core::convert::Infallible;
 
 use dfu_core::DfuIo;
+#[cfg(feature = "_verify")]
+use embassy_boot::State;
 use embassy_boot::{BlockingFirmwareUpdater, FirmwareUpdaterConfig};
 use embassy_usb::Handler;
 use embassy_usb::class::dfu::dfu_mode::Handler as DfuModeHandler;
 use embassy_usb::control::{InResponse, OutResponse, Recipient, Request as ControlRequest, RequestType};
 use embassy_usb::driver::Direction;
 use embassy_usb_dfu::consts::DfuAttributes;
-use embassy_usb_dfu::{Reset, UsbDfuState, new_state};
+#[cfg(not(feature = "_verify"))]
+use embassy_usb_dfu::new_state;
+#[cfg(feature = "_verify")]
+use embassy_usb_dfu::new_state_deferred;
+use embassy_usb_dfu::{Reset, UsbDfuState};
 use embedded_storage::nor_flash::{ErrorType, NorFlash, ReadNorFlash};
 
 const READ_WRITE_SIZE: usize = 8;
@@ -162,7 +168,10 @@ fn usb_dfu(dfu_attributes: DfuAttributes) {
         transfer_size: READ_WRITE_SIZE as u16,
         dfu_version: (1, 1),
     };
+    #[cfg(not(feature = "_verify"))]
     let dfu_state = new_state::<_, _, _, BLOCK_SIZE>(updater, dfu_attributes, NoopReset {});
+    #[cfg(feature = "_verify")]
+    let dfu_state = new_state_deferred::<_, _, _, BLOCK_SIZE>(updater, dfu_attributes, NoopReset {});
     let mut dfu = dfu_core::sync::DfuSync::new(InMemoryDfu {
         functional_descriptor,
         dfu_state: RefCell::new(dfu_state),
@@ -173,6 +182,11 @@ fn usb_dfu(dfu_attributes: DfuAttributes) {
     println!("{:?}", err);
     assert_eq!(&dfu_buffer.borrow()[..firmware.len()], firmware);
     assert!(err.is_ok());
+    #[cfg(feature = "_verify")]
+    {
+        drop(dfu);
+        assert_eq!(State::from(&state_buffer.borrow()[..READ_WRITE_SIZE]), State::Verify);
+    }
 }
 
 #[test]


### PR DESCRIPTION
I want to stage a firmware image that my application receives via OTA MQTT and then later have it crypto-verified by the bootloader and swapped.

For that introduce a new `State::Verify` and magic to signal a deferred image verification in the bootloader. That way the applications only need the tiny OTA staging shim and the bootloader keeps all the crypto+trusted keys.

Things I don't want to do:

* I don't want to duplicate in the crypto stuff and the key material (that the bootloader already has for USB DFU) in both my app A/B images to do the OTA verification before booting into the bootloader.
* And I don't want to duplicate the network+MQTT layer (that my app has already) in the bootloader to do the OTA staging in the bootloader. Both approaches are bad for code size reasons.
* Finally I don't want to open up another handoff/communication channel between my app and the bootlaoder. I'd prefer to continue using the existing boot state as the handoff.

The invariant is:

* `Verify` = complete but untrusted staging
* `Swap`   = authenticated and authorized; bootloader may copy or resume copying

State transitions:

* `Boot / DfuDetach / Revert` -> `mark_verify()`
* `Verify` + successful verification -> `Swap`
* `Verify` + `reject_update()` -> `Boot`
* `Swap` + application `mark_booted()` -> `Boot`
* `Swap` without `mark_booted()` -> do revert -> `Revert`

Notes:

* This is semver-breaking because of the change to the public exhaustive `State` enum.
* Makes `State` non-exhaustive to ease future changes
* Support deferred verification in DFU by analogy

Disclosure:

I used an LLM in the implementation and testing and several rounds of changes.
