### PR TITLE
stm32/usb: add STM32N6 USB OTG HS support (integrated HS PHY)

### DIFF
--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -264,6 +264,8 @@ fn main() {
         "peri_ucpd2",
         "peri_usb_otg_fs",
         "peri_usb_otg_hs",
+        "peri_usb1_otg_hs",
+        "peri_usb2_otg_hs",
         "peri_octospi2",
         "peri_xspi2",
     ]);

--- a/embassy-stm32/src/usb/mod.rs
+++ b/embassy-stm32/src/usb/mod.rs
@@ -22,10 +22,17 @@ fn common_init<T: Instance>() {
             freq.0
         )
     }
+
+    // On the N6 the OTG core always runs off its integrated High-Speed PHY, whose reference
+    // clock must be 19.2, 20 or 24 MHz (RM0486 Rev 4, USBPHYC_CR.FSEL, p. 3929). Panics
+    // naming the offending frequency; the same mapping programs FSEL in `T::phy_init()`.
+    #[cfg(stm32n6)]
+    let _ = fsel_from_freq(freq);
+
     // Check frequency is within the 0.25% tolerance allowed by the spec.
     // Clock might not be exact 48Mhz due to rounding errors in PLL calculation, or if the user
     // has tight clock restrictions due to something else (like audio).
-    #[cfg(not(any(stm32h7rs, all(stm32u5, peri_usb_otg_hs), all(stm32wba, peri_usb_otg_hs))))]
+    #[cfg(not(any(stm32h7rs, stm32n6, all(stm32u5, peri_usb_otg_hs), all(stm32wba, peri_usb_otg_hs))))]
     if freq.0.abs_diff(48_000_000) > 120_000 {
         panic!(
             "USB clock should be 48Mhz but is {} Hz. Please double-check your RCC settings.",
@@ -127,6 +134,30 @@ fn common_init<T: Instance>() {
             while !crate::pac::PWR.vosr().read().usbboostrdy() {}
         }
     }
+
+    #[cfg(stm32n6)]
+    {
+        use crate::pac::pwr::vals::{Usb33rdy, Usb33sv};
+
+        // "The following sequence must be done before using the USB HS PHYs: 1. If VDD33USB
+        // is independent from VDD: a) Enable the USB33VM by setting USB33VMEN in PWR_SVMCR3.
+        // b) Wait until USB33RDY is set [...] 2. Set USB33SV in PWR_SVMCR3 to remove the
+        // VDD33USB power isolation." — RM0486 Rev 4, §13, p. 365; PWR_SVMCR3, pp. 395-396.
+        // Step 1c (disabling the monitor again to save power) is optional; skipped.
+        critical_section::with(|_| crate::pac::PWR.svmcr3().modify(|w| w.set_usb33vmen(true)));
+
+        // Wait for USB power to stabilize
+        while crate::pac::PWR.svmcr3().read().usb33rdy() != Usb33rdy::B0x1 {}
+
+        critical_section::with(|_| crate::pac::PWR.svmcr3().modify(|w| w.set_usb33sv(Usb33sv::B0x1)));
+    }
+
+    // Bring the PHY up before the core. On the N6 this selects the reference clock
+    // frequency (USBPHYC_CR.FSEL) with the PHY held under reset, the same window the RM
+    // requires for the PHY trims (RM0486 Rev 4, §74.4.4, p. 3928). No-op for every other
+    // OTG instance.
+    #[cfg(otg)]
+    T::phy_init();
 
     T::Interrupt::unpend();
     unsafe { T::Interrupt::enable() };

--- a/embassy-stm32/src/usb/otg.rs
+++ b/embassy-stm32/src/usb/otg.rs
@@ -130,6 +130,44 @@ impl<'d, T: Instance> Driver<'d, T> {
         }
     }
 
+    /// Initializes USB OTG peripheral with internal High-Speed PHY, on chips where that PHY
+    /// drives dedicated package pins instead of GPIO alternate functions.
+    ///
+    /// On the STM32N6 the integrated UTMI+ PHY is wired to the `OTGx_HSDP` / `OTGx_HSDM`
+    /// balls (RM0486 Rev 4, Figure 982, p. 3763), which are not GPIOs and therefore have no
+    /// [`DpPin`] / [`DmPin`] implementations — there is nothing to hand over here.
+    /// For chips whose internal High-Speed PHY *is* reached through GPIO alternate functions
+    /// (STM32U5, STM32H7RS, ...), use [`Driver::new_hs`] and pass the two pins.
+    ///
+    /// # Arguments
+    ///
+    /// * `ep_out_buffer` - An internal buffer used to temporarily store received packets.
+    /// Must be large enough to fit all OUT endpoint max packet sizes.
+    /// Endpoint allocation will fail if it is too small.
+    pub fn new_hs_dedicated_pins(
+        _peri: Peri<'d, T>,
+        _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
+        ep_out_buffer: &'d mut [u8],
+        config: Config,
+    ) -> Self {
+        assert!(T::HIGH_SPEED, "Peripheral is not capable of high-speed USB");
+
+        let instance = OtgInstance {
+            regs: T::regs(),
+            state: T::state(),
+            fifo_depth_words: T::FIFO_DEPTH_WORDS,
+            tx_fifo_count: T::state().endpoint_count() as u8,
+            extra_rx_fifo_words: RX_FIFO_EXTRA_SIZE_WORDS,
+            phy_type: PhyType::InternalHighSpeed,
+            calculate_trdt_fn: calculate_trdt::<T>,
+        };
+
+        Self {
+            inner: OtgDriver::new(ep_out_buffer, instance, config),
+            phantom: PhantomData,
+        }
+    }
+
     /// Initializes USB OTG peripheral with external Full-speed PHY (usually, a High-speed PHY in Full-speed mode).
     ///
     /// # Arguments
@@ -440,12 +478,37 @@ impl<'d, T: Instance> Drop for Bus<'d, T> {
     }
 }
 
-trait SealedInstance {
+pub(super) trait SealedInstance {
     const HIGH_SPEED: bool;
     const FIFO_DEPTH_WORDS: u16;
 
     fn regs() -> Otg;
     fn state() -> State<'static>;
+
+    /// Bring up the PHY that feeds this instance, if it needs a bring-up of its own.
+    ///
+    /// Called by `common_init` before the OTG core is enabled and reset. Empty for every
+    /// family whose PHY is handled by the core's own clock/power gating.
+    fn phy_init() {}
+}
+
+/// STM32N6: map the PHY reference clock to `USBPHYC_CR.FSEL`.
+///
+/// The integrated High-Speed PHY only accepts these three frequencies
+/// (RM0486 Rev 4, `USBPHYC_CR.FSEL`, p. 3929).
+#[cfg(stm32n6)]
+pub(super) fn fsel_from_freq(freq: crate::time::Hertz) -> crate::pac::usbphyc::vals::Fsel {
+    use crate::pac::usbphyc::vals::Fsel;
+
+    match freq.0 {
+        19_200_000 => Fsel::Mhz192,
+        20_000_000 => Fsel::Mhz20,
+        24_000_000 => Fsel::Mhz24,
+        _ => panic!(
+            "USB HS PHY reference clock should be 19.2, 20 or 24 MHz but is {} Hz. Please double-check your RCC settings.",
+            freq.0
+        ),
+    }
 }
 
 /// USB instance trait.
@@ -652,6 +715,135 @@ foreach_interrupt!(
         }
 
         impl Instance for crate::peripherals::USB_OTG_HS {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+    };
+
+    (USB1_OTG_HS, otg, $block:ident, GLOBAL, $irq:ident) => {
+        impl crate::peripherals::USB1_OTG_HS {
+            cfg_if::cfg_if! {
+                if #[cfg(stm32n6)] {
+                    // RM0486 Rev 4, §73.3 Table 736, p. 3762: 9 bidirectional device
+                    // endpoints including EP0, and 4 KB of dedicated SRAM = 1024 words.
+                    const ENDPOINT_COUNT: usize = 9;
+                } else {
+                    compile_error!("USB1_OTG_HS peripheral is not supported by this chip.");
+                }
+            }
+        }
+
+        impl SealedInstance for crate::peripherals::USB1_OTG_HS {
+            const HIGH_SPEED: bool = true;
+
+            cfg_if::cfg_if! {
+                if #[cfg(stm32n6)] {
+                    const FIFO_DEPTH_WORDS: u16 = 1024;
+                } else {
+                    compile_error!("USB1_OTG_HS peripheral is not supported by this chip.");
+                }
+            }
+
+            fn regs() -> Otg {
+                unsafe { Otg::from_ptr(crate::pac::USB1_OTG_HS.as_ptr()) }
+            }
+
+            fn state() -> State<'static> {
+                use embassy_usb_synopsys_otg::StateStorage;
+                use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+                const EP_COUNT: usize = crate::peripherals::USB1_OTG_HS::ENDPOINT_COUNT;
+                static STATE: StateStorage<EP_COUNT> = StateStorage::new(CriticalSectionRawMutex::new());
+                STATE.as_state()
+            }
+
+            fn phy_init() {
+                let fsel = fsel_from_freq(<Self as crate::rcc::SealedRccPeripheral>::frequency());
+                let rcc = crate::pac::RCC;
+
+                // The RM requires the PHY trims to be programmed while the PHY is under
+                // reset (RM0486 Rev 4, §74.4.4, p. 3928) and says nothing either way about
+                // FSEL, which lives next to them in USBPHYC_CR; program it in the same
+                // window to be safe. Use the atomic set/clear reset registers so the reset
+                // stays asserted across the write; the generic `rcc::enable_and_reset`
+                // would already have released it.
+                rcc.ahb5rstsr().write(|w| {
+                    w.set_otgphy1rsts(true);
+                    w.set_syscfgotghsphy1rsts(true);
+                });
+                // Clocking the PHY by hand skips the RCC refcount. That is fine here:
+                // the PHY is private to its OTG core and lives and dies with it.
+                rcc.ahb5ensr().write(|w| w.set_otgphy1ens(true));
+                // The trims (TRIM1CR / TRIM2CR) keep their reset values, which are the
+                // recommended ones (RM0486 Rev 4, §74.5, pp. 3930-3934).
+                crate::pac::OTG1PHYCTL.cr().modify(|w| w.set_fsel(fsel));
+                rcc.ahb5rstcr().write(|w| {
+                    w.set_otgphy1rstc(true);
+                    w.set_syscfgotghsphy1rstc(true);
+                });
+            }
+        }
+
+        impl Instance for crate::peripherals::USB1_OTG_HS {
+            type Interrupt = crate::interrupt::typelevel::$irq;
+        }
+    };
+
+    (USB2_OTG_HS, otg, $block:ident, GLOBAL, $irq:ident) => {
+        impl crate::peripherals::USB2_OTG_HS {
+            cfg_if::cfg_if! {
+                if #[cfg(stm32n6)] {
+                    // Second instance, identical to the first — RM0486 Rev 4,
+                    // §73.3 Table 736, p. 3762.
+                    const ENDPOINT_COUNT: usize = 9;
+                } else {
+                    compile_error!("USB2_OTG_HS peripheral is not supported by this chip.");
+                }
+            }
+        }
+
+        impl SealedInstance for crate::peripherals::USB2_OTG_HS {
+            const HIGH_SPEED: bool = true;
+
+            cfg_if::cfg_if! {
+                if #[cfg(stm32n6)] {
+                    const FIFO_DEPTH_WORDS: u16 = 1024;
+                } else {
+                    compile_error!("USB2_OTG_HS peripheral is not supported by this chip.");
+                }
+            }
+
+            fn regs() -> Otg {
+                unsafe { Otg::from_ptr(crate::pac::USB2_OTG_HS.as_ptr()) }
+            }
+
+            fn state() -> State<'static> {
+                use embassy_usb_synopsys_otg::StateStorage;
+                use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+
+                const EP_COUNT: usize = crate::peripherals::USB2_OTG_HS::ENDPOINT_COUNT;
+                static STATE: StateStorage<EP_COUNT> = StateStorage::new(CriticalSectionRawMutex::new());
+                STATE.as_state()
+            }
+
+            fn phy_init() {
+                // Same sequence as USB1_OTG_HS above, on PHY2.
+                let fsel = fsel_from_freq(<Self as crate::rcc::SealedRccPeripheral>::frequency());
+                let rcc = crate::pac::RCC;
+
+                rcc.ahb5rstsr().write(|w| {
+                    w.set_otgphy2rsts(true);
+                    w.set_syscfgotghsphy2rsts(true);
+                });
+                rcc.ahb5ensr().write(|w| w.set_otgphy2ens(true));
+                crate::pac::OTG2PHYCTL.cr().modify(|w| w.set_fsel(fsel));
+                rcc.ahb5rstcr().write(|w| {
+                    w.set_otgphy2rstc(true);
+                    w.set_syscfgotghsphy2rstc(true);
+                });
+            }
+        }
+
+        impl Instance for crate::peripherals::USB2_OTG_HS {
             type Interrupt = crate::interrupt::typelevel::$irq;
         }
     };

--- a/examples/stm32n6/src/bin/usb_serial.rs
+++ b/examples/stm32n6/src/bin/usb_serial.rs
@@ -1,0 +1,141 @@
+#![no_std]
+#![no_main]
+
+//! CDC-ACM echo over USB1_OTG_HS on the STM32N6570-DK.
+//!
+//! The N6's OTG cores are High-Speed only and drive an integrated UTMI+ PHY on
+//! dedicated `OTG1_HSDP` / `OTG1_HSDM` balls, so the driver takes no D+/D- pins.
+
+use defmt::{panic, *};
+use defmt_rtt as _; // global logger
+use embassy_executor::Spawner;
+use embassy_futures::join::join;
+use embassy_stm32::rcc::mux::Otgphysel;
+use embassy_stm32::rcc::{IcConfig, Icint, Icsel, Pll, Plldivm, Pllpdiv, Pllsel, SupplyConfig};
+use embassy_stm32::usb::{Driver, Instance};
+use embassy_stm32::{Config, bind_interrupts, peripherals, usb};
+use embassy_usb::Builder;
+use embassy_usb::class::cdc_acm::{CdcAcmClass, State};
+use embassy_usb::driver::EndpointError;
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    USB1_OTG_HS => usb::InterruptHandler<peripherals::USB1_OTG_HS>;
+});
+
+#[embassy_executor::main]
+async fn main(_spawner: Spawner) {
+    info!("Hello World!");
+
+    let mut config = Config::default();
+    {
+        // DK uses external SMPS (UM3300 Tab.6); embassy default = internal SMPS hangs init() at VOSRDY.
+        config.rcc.supply_config = SupplyConfig::External;
+
+        // The HS PHY reference clock must be exactly 19.2, 20 or 24 MHz (RM0486 Rev 4,
+        // USBPHYC_CR.FSEL, p. 3929). Derive 24 MHz from the HSI so the example does not
+        // depend on the board's crystal:
+        //
+        //   hsi_ck   = 64 MHz                              (RM0486 Rev 4, §14.6.2)
+        //   FREF     = 64 MHz / DIVM 4      =  16 MHz      (5..1200 MHz, integer mode, p. 435)
+        //   FVCO     = 16 MHz * DIVN 60     = 960 MHz      (800..3200 MHz, p. 435)
+        //   pll4_ck  = 960 MHz / 2 / 1      = 480 MHz      (DIVP1 = 2, DIVP2 = 1)
+        //   ic15_ck  = 480 MHz / 20         =  24 MHz      (ICINT = Div20)
+        //
+        // PLL4 is the RM's "display, camera, FDCAN, and other peripherals" PLL (§14.6.5,
+        // p. 435) and nothing else in this example uses it.
+        config.rcc.pll4 = Some(Pll::Oscillator {
+            source: Pllsel::Hsi,
+            divm: Plldivm::Div4,
+            fractional: 0,
+            divn: 60,
+            divp1: Pllpdiv::Div2,
+            divp2: Pllpdiv::Div1,
+        });
+        config.rcc.ic15 = Some(IcConfig {
+            source: Icsel::Pll4,
+            divider: Icint::Div20,
+        });
+        config.rcc.mux.otgphy1sel = Otgphysel::Ic15;
+    }
+
+    let p = embassy_stm32::init(config);
+
+    // Create the driver, from the HAL.
+    let mut ep_out_buffer = [0u8; 1024];
+    let mut config = embassy_stm32::usb::Config::default();
+    // Do not enable vbus_detection. This is a safe default that works in all boards.
+    // However, if your USB device is self-powered (can stay powered on if USB is unplugged), you need
+    // to enable vbus_detection to comply with the USB spec. If you enable it, the board
+    // has to support it or USB won't work at all. See docs on `vbus_detection` for details.
+    config.vbus_detection = false;
+    let driver = Driver::new_hs_dedicated_pins(p.USB1_OTG_HS, Irqs, &mut ep_out_buffer, config);
+
+    // Create embassy-usb Config
+    let mut config = embassy_usb::Config::new(0xc0de, 0xcafe);
+    config.manufacturer = Some("Embassy");
+    config.product = Some("USB-serial example");
+    config.serial_number = Some("12345678");
+
+    // Create embassy-usb DeviceBuilder using the driver and config.
+    // It needs some buffers for building the descriptors.
+    let mut config_descriptor = [0; 256];
+    let mut bos_descriptor = [0; 256];
+    let mut control_buf = [0; 64];
+
+    let mut state = State::new();
+
+    let mut builder = Builder::new(
+        driver,
+        config,
+        &mut config_descriptor,
+        &mut bos_descriptor,
+        &mut [], // no msos descriptors
+        &mut control_buf,
+    );
+
+    // Create classes on the builder.
+    // High-speed bulk endpoints must have a max packet size of 512 bytes.
+    let mut class = CdcAcmClass::new(&mut builder, &mut state, 512);
+
+    // Build the builder.
+    let mut usb = builder.build();
+
+    // Run the USB device.
+    let usb_fut = usb.run();
+
+    // Do stuff with the class!
+    let echo_fut = async {
+        loop {
+            class.wait_connection().await;
+            info!("Connected");
+            let _ = echo(&mut class).await;
+            info!("Disconnected");
+        }
+    };
+
+    // Run everything concurrently.
+    // If we had made everything `'static` above instead, we could do this using separate tasks instead.
+    join(usb_fut, echo_fut).await;
+}
+
+struct Disconnected {}
+
+impl From<EndpointError> for Disconnected {
+    fn from(val: EndpointError) -> Self {
+        match val {
+            EndpointError::BufferOverflow => panic!("Buffer overflow"),
+            EndpointError::Disabled => Disconnected {},
+        }
+    }
+}
+
+async fn echo<'d, T: Instance + 'd>(class: &mut CdcAcmClass<'d, Driver<'d, T>>) -> Result<(), Disconnected> {
+    let mut buf = [0; 512];
+    loop {
+        let n = class.read_packet(&mut buf).await?;
+        let data = &buf[..n];
+        info!("data: {:x}", data);
+        class.write_packet(data).await?;
+    }
+}


### PR DESCRIPTION
## Summary

Adds USB OTG HS device support for the STM32N6, which so far had no `usb::Instance` at all: the N6 names its cores `USB1_OTG_HS` / `USB2_OTG_HS` (no `foreach_interrupt!` arm matched them), and its integrated High-Speed PHY needs a bring-up of its own before the OTG core can be enabled.

**Depends on embassy-rs/stm32-data#911** (RCC mapping for the two OTG cores, the `USBPHYC` register block, and a fix to the `OTGPHYSEL` enum). This PR is a draft until that lands and `stm32-metapac` is bumped to a tag that includes it; it was verified locally against a metapac generated from that branch.

## What changes

- **`rcc/n6.rs`**: adds the `hse_div2_osc` kernel clock (HSE/2, the `hse_div2_osc_ck` input of the OTGPHY mux — RM0486 Rev 4, RCC_CCIPR6, pp. 534-535). Without it the N6 does not compile once the metapac carries the OTG mux.
- **`build.rs`**: declares `peri_usb1_otg_hs` / `peri_usb2_otg_hs` (they are enabled automatically from the `otg` kind, but need declaring).
- **`usb/otg.rs`**:
  - `foreach_interrupt!` arms for `USB1_OTG_HS` and `USB2_OTG_HS`: 9 bidirectional device endpoints including EP0 and 4 KB of dedicated FIFO RAM = 1024 words (RM0486 Rev 4, §73.3 Table 736, p. 3762), `HIGH_SPEED = true`, one `StateStorage` per instance.
  - `Driver::new_hs_dedicated_pins(peri, irq, ep_out_buffer, config)`: a constructor for cores whose integrated HS PHY drives dedicated package balls (`OTGx_HSDP` / `OTGx_HSDM`, Figure 982 p. 3763) rather than GPIO alternate functions — on the N6 nothing implements `DpPin`/`DmPin`, so `new_hs` cannot be called. Chips that reach their internal HS PHY through GPIO AFs (U5, H7RS) keep using `new_hs`.
  - A `SealedInstance::phy_init()` hook with an empty default, implemented for the two N6 instances with the sequence the RM requires: hold `OTGPHYxRST` and `SYSCFGOTGHSPHYxRST`, enable `OTGPHYxEN`, program `USBPHYC_CR.FSEL` from the configured reference clock **while the PHY is under reset** (§74.4.4, p. 3928), release the resets. FSEL accepts only 19.2 / 20 / 24 MHz (p. 3929); anything else panics naming the frequency. Trims keep their reset values. `SealedInstance` becomes `pub(super)` so `common_init` can call the hook.
- **`usb/mod.rs`**: N6 arm in `common_init` — the `PWR_SVMCR3` sequence `USB33VMEN` → wait `USB33RDY` → `USB33SV` (§13 p. 365, pp. 395-396), the N6-specific reference-clock check, and the `phy_init()` call before `rcc::enable_and_reset::<T>()`.
- **`examples/stm32n6/src/bin/usb_serial.rs`**: CDC-ACM echo on `USB1_OTG_HS` for the STM32N6570-DK. The 24 MHz PHY reference is derived from HSI through PLL4 → IC15 (64 / 4 × 60 = 960 MHz VCO, within 800-3200 MHz per p. 435; / 2 / 1 = 480 MHz; / 20 = 24 MHz) so the example does not depend on the board crystal.

## Verification

Against a local metapac generated from stm32-data#911:

- `examples/stm32n6`: `usb_serial` and `blinky` check clean.
- `examples/stm32u5 usb_hs_serial`, `examples/stm32h7rs usb_serial`, `examples/stm32f4 usb_serial`: unchanged, check clean.
- `cargo clippy` for `stm32n657x0`: no findings in the touched files (the crate has pre-existing warnings elsewhere).

Not verified on hardware — I do not have an N6 board on the bench yet. The PHY sequence follows the RM to the letter, but the first real test will be the example on a DK.

## Open questions for review

- `new_hs_dedicated_pins` is not family-gated. On a chip whose DP/DM are GPIO alternate functions it would skip the AF setup (documented; no UB). Happy to add a `cfg` if you prefer it unreachable there.
- `SealedInstance` changed from private to `pub(super)`; if there is a preferred way to let `usb/mod.rs` call into the `_version` module, say the word.
- `OTGPHYxCKREFSEL` is left at reset (mux output); the `HSE_DIV2_OSC` variant covers the raw-HSE/2 case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015irzUk2ubW8HPRrtKyjLxb
