### PR TITLE
wasm: use `web-time` for Node.js compatibility

### DIFF
--- a/embassy-time/Cargo.toml
+++ b/embassy-time/Cargo.toml
@@ -59,7 +59,7 @@ mock-driver = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 ## Create a time driver for `std` environments.
 std = ["tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 ## Create a time driver for WASM.
-wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:wasm-timer", "tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
+wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:web-time", "tick-hz-1_000_000", "dep:embassy-time-queue-utils"]
 ## Provides a time driver using the ARM CMSDK timer.
 cmsdk = [
   "dep:derive-mmio",
@@ -463,7 +463,7 @@ document-features = "0.2.7"
 # WASM dependencies
 wasm-bindgen = { version = "0.2.81", optional = true }
 js-sys = { version = "0.3", optional = true }
-wasm-timer = { version = "0.2.5", optional = true }
+web-time = { version = "1.1.0", default-features = false, optional = true }
 
 # ARM CMSDK dependencies
 derive-mmio = { version = "0.6", optional = true }

--- a/embassy-time/src/driver_wasm.rs
+++ b/embassy-time/src/driver_wasm.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use embassy_time_driver::Driver;
 use embassy_time_queue_utils::Queue;
 use wasm_bindgen::prelude::*;
-use wasm_timer::Instant as StdInstant;
+use web_time::Instant as StdInstant;
 
 #[derive(Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]


### PR DESCRIPTION
The `wasm-timer` crate is unmaintained, and its `Instant` is backed by `web_sys::window().performance()`, which is undefined in Workers / Node.js.

This swaps it for `web-time`, a drop-in replacement for `std::time::Instant` that reads `globalThis.performance.now()` and works in both the browser and Node.js / web workers.

(This was needed for [Saikuro](https://github.com/Nisoku/Saikuro) Node.js WASM support.)
