### PR TITLE
nrf: make DMA_SIZE a per-peripheral const, derived from the PAC.

### DIFF
--- a/embassy-net-nrf91/Cargo.toml
+++ b/embassy-net-nrf91/Cargo.toml
@@ -18,8 +18,8 @@ log = ["dep:log"]
 defmt = { version = "1.0.1", optional = true }
 log = { version = "0.4.14", optional = true }
 
-nrf-pac = "0.4.0"
-# nrf-pac = { git = "https://github.com/embassy-rs/nrf-pac", rev = "dcbec3723fa14fc81e004ab288c9b2e454dba802" }
+# nrf-pac = "0.4.0"
+nrf-pac = { git = "https://github.com/embassy-rs/nrf-pac", rev = "4499375510e2fdb3a5426911beb846d8d2dbbb80" }
 cortex-m = "0.7.7"
 
 embassy-time = { version = "0.5.1", path = "../embassy-time" }

--- a/embassy-nrf/CHANGELOG.md
+++ b/embassy-nrf/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 ## Unreleased - ReleaseDate
 
+- bugfix: enforce each peripheral's own EasyDMA `MAXCNT` limit in uarte, buffered_uarte, spim, spis, twim, twis, i2s, pdm, pwm and saadc instead of the chip-wide `DMA_SIZE`.
+- added: per-peripheral `DMA_SIZE` constants in the `uarte`, `spim`, `spis`, `twim`, `twis`, `i2s`, `pdm` and `saadc` modules, and `pwm::MAX_SEQUENCE_LEN`.
+- removed: the crate-level `DMA_SIZE` constant. It was wrong because the max DMA size changes per peripheral.
 - added: System OFF support for the nRF54L series.
 - bugfix: usb: don't re-arm OUT endpoints twice per packet, which could silently drop received packets under load.
 - bugfix: usb: apply the nRF52840 Erratum 199 workaround around USBD EasyDMA transfers.
@@ -199,4 +202,3 @@ Support for chip-specific features:
   - nrf52840
   - nrf5340
   - nrf9160
-

--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -234,8 +234,8 @@ rand-core-06 = { package = "rand_core", version = "0.6" }
 rand-core-09 = { package = "rand_core", version = "0.9" }
 rand-core-10 = { package = "rand_core", version = "0.10" }
 
-nrf-pac = "0.4.0"
-# nrf-pac = { git = "https://github.com/embassy-rs/nrf-pac", rev = "dcbec3723fa14fc81e004ab288c9b2e454dba802" }
+# nrf-pac = "0.4.0"
+nrf-pac = { git = "https://github.com/embassy-rs/nrf-pac", rev = "4499375510e2fdb3a5426911beb846d8d2dbbb80" }
 
 defmt = { version = "1.0.1", optional = true }
 thiserror = { version = "2", default-features = false }

--- a/embassy-nrf/src/buffered_uarte/v1.rs
+++ b/embassy-nrf/src/buffered_uarte/v1.rs
@@ -28,8 +28,10 @@ use crate::ppi::{
     self, AnyConfigurableChannel, AnyGroup, Channel, ConfigurableChannel, Event, Group, Ppi, PpiGroup, Task,
 };
 use crate::timer::{Instance as TimerInstance, Timer};
-use crate::uarte::{Config, Instance as UarteInstance, configure, configure_rx_pins, configure_tx_pins, drop_tx_rx};
-use crate::{EASY_DMA_SIZE, interrupt, pac};
+use crate::uarte::{
+    Config, DMA_SIZE, Instance as UarteInstance, configure, configure_rx_pins, configure_tx_pins, drop_tx_rx,
+};
+use crate::{interrupt, pac};
 
 pub(crate) struct State {
     tx_buf: RingBuffer,
@@ -193,7 +195,7 @@ impl<U: UarteInstance> interrupt::typelevel::Handler<U::Interrupt> for Interrupt
             // If not TXing, start.
             if s.tx_count.load(Ordering::Relaxed) == 0 {
                 let (ptr, len) = tx.pop_buf();
-                let len = len.min(EASY_DMA_SIZE);
+                let len = len.min(DMA_SIZE);
                 if len != 0 {
                     //trace!("  irq_tx: starting {:?}", len);
                     s.tx_count.store(len, Ordering::Relaxed);
@@ -695,7 +697,7 @@ impl<'d> BufferedUarteRx<'d> {
         buffered_state.rx_ended_count.store(0, Ordering::Relaxed);
         buffered_state.rx_started.store(false, Ordering::Relaxed);
         buffered_state.rx_overrun.store(false, Ordering::Relaxed);
-        let rx_len = rx_buffer.len().min(EASY_DMA_SIZE * 2);
+        let rx_len = rx_buffer.len().min(DMA_SIZE * 2);
         unsafe { buffered_state.rx_buf.init(rx_buffer.as_mut_ptr(), rx_len) };
 
         // clear errors

--- a/embassy-nrf/src/buffered_uarte/v2.rs
+++ b/embassy-nrf/src/buffered_uarte/v2.rs
@@ -31,8 +31,10 @@ pub use pac::uarte::vals::{Baudrate, ConfigParity as Parity};
 
 use crate::gpio::{AnyPin, Pin as GpioPin};
 use crate::interrupt::typelevel::Interrupt;
-use crate::uarte::{Config, Instance as UarteInstance, configure, configure_rx_pins, configure_tx_pins, drop_tx_rx};
-use crate::{EASY_DMA_SIZE, interrupt, pac};
+use crate::uarte::{
+    Config, DMA_SIZE, Instance as UarteInstance, configure, configure_rx_pins, configure_tx_pins, drop_tx_rx,
+};
+use crate::{interrupt, pac};
 
 pub(crate) struct State {
     tx_buf: RingBuffer,
@@ -132,7 +134,7 @@ impl<U: UarteInstance> interrupt::typelevel::Handler<U::Interrupt> for Interrupt
             // If not TXing, start.
             if s.tx_count.load(Ordering::Relaxed) == 0 {
                 let (ptr, len) = tx.pop_buf();
-                let len = len.min(EASY_DMA_SIZE);
+                let len = len.min(DMA_SIZE);
                 if len != 0 {
                     //trace!("  irq_tx: starting {:?}", len);
                     s.tx_count.store(len, Ordering::Relaxed);
@@ -508,7 +510,7 @@ impl<'d, U: UarteInstance> BufferedUarteRx<'d, U> {
 
         // Initialize state
         let s = U::buffered_state();
-        let rx_len = rx_buffer.len().min(EASY_DMA_SIZE * 2);
+        let rx_len = rx_buffer.len().min(DMA_SIZE * 2);
         let rx_ptr = rx_buffer.as_mut_ptr();
         unsafe { s.rx_buf.init(rx_ptr, rx_len) };
 

--- a/embassy-nrf/src/chips/nrf51.rs
+++ b/embassy-nrf/src/chips/nrf51.rs
@@ -1,8 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 14) - 1;
-
 pub const FLASH_SIZE: usize = 128 * 1024;
 
 embassy_hal_internal::peripherals! {

--- a/embassy-nrf/src/chips/nrf52805.rs
+++ b/embassy-nrf/src/chips/nrf52805.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 14) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 
 pub const FLASH_SIZE: usize = 192 * 1024;

--- a/embassy-nrf/src/chips/nrf52810.rs
+++ b/embassy-nrf/src/chips/nrf52810.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 10) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 
 pub const FLASH_SIZE: usize = 192 * 1024;

--- a/embassy-nrf/src/chips/nrf52811.rs
+++ b/embassy-nrf/src/chips/nrf52811.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 14) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 256;
 
 pub const FLASH_SIZE: usize = 192 * 1024;

--- a/embassy-nrf/src/chips/nrf52820.rs
+++ b/embassy-nrf/src/chips/nrf52820.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 15) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 
 pub const FLASH_SIZE: usize = 256 * 1024;

--- a/embassy-nrf/src/chips/nrf52832.rs
+++ b/embassy-nrf/src/chips/nrf52832.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 8) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 255;
 
 // There are two variants. We set the higher size to make the entire flash

--- a/embassy-nrf/src/chips/nrf52833.rs
+++ b/embassy-nrf/src/chips/nrf52833.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 
 pub const FLASH_SIZE: usize = 512 * 1024;

--- a/embassy-nrf/src/chips/nrf52840.rs
+++ b/embassy-nrf/src/chips/nrf52840.rs
@@ -1,7 +1,5 @@
 pub use nrf_pac as pac;
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 512;
 
 pub const FLASH_SIZE: usize = 1024 * 1024;

--- a/embassy-nrf/src/chips/nrf5340_app.rs
+++ b/embassy-nrf/src/chips/nrf5340_app.rs
@@ -158,8 +158,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 pub const FLASH_SIZE: usize = 1024 * 1024;

--- a/embassy-nrf/src/chips/nrf5340_net.rs
+++ b/embassy-nrf/src/chips/nrf5340_net.rs
@@ -50,8 +50,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 pub const FLASH_SIZE: usize = 256 * 1024;

--- a/embassy-nrf/src/chips/nrf54l05_app.rs
+++ b/embassy-nrf/src/chips/nrf54l05_app.rs
@@ -194,8 +194,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 // 1.5 MB NVM

--- a/embassy-nrf/src/chips/nrf54l10_app.rs
+++ b/embassy-nrf/src/chips/nrf54l10_app.rs
@@ -194,8 +194,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 // 1.5 MB NVM

--- a/embassy-nrf/src/chips/nrf54l15_app.rs
+++ b/embassy-nrf/src/chips/nrf54l15_app.rs
@@ -194,8 +194,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 // 1.5 MB NVM

--- a/embassy-nrf/src/chips/nrf54lm20_app.rs
+++ b/embassy-nrf/src/chips/nrf54lm20_app.rs
@@ -201,8 +201,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 16) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 // 2 MB NVM

--- a/embassy-nrf/src/chips/nrf9120.rs
+++ b/embassy-nrf/src/chips/nrf9120.rs
@@ -123,8 +123,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 13) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 pub const FLASH_SIZE: usize = 1024 * 1024;

--- a/embassy-nrf/src/chips/nrf9160.rs
+++ b/embassy-nrf/src/chips/nrf9160.rs
@@ -123,8 +123,6 @@ pub mod pac {
     };
 }
 
-/// The maximum buffer size that the EasyDMA can send/recv in one operation.
-pub const EASY_DMA_SIZE: usize = (1 << 13) - 1;
 pub const FORCE_COPY_BUFFER_SIZE: usize = 1024;
 
 pub const FLASH_SIZE: usize = 1024 * 1024;

--- a/embassy-nrf/src/i2s.rs
+++ b/embassy-nrf/src/i2s.rs
@@ -17,7 +17,10 @@ use crate::gpio::{AnyPin, Pin as GpioPin, PselBits};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::i2s::vals;
 use crate::util::slice_in_ram_or;
-use crate::{EASY_DMA_SIZE, interrupt, pac};
+use crate::{interrupt, pac};
+
+/// The maximum buffer size (in 32-bit words) that the I2S EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(pac::i2s::regs::Maxcnt, set_maxcnt, maxcnt);
 
 /// Type alias for `MultiBuffering` with 2 buffers.
 pub type DoubleBuffering<S, const NS: usize> = MultiBuffering<S, 2, NS>;
@@ -1066,7 +1069,7 @@ impl Device {
             Err(Error::BufferMisaligned)
         } else if bytes_len % 4 != 0 {
             Err(Error::BufferLengthMisaligned)
-        } else if maxcnt as usize > EASY_DMA_SIZE {
+        } else if maxcnt as usize > DMA_SIZE {
             Err(Error::BufferTooLong)
         } else {
             Ok((ptr, maxcnt))

--- a/embassy-nrf/src/lib.rs
+++ b/embassy-nrf/src/lib.rs
@@ -335,7 +335,7 @@ macro_rules! bind_interrupts {
 pub use chip::pac;
 #[cfg(not(feature = "unstable-pac"))]
 pub(crate) use chip::pac;
-pub use chip::{EASY_DMA_SIZE, Peripherals, peripherals};
+pub use chip::{Peripherals, peripherals};
 pub use embassy_hal_internal::{Peri, PeripheralType};
 
 pub use crate::chip::interrupt;

--- a/embassy-nrf/src/pdm.rs
+++ b/embassy-nrf/src/pdm.rs
@@ -12,7 +12,6 @@ use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 use fixed::types::I7F1;
 
-use crate::chip::EASY_DMA_SIZE;
 use crate::gpio::{AnyPin, DISCONNECTED, Pin as GpioPin, SealedPin};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
@@ -26,6 +25,9 @@ pub use crate::pac::pdm::vals::Freq as Frequency;
 ))]
 pub use crate::pac::pdm::vals::Ratio;
 use crate::{interrupt, pac};
+
+/// The maximum buffer size (in 16-bit samples) that the PDM EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(crate::pac::pdm::regs::Maxcnt, set_buffsize, buffsize);
 
 /// Interrupt handler
 pub struct InterruptHandler<T: Instance> {
@@ -184,7 +186,7 @@ impl<'d> Pdm<'d> {
         if buffer.is_empty() {
             return Err(Error::BufferZeroLength);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 

--- a/embassy-nrf/src/pwm.rs
+++ b/embassy-nrf/src/pwm.rs
@@ -39,8 +39,8 @@ pub struct SequencePwm<'d> {
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[non_exhaustive]
 pub enum Error {
-    /// Max Sequence size is 32767
-    #[error("sequence too long: max sequence size is 32767")]
+    /// Sequence is longer than `MAX_SEQUENCE_LEN`.
+    #[error("sequence too long")]
     SequenceTooLong,
     /// Min Sequence count is 1
     #[error("sequence must play at least once")]
@@ -50,7 +50,9 @@ pub enum Error {
     BufferNotInRAM,
 }
 
-const MAX_SEQUENCE_LEN: usize = 32767;
+/// The maximum number of words in a PWM sequence.
+pub const MAX_SEQUENCE_LEN: usize =
+    crate::util::easy_dma_max!(pac::pwm::regs::Maxcnt, set_maxcnt, maxcnt) / CNT_UNIT as usize;
 /// The used pwm clock frequency
 pub const PWM_CLK_HZ: u32 = 16_000_000;
 
@@ -386,7 +388,7 @@ impl Default for SequenceConfig {
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Sequence<'s> {
-    /// The words comprising the sequence. Must not exceed 32767 words.
+    /// The words comprising the sequence. Must not exceed [`MAX_SEQUENCE_LEN`] words.
     pub words: &'s [u16],
     /// Configuration associated with the sequence.
     pub config: SequenceConfig,

--- a/embassy-nrf/src/saadc.rs
+++ b/embassy-nrf/src/saadc.rs
@@ -130,6 +130,9 @@ impl<'d> ChannelConfig<'d> {
 
 const CNT_UNIT: usize = if cfg!(feature = "_nrf54l") { 2 } else { 1 };
 
+/// The maximum buffer size (in 16-bit samples) that the SAADC EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(crate::pac::saadc::regs::Maxcnt, set_maxcnt, maxcnt) / CNT_UNIT;
+
 /// Value returned by the SAADC callback, deciding what happens next.
 #[derive(PartialEq)]
 pub enum CallbackResult {
@@ -250,6 +253,8 @@ impl<'d, const N: usize> Saadc<'d, N> {
     /// consumption remains higher if sampling is not stopped explicitly). Cancellation will
     /// also cause the sampling to be stopped.
     pub async fn sample(&mut self, buf: &mut [i16; N]) {
+        const { core::assert!(N <= DMA_SIZE, "buffer is too long for the SAADC EasyDMA") }
+
         // In case the future is dropped, stop the task and wait for it to end.
         let on_drop = OnDrop::new(Self::stop_sampling_immediately);
 
@@ -389,6 +394,7 @@ impl<'d, const N: usize> Saadc<'d, N> {
 
         // Set up the initial DMA
         r.result().ptr().write_value(bufs[0].as_mut_ptr() as u32);
+        const { core::assert!(N0 * N <= DMA_SIZE, "buffer is too long for the SAADC EasyDMA") }
         r.result().maxcnt().write(|w| w.set_maxcnt((N0 * N * CNT_UNIT) as _));
 
         // Reset and enable the events

--- a/embassy-nrf/src/spim.rs
+++ b/embassy-nrf/src/spim.rs
@@ -15,13 +15,17 @@ use embassy_sync::waitqueue::AtomicWaker;
 pub use embedded_hal_02::spi::{MODE_0, MODE_1, MODE_2, MODE_3, Mode, Phase, Polarity};
 pub use pac::spim::vals::Order as BitOrder;
 
-use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
+use crate::chip::FORCE_COPY_BUFFER_SIZE;
 use crate::gpio::{self, AnyPin, OutputDrive, Pin as GpioPin, PselBits, SealedPin as _, convert_drive};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
+use crate::pac::spim::regs::RxMaxcnt;
 use crate::pac::spim::vals;
 use crate::util::slice_in_ram_or;
 use crate::{interrupt, pac};
+
+/// The maximum buffer size (in bytes) that the SPIM EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(RxMaxcnt, set_maxcnt, maxcnt);
 
 /// SPI frequencies.
 #[repr(transparent)]
@@ -416,8 +420,8 @@ impl<'d> Spim<'d> {
         // slice can only be built from data located in RAM.
 
         let xfer_len = core::cmp::max(rx.len(), tx.len());
-        for offset in (0..xfer_len).step_by(EASY_DMA_SIZE) {
-            let length = core::cmp::min(xfer_len - offset, EASY_DMA_SIZE);
+        for offset in (0..xfer_len).step_by(DMA_SIZE) {
+            let length = core::cmp::min(xfer_len - offset, DMA_SIZE);
             self.blocking_inner_from_ram_chunk(rx, tx, offset, length);
         }
         Ok(())
@@ -470,8 +474,8 @@ impl<'d> Spim<'d> {
         // slice can only be built from data located in RAM.
 
         let xfer_len = core::cmp::max(rx.len(), tx.len());
-        for offset in (0..xfer_len).step_by(EASY_DMA_SIZE) {
-            let length = core::cmp::min(xfer_len - offset, EASY_DMA_SIZE);
+        for offset in (0..xfer_len).step_by(DMA_SIZE) {
+            let length = core::cmp::min(xfer_len - offset, DMA_SIZE);
             self.async_inner_from_ram_chunk(rx, tx, offset, length).await;
         }
         Ok(())

--- a/embassy-nrf/src/spis.rs
+++ b/embassy-nrf/src/spis.rs
@@ -12,14 +12,18 @@ use embassy_sync::waitqueue::AtomicWaker;
 pub use embedded_hal_02::spi::{MODE_0, MODE_1, MODE_2, MODE_3, Mode, Phase, Polarity};
 pub use pac::spis::vals::Order as BitOrder;
 
-use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
+use crate::chip::FORCE_COPY_BUFFER_SIZE;
 use crate::gpio::{self, AnyPin, OutputDrive, Pin as GpioPin, SealedPin as _, convert_drive};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
+use crate::pac::spis::regs::RxMaxcnt;
 use crate::pac::spis::vals;
 use crate::ppi::Event;
 use crate::util::slice_in_ram_or;
 use crate::{interrupt, pac};
+
+/// The maximum buffer size (in bytes) that the SPIS EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(RxMaxcnt, set_maxcnt, maxcnt);
 
 /// SPIS error
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
@@ -225,14 +229,14 @@ impl<'d> Spis<'d> {
         let r = self.r;
 
         // Set up the DMA write.
-        if tx.len() > EASY_DMA_SIZE {
+        if tx.len() > DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
         r.dma().tx().ptr().write_value(tx as *const u8 as _);
         r.dma().tx().maxcnt().write(|w| w.set_maxcnt(tx.len() as _));
 
         // Set up the DMA read.
-        if rx.len() > EASY_DMA_SIZE {
+        if rx.len() > DMA_SIZE {
             return Err(Error::RxBufferTooLong);
         }
         r.dma().rx().ptr().write_value(rx as *mut u8 as _);

--- a/embassy-nrf/src/twim.rs
+++ b/embassy-nrf/src/twim.rs
@@ -16,13 +16,16 @@ use embassy_time::{Duration, Instant};
 use embedded_hal_1::i2c::Operation;
 pub use pac::twim::vals::Frequency;
 
-use crate::chip::EASY_DMA_SIZE;
 use crate::gpio::Pin as GpioPin;
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
+use crate::pac::twim::regs::RxMaxcnt;
 use crate::pac::twim::vals;
 use crate::util::slice_in_ram;
 use crate::{gpio, interrupt, pac};
+
+/// The maximum buffer size (in bytes) that the TWIM EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(RxMaxcnt, set_maxcnt, maxcnt);
 
 /// TWIM config.
 #[non_exhaustive]
@@ -241,7 +244,7 @@ impl<'d> Twim<'d> {
             &*ram_buffer
         };
 
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
 
@@ -268,7 +271,7 @@ impl<'d> Twim<'d> {
         // NOTE: RAM slice check is not necessary, as a mutable
         // slice can only be built from data located in RAM.
 
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::RxBufferTooLong);
         }
 

--- a/embassy-nrf/src/twis.rs
+++ b/embassy-nrf/src/twis.rs
@@ -13,13 +13,17 @@ use embassy_sync::waitqueue::AtomicWaker;
 #[cfg(feature = "time")]
 use embassy_time::{Duration, Instant};
 
-use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
+use crate::chip::FORCE_COPY_BUFFER_SIZE;
 use crate::gpio::Pin as GpioPin;
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
+use crate::pac::twis::regs::RxMaxcnt;
 use crate::pac::twis::vals;
 use crate::util::slice_in_ram_or;
 use crate::{gpio, interrupt, pac};
+
+/// The maximum buffer size (in bytes) that the TWIS EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(RxMaxcnt, set_maxcnt, maxcnt);
 
 /// TWIS config.
 #[non_exhaustive]
@@ -245,7 +249,7 @@ impl<'d> Twis<'d> {
     unsafe fn set_tx_buffer(&mut self, buffer: &[u8]) -> Result<(), Error> {
         slice_in_ram_or(buffer, Error::BufferNotInRAM)?;
 
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::TxBufferTooLong);
         }
 
@@ -272,7 +276,7 @@ impl<'d> Twis<'d> {
         // NOTE: RAM slice check is not necessary, as a mutable
         // slice can only be built from data located in RAM.
 
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::RxBufferTooLong);
         }
 

--- a/embassy-nrf/src/uarte.rs
+++ b/embassy-nrf/src/uarte.rs
@@ -24,15 +24,19 @@ use embassy_sync::waitqueue::AtomicWaker;
 // Re-export SVD variants to allow user to directly set values.
 pub use pac::uarte::vals::{Baudrate, ConfigParity as Parity};
 
-use crate::chip::{EASY_DMA_SIZE, FORCE_COPY_BUFFER_SIZE};
+use crate::chip::FORCE_COPY_BUFFER_SIZE;
 use crate::gpio::{self, AnyPin, DISCONNECTED, Pin as GpioPin, PselBits, SealedPin as _};
 use crate::interrupt::typelevel::Interrupt;
 use crate::pac::gpio::vals as gpiovals;
+use crate::pac::uarte::regs::RxMaxcnt;
 use crate::pac::uarte::vals;
 use crate::ppi::{AnyConfigurableChannel, ConfigurableChannel, Event, Ppi, Task};
 use crate::timer::{Frequency, Instance as TimerInstance, Timer};
 use crate::util::slice_in_ram_or;
 use crate::{interrupt, pac};
+
+/// The maximum buffer size (in bytes) that the UARTE EasyDMA can transfer in one operation.
+pub const DMA_SIZE: usize = crate::util::easy_dma_max!(RxMaxcnt, set_maxcnt, maxcnt);
 
 /// UARTE config.
 #[derive(Clone)]
@@ -471,7 +475,7 @@ impl<'d> UarteTx<'d> {
         }
 
         slice_in_ram_or(buffer, Error::BufferNotInRAM)?;
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -541,7 +545,7 @@ impl<'d> UarteTx<'d> {
         }
 
         slice_in_ram_or(buffer, Error::BufferNotInRAM)?;
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -701,7 +705,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(());
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -769,7 +773,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(());
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -886,7 +890,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -945,7 +949,7 @@ impl<'d> UarteRx<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -1059,7 +1063,7 @@ impl<'d> UarteRxWithIdle<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 
@@ -1133,7 +1137,7 @@ impl<'d> UarteRxWithIdle<'d> {
         if buffer.is_empty() {
             return Ok(0);
         }
-        if buffer.len() > EASY_DMA_SIZE {
+        if buffer.len() > DMA_SIZE {
             return Err(Error::BufferTooLong);
         }
 

--- a/embassy-nrf/src/util.rs
+++ b/embassy-nrf/src/util.rs
@@ -17,3 +17,18 @@ pub(crate) fn slice_in_ram<T>(slice: *const [T]) -> bool {
 pub(crate) fn slice_in_ram_or<T, E>(slice: *const [T], err: E) -> Result<(), E> {
     if slice_in_ram(slice) { Ok(()) } else { Err(err) }
 }
+
+/// Compute the maximum value of an EasyDMA `MAXCNT`-style register field.
+///
+/// Writes all-ones through the PAC's (masking) field setter and reads the field
+/// back, so the result is exactly the largest value the hardware field can hold.
+#[cfg(not(feature = "_nrf51"))]
+macro_rules! easy_dma_max {
+    ($reg:path, $set:ident, $get:ident) => {{
+        let mut r = $reg(0);
+        r.$set(!0);
+        r.$get() as usize
+    }};
+}
+#[cfg(not(feature = "_nrf51"))]
+pub(crate) use easy_dma_max;

--- a/examples/nrf54l15-flpr/Cargo.toml
+++ b/examples/nrf54l15-flpr/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 embassy-executor = { version = "0.10.0", path = "../../embassy-executor", features = ["platform-riscv32", "executor-thread"] }
-nrf-pac = { git = "https://github.com/embassy-rs/nrf-pac", rev = "dcbec3723fa14fc81e004ab288c9b2e454dba802", features = ["nrf54l15-flpr"] }
+nrf-pac = { git = "https://github.com/embassy-rs/nrf-pac", rev = "4499375510e2fdb3a5426911beb846d8d2dbbb80", features = ["nrf54l15-flpr"] }
 panic-halt = "1.0"
 embedded-hal = "1.0"
 


### PR DESCRIPTION
Fixes https://github.com/embassy-rs/embassy/issues/6911