### PR TITLE
stm32/spi: keep SPI enabled before SPIv1 DMA transfers

### DIFF
--- a/embassy-stm32/src/spi/mod.rs
+++ b/embassy-stm32/src/spi/mod.rs
@@ -1253,6 +1253,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
             return Ok(());
         }
 
+        #[cfg(not(spi_v1))]
         self.info.regs.cr1().modify(|w| {
             w.set_spe(false);
         });
@@ -1392,6 +1393,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
             return Ok(());
         }
 
+        #[cfg(not(spi_v1))]
         self.info.regs.cr1().modify(|w| {
             w.set_spe(false);
         });
@@ -1457,6 +1459,7 @@ impl<'d, CM: CommunicationMode> Spi<'d, Async, CM> {
             return Ok(());
         }
 
+        #[cfg(not(spi_v1))]
         self.info.regs.cr1().modify(|w| {
             w.set_spe(false);
         });

--- a/examples/stm32f1/src/bin/spi_dma_software_cs.rs
+++ b/examples/stm32f1/src/bin/spi_dma_software_cs.rs
@@ -1,0 +1,44 @@
+#![no_std]
+#![no_main]
+
+//! SPI DMA example with software-controlled chip select.
+//!
+//! Connect a logic analyzer to PA4 (CS), PA5 (SCK), and PA7 (MOSI). Each CS
+//! pulse contains one mode-1 transfer of `0xa5`. SCK must remain at its idle
+//! level after CS goes low until the DMA transfer starts.
+
+use defmt::info;
+use defmt_rtt as _;
+use embassy_executor::Spawner;
+use embassy_stm32::gpio::{Level, Output, Speed};
+use embassy_stm32::spi::{Config, MODE_1, Spi};
+use embassy_stm32::time::Hertz;
+use embassy_stm32::{bind_interrupts, dma, peripherals};
+use embassy_time::Timer;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    DMA1_CHANNEL3 => dma::InterruptHandler<peripherals::DMA1_CH3>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    let p = embassy_stm32::init(Default::default());
+
+    let mut config = Config::default();
+    config.mode = MODE_1;
+    config.frequency = Hertz(1_000_000);
+
+    let mut spi = Spi::new_txonly(p.SPI1, p.PA5, p.PA7, p.DMA1_CH3, Irqs, config);
+    let mut cs = Output::new(p.PA4, Level::High, Speed::VeryHigh);
+
+    info!("SPI DMA software-CS example started");
+
+    loop {
+        cs.set_low();
+        spi.write(&[0xa5u8]).await.unwrap();
+        cs.set_high();
+
+        Timer::after_secs(1).await;
+    }
+}


### PR DESCRIPTION
Fixes #6932.

Async SPI DMA operations on SPI v1 cleared `SPE` after software-controlled chip select had already been asserted. In mode 1, this can disturb SCK before the DMA clocks begin and shift the slave transaction.

This change keeps SPI v1 enabled when the word width is unchanged. `set_word_size()` still disables the peripheral when a width change is required, and `set_config()` continues to disable it before changing CPOL or CPHA. Newer SPI revisions retain their existing behavior.

The new STM32F1 example produces a minimal, slave-independent trace using PA4 as software CS and SPI1 on PA5/PA7.

Tested on STM32F103C8:

- Mode 1 at 100 kHz, 500 kHz, 1 MHz, and 5 MHz
- Async write, read, split-operation, and full-duplex transfers
