### PR TITLE
stm32: feature/uart 9 bit data fields

### DIFF
--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -623,7 +623,11 @@ impl<'d> UartTx<'d, Async> {
         )
     }
 
-    async fn write_helper<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+    /// Initiate an asynchronous UART write
+    ///
+    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
+    /// the low-order bits of each word.
+    pub async fn write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         let r = self.info.regs;
@@ -666,19 +670,6 @@ impl<'d> UartTx<'d, Async> {
         }
 
         Ok(())
-    }
-
-    /// Initiate an asynchronous UART write
-    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
-        self.write_helper(buffer).await
-    }
-
-    /// Initiate an asynchronous UART write of 16 bit words
-    ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
-    /// transmits only the low-order bits of each word.
-    pub async fn write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
-        self.write_helper(buffer).await
     }
 
     /// Wait until transmission complete
@@ -842,7 +833,11 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
         }
     }
 
-    fn blocking_write_helper<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+    /// Perform a blocking UART write
+    ///
+    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
+    /// the low-order bits of each word.
+    pub fn blocking_write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
         let r = self.info.regs;
         let half_duplex = r.cr3().read().hdsel();
 
@@ -867,19 +862,6 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
         }
 
         Ok(())
-    }
-
-    /// Perform a blocking UART write
-    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
-        self.blocking_write_helper(buffer)
-    }
-
-    /// Perform a blocking UART write of 16 bit words
-    ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
-    /// transmits only the low-order bits of each word.
-    pub fn blocking_write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
-        self.blocking_write_helper(buffer)
     }
 
     /// Block until transmission complete
@@ -1059,19 +1041,10 @@ impl<'d> UartRx<'d, Async> {
     }
 
     /// Initiate an asynchronous UART read
-    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
-        let _scoped_wake_guard = self.info.rcc.wake_guard();
-
-        self.inner_read(buffer, false).await?;
-
-        Ok(())
-    }
-
-    /// Initiate an asynchronous UART read of 16 bit words
     ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
-    /// bits of each received word are zero.
-    pub async fn read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
+    /// received word are zero.
+    pub async fn read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.inner_read(buffer, false).await?;
@@ -1083,22 +1056,10 @@ impl<'d> UartRx<'d, Async> {
     ///
     /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
     /// as if you had called [`read(buffer)`](Self::read) instead!
-    pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
-        let _scoped_wake_guard = self.info.rcc.wake_guard();
-
-        self.inner_read(buffer, true).await
-    }
-
-    /// Initiate an asynchronous read of 16 bit words with idle line detection enabled.
     ///
-    /// Returns the number of words received.
-    ///
-    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
-    /// as if you had called [`read_u16(buffer)`](Self::read_u16) instead!
-    ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
-    /// bits of each received word are zero.
-    pub async fn read_until_idle_u16(&mut self, buffer: &mut [u16]) -> Result<usize, Error> {
+    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
+    /// received word are zero.
+    pub async fn read_until_idle<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<usize, Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.inner_read(buffer, true).await
@@ -1535,7 +1496,11 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
         }
     }
 
-    fn blocking_read_helper<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+    /// Perform a blocking read into `buffer`
+    ///
+    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
+    /// received word are zero.
+    pub fn blocking_read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
         let r = self.info.regs;
 
         // Call flush for Half-Duplex mode if some bytes were written and flush was not called.
@@ -1558,19 +1523,6 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
             unsafe { *b = W::rdr_ptr(r).read_volatile() }
         }
         Ok(())
-    }
-
-    /// Perform a blocking read into `buffer`
-    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
-        self.blocking_read_helper(buffer)
-    }
-
-    /// Perform a blocking read of 16 bit words into `buffer`
-    ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
-    /// bits of each received word are zero.
-    pub fn blocking_read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
-        self.blocking_read_helper(buffer)
     }
 
     /// Set baudrate
@@ -1934,16 +1886,11 @@ impl<'d> Uart<'d, Async> {
     }
 
     /// Perform an asynchronous write
-    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
-        self.tx.write(buffer).await
-    }
-
-    /// Perform an asynchronous write of 16 bit words
     ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
-    /// transmits only the low-order bits of each word.
-    pub async fn write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
-        self.tx.write_u16(buffer).await
+    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
+    /// the low-order bits of each word.
+    pub async fn write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+        self.tx.write(buffer).await
     }
 
     /// Wait until transmission complete
@@ -1952,35 +1899,22 @@ impl<'d> Uart<'d, Async> {
     }
 
     /// Perform an asynchronous read into `buffer`
-    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
-        self.rx.read(buffer).await
-    }
-
-    /// Perform an asynchronous read into `buffer` using 16 bit words
     ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
-    /// bits of each received word are zero.
-    pub async fn read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
-        self.rx.read_u16(buffer).await
+    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
+    /// received word are zero.
+    pub async fn read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+        self.rx.read(buffer).await
     }
 
     /// Perform an an asynchronous read with idle line detection enabled.
     ///
     /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
     /// as if you had called [`read(buffer)`](Self::read) instead!
-    pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
+    ///
+    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
+    /// received word are zero.
+    pub async fn read_until_idle<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<usize, Error> {
         self.rx.read_until_idle(buffer).await
-    }
-
-    /// Perform an asynchronous read with idle line detection enabled using 16 bit words.
-    ///
-    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
-    /// as if you had called [`read_u16(buffer)`](Self::read_u16) instead!
-    ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
-    /// bits of each received word are zero.
-    pub async fn read_until_idle_u16(&mut self, buffer: &mut [u16]) -> Result<usize, Error> {
-        self.rx.read_until_idle_u16(buffer).await
     }
 }
 
@@ -2354,16 +2288,11 @@ impl<'d, M: PeriMode> Uart<'d, M> {
     }
 
     /// Perform a blocking write
-    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
-        self.tx.blocking_write(buffer)
-    }
-
-    /// Perform a blocking write of 16 bit words
     ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
-    /// transmits only the low-order bits of each word.
-    pub fn blocking_write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
-        self.tx.blocking_write_u16(buffer)
+    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
+    /// the low-order bits of each word.
+    pub fn blocking_write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+        self.tx.blocking_write(buffer)
     }
 
     /// Block until transmission complete
@@ -2377,16 +2306,11 @@ impl<'d, M: PeriMode> Uart<'d, M> {
     }
 
     /// Perform a blocking read into `buffer`
-    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
-        self.rx.blocking_read(buffer)
-    }
-
-    /// Perform a blocking read of 16 bit words into `buffer`
     ///
-    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
-    /// bits of each received word are zero.
-    pub fn blocking_read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
-        self.rx.blocking_read_u16(buffer)
+    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
+    /// received word are zero.
+    pub fn blocking_read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+        self.rx.blocking_read(buffer)
     }
 
     /// Split the Uart into a transmitter and receiver, which is
@@ -2931,11 +2855,7 @@ mod buffered;
 mod ringbuffered;
 pub use ringbuffered::RingBufferedUartRx;
 
-/// The word sizes the USART data register can carry.
-///
-/// Selects the width used to access the data register, so that a 9 bit frame is
-/// read and written as a `u16` while an 8 bit frame stays a `u8`.
-trait UsartWord: Word {
+pub(crate) trait SealedUsartWord {
     /// Transmit data register, accessed at this word's width.
     fn tdr_ptr(r: Regs) -> *mut Self;
 
@@ -2943,7 +2863,16 @@ trait UsartWord: Word {
     fn rdr_ptr(r: Regs) -> *mut Self;
 }
 
-impl UsartWord for u8 {
+/// The word sizes the USART data register can carry.
+///
+/// Selects the width used to access the data register, so that a 9 bit frame is
+/// read and written as a `u16` while an 8 bit frame stays a `u8`.
+///
+/// Implemented for `u8` and `u16`; this trait is sealed.
+#[allow(private_bounds)]
+pub trait UsartWord: Word + SealedUsartWord {}
+
+impl SealedUsartWord for u8 {
     fn tdr_ptr(r: Regs) -> *mut u8 {
         tdr(r)
     }
@@ -2953,7 +2882,9 @@ impl UsartWord for u8 {
     }
 }
 
-impl UsartWord for u16 {
+impl UsartWord for u8 {}
+
+impl SealedUsartWord for u16 {
     fn tdr_ptr(r: Regs) -> *mut u16 {
         tdr(r).cast()
     }
@@ -2962,6 +2893,8 @@ impl UsartWord for u16 {
         rdr(r).cast()
     }
 }
+
+impl UsartWord for u16 {}
 
 #[cfg(any(usart_v1, usart_v2))]
 fn tdr(r: crate::pac::usart::Usart) -> *mut u8 {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -496,16 +496,16 @@ impl<'d, M: PeriMode> SetConfig for UartTx<'d, M> {
 /// `embedded_io::Read` requires guarantees that this struct cannot provide:
 ///
 /// - Any data received between calls to [`UartRx::read`] or [`UartRx::blocking_read`]
-/// will be thrown away, as `UartRx` is unbuffered.
-/// Users of `embedded_io::Read` are likely to not expect this behavior
-/// (for instance if they read multiple small chunks in a row).
+///   will be thrown away, as `UartRx` is unbuffered.
+///   Users of `embedded_io::Read` are likely to not expect this behavior
+///   (for instance if they read multiple small chunks in a row).
 /// - [`UartRx::read`] and [`UartRx::blocking_read`] only return once the entire buffer has been
-/// filled, whereas `embedded_io::Read` requires us to fill the buffer with what we already
-/// received, and only block/wait until the first byte arrived.
-/// <br />
-/// While [`UartRx::read_until_idle`] does return early, it will still eagerly wait for data until
-/// the buffer is full or no data has been transmitted in a while,
-/// which may not be what users of `embedded_io::Read` expect.
+///   filled, whereas `embedded_io::Read` requires us to fill the buffer with what we already
+///   received, and only block/wait until the first byte arrived.
+///   <br />
+///   While [`UartRx::read_until_idle`] does return early, it will still eagerly wait for data until
+///   the buffer is full or no data has been transmitted in a while,
+///   which may not be what users of `embedded_io::Read` expect.
 ///
 /// [`UartRx::into_ring_buffered`] can be called to equip `UartRx` with a buffer,
 /// that it can then use to store data received between calls to `read`,
@@ -662,7 +662,7 @@ impl<'d> UartTx<'d, Async> {
             // first so the last byte(s) have actually left the shift register
             // before RE comes back, otherwise the tail of this transmission
             // gets read back as incoming data.
-            flush(&self.info, &self.state).await?;
+            flush(self.info, self.state).await?;
             r.cr1().modify(|reg| {
                 reg.set_re(true);
                 reg.set_te(false);
@@ -676,7 +676,7 @@ impl<'d> UartTx<'d, Async> {
     pub async fn flush(&mut self) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
-        flush(&self.info, &self.state).await
+        flush(self.info, self.state).await
     }
 }
 
@@ -1075,7 +1075,7 @@ impl<'d> UartRx<'d, Async> {
         // Call flush for Half-Duplex mode if some bytes were written and flush was not called.
         // It prevents reading of bytes which have just been written.
         if r.cr3().read().hdsel() && r.cr1().read().te() {
-            flush(&self.info, &self.state).await?;
+            flush(self.info, self.state).await?;
 
             // Disable Transmitter and enable Receiver after flush
             r.cr1().set_bits(|reg| {
@@ -1411,7 +1411,7 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
         configure(
             info,
             self.kernel_clock,
-            &config,
+            config,
             self._ck.is_some(),
             true,
             false,

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -17,6 +17,7 @@ use futures_util::future::{Either, select};
 use crate::Peri;
 use crate::atomic::{AtomicClear, AtomicDecrement, AtomicModify};
 use crate::dma::ChannelAndRequest;
+use crate::dma::word::Word;
 use crate::gpio::{AfType, Flex, OutputType, Pull, Speed};
 use crate::interrupt::typelevel::Interrupt as _;
 use crate::interrupt::{self, Interrupt, InterruptExt};
@@ -622,8 +623,7 @@ impl<'d> UartTx<'d, Async> {
         )
     }
 
-    /// Initiate an asynchronous UART write
-    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+    async fn write_helper<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         let r = self.info.regs;
@@ -645,7 +645,7 @@ impl<'d> UartTx<'d, Async> {
         });
         // If we don't assign future to a variable, the data register pointer
         // is held across an await and makes the future non-Send.
-        let transfer = unsafe { ch.write(buffer, tdr(r), Default::default()) };
+        let transfer = unsafe { ch.write(buffer, W::tdr_ptr(r), Default::default()) };
         transfer.await;
 
         if half_duplex {
@@ -666,6 +666,19 @@ impl<'d> UartTx<'d, Async> {
         }
 
         Ok(())
+    }
+
+    /// Initiate an asynchronous UART write
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.write_helper(buffer).await
+    }
+
+    /// Initiate an asynchronous UART write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub async fn write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.write_helper(buffer).await
     }
 
     /// Wait until transmission complete
@@ -829,8 +842,7 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
         }
     }
 
-    /// Perform a blocking UART write
-    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+    fn blocking_write_helper<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
         let r = self.info.regs;
         let half_duplex = r.cr3().read().hdsel();
 
@@ -841,7 +853,7 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
 
         for &b in buffer {
             while !sr(r).read().txe() {}
-            unsafe { tdr(r).write_volatile(b) };
+            unsafe { W::tdr_ptr(r).write_volatile(b) };
         }
 
         if half_duplex {
@@ -855,6 +867,19 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
         }
 
         Ok(())
+    }
+
+    /// Perform a blocking UART write
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.blocking_write_helper(buffer)
+    }
+
+    /// Perform a blocking UART write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub fn blocking_write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.blocking_write_helper(buffer)
     }
 
     /// Block until transmission complete
@@ -1042,6 +1067,18 @@ impl<'d> UartRx<'d, Async> {
         Ok(())
     }
 
+    /// Initiate an asynchronous UART read of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
+
+        self.inner_read(buffer, false).await?;
+
+        Ok(())
+    }
+
     /// Initiate an asynchronous read with idle line detection enabled.
     ///
     /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
@@ -1052,9 +1089,24 @@ impl<'d> UartRx<'d, Async> {
         self.inner_read(buffer, true).await
     }
 
-    async fn inner_read_run(
+    /// Initiate an asynchronous read of 16 bit words with idle line detection enabled.
+    ///
+    /// Returns the number of words received.
+    ///
+    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
+    /// as if you had called [`read_u16(buffer)`](Self::read_u16) instead!
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_until_idle_u16(&mut self, buffer: &mut [u16]) -> Result<usize, Error> {
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
+
+        self.inner_read(buffer, true).await
+    }
+
+    async fn inner_read_run<W: UsartWord>(
         &mut self,
-        buffer: &mut [u8],
+        buffer: &mut [W],
         enable_idle_line_detection: bool,
     ) -> Result<ReadCompletionEvent, Error> {
         let r = self.info.regs;
@@ -1100,7 +1152,7 @@ impl<'d> UartRx<'d, Async> {
         // Start USART DMA
         // will not do anything yet because DMAR is not yet set
         // future which will complete when DMA Read request completes
-        let transfer = unsafe { ch.read(rdr(r), buffer, Default::default()) };
+        let transfer = unsafe { ch.read(W::rdr_ptr(r), buffer, Default::default()) };
 
         // clear ORE flag just before enabling DMA Rx Request: can be mandatory for the second transfer
         if !self.detect_previous_overrun {
@@ -1246,7 +1298,11 @@ impl<'d> UartRx<'d, Async> {
         r
     }
 
-    async fn inner_read(&mut self, buffer: &mut [u8], enable_idle_line_detection: bool) -> Result<usize, Error> {
+    async fn inner_read<W: UsartWord>(
+        &mut self,
+        buffer: &mut [W],
+        enable_idle_line_detection: bool,
+    ) -> Result<usize, Error> {
         if buffer.is_empty() {
             return Ok(0);
         } else if buffer.len() > 0xFFFF {
@@ -1479,8 +1535,7 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
         }
     }
 
-    /// Perform a blocking read into `buffer`
-    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+    fn blocking_read_helper<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
         let r = self.info.regs;
 
         // Call flush for Half-Duplex mode if some bytes were written and flush was not called.
@@ -1500,9 +1555,22 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
 
         for b in buffer {
             while !self.check_rx_flags()? {}
-            unsafe { *b = rdr(r).read_volatile() }
+            unsafe { *b = W::rdr_ptr(r).read_volatile() }
         }
         Ok(())
+    }
+
+    /// Perform a blocking read into `buffer`
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.blocking_read_helper(buffer)
+    }
+
+    /// Perform a blocking read of 16 bit words into `buffer`
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub fn blocking_read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        self.blocking_read_helper(buffer)
     }
 
     /// Set baudrate
@@ -1870,6 +1938,14 @@ impl<'d> Uart<'d, Async> {
         self.tx.write(buffer).await
     }
 
+    /// Perform an asynchronous write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub async fn write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.tx.write_u16(buffer).await
+    }
+
     /// Wait until transmission complete
     pub async fn flush(&mut self) -> Result<(), Error> {
         self.tx.flush().await
@@ -1880,12 +1956,31 @@ impl<'d> Uart<'d, Async> {
         self.rx.read(buffer).await
     }
 
+    /// Perform an asynchronous read into `buffer` using 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        self.rx.read_u16(buffer).await
+    }
+
     /// Perform an an asynchronous read with idle line detection enabled.
     ///
     /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
     /// as if you had called [`read(buffer)`](Self::read) instead!
     pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
         self.rx.read_until_idle(buffer).await
+    }
+
+    /// Perform an asynchronous read with idle line detection enabled using 16 bit words.
+    ///
+    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
+    /// as if you had called [`read_u16(buffer)`](Self::read_u16) instead!
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_until_idle_u16(&mut self, buffer: &mut [u16]) -> Result<usize, Error> {
+        self.rx.read_until_idle_u16(buffer).await
     }
 }
 
@@ -2263,6 +2358,14 @@ impl<'d, M: PeriMode> Uart<'d, M> {
         self.tx.blocking_write(buffer)
     }
 
+    /// Perform a blocking write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub fn blocking_write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.tx.blocking_write_u16(buffer)
+    }
+
     /// Block until transmission complete
     pub fn blocking_flush(&mut self) -> Result<(), Error> {
         self.tx.blocking_flush()
@@ -2276,6 +2379,14 @@ impl<'d, M: PeriMode> Uart<'d, M> {
     /// Perform a blocking read into `buffer`
     pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         self.rx.blocking_read(buffer)
+    }
+
+    /// Perform a blocking read of 16 bit words into `buffer`
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub fn blocking_read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        self.rx.blocking_read_u16(buffer)
     }
 
     /// Split the Uart into a transmitter and receiver, which is
@@ -2819,6 +2930,38 @@ mod buffered;
 
 mod ringbuffered;
 pub use ringbuffered::RingBufferedUartRx;
+
+/// The word sizes the USART data register can carry.
+///
+/// Selects the width used to access the data register, so that a 9 bit frame is
+/// read and written as a `u16` while an 8 bit frame stays a `u8`.
+trait UsartWord: Word {
+    /// Transmit data register, accessed at this word's width.
+    fn tdr_ptr(r: Regs) -> *mut Self;
+
+    /// Receive data register, accessed at this word's width.
+    fn rdr_ptr(r: Regs) -> *mut Self;
+}
+
+impl UsartWord for u8 {
+    fn tdr_ptr(r: Regs) -> *mut u8 {
+        tdr(r)
+    }
+
+    fn rdr_ptr(r: Regs) -> *mut u8 {
+        rdr(r)
+    }
+}
+
+impl UsartWord for u16 {
+    fn tdr_ptr(r: Regs) -> *mut u16 {
+        tdr(r).cast()
+    }
+
+    fn rdr_ptr(r: Regs) -> *mut u16 {
+        rdr(r).cast()
+    }
+}
 
 #[cfg(any(usart_v1, usart_v2))]
 fn tdr(r: crate::pac::usart::Usart) -> *mut u8 {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -2931,11 +2931,7 @@ mod buffered;
 mod ringbuffered;
 pub use ringbuffered::RingBufferedUartRx;
 
-/// The word sizes the USART data register can carry.
-///
-/// Selects the width used to access the data register, so that a 9 bit frame is
-/// read and written as a `u16` while an 8 bit frame stays a `u8`.
-trait UsartWord: Word {
+pub(crate) trait SealedUsartWord {
     /// Transmit data register, accessed at this word's width.
     fn tdr_ptr(r: Regs) -> *mut Self;
 
@@ -2943,7 +2939,16 @@ trait UsartWord: Word {
     fn rdr_ptr(r: Regs) -> *mut Self;
 }
 
-impl UsartWord for u8 {
+/// The word sizes the USART data register can carry.
+///
+/// Selects the width used to access the data register, so that a 9 bit frame is
+/// read and written as a `u16` while an 8 bit frame stays a `u8`.
+///
+/// Implemented for `u8` and `u16`; this trait is sealed.
+#[allow(private_bounds)]
+pub trait UsartWord: Word + SealedUsartWord {}
+
+impl SealedUsartWord for u8 {
     fn tdr_ptr(r: Regs) -> *mut u8 {
         tdr(r)
     }
@@ -2953,7 +2958,9 @@ impl UsartWord for u8 {
     }
 }
 
-impl UsartWord for u16 {
+impl UsartWord for u8 {}
+
+impl SealedUsartWord for u16 {
     fn tdr_ptr(r: Regs) -> *mut u16 {
         tdr(r).cast()
     }
@@ -2962,6 +2969,8 @@ impl UsartWord for u16 {
         rdr(r).cast()
     }
 }
+
+impl UsartWord for u16 {}
 
 #[cfg(any(usart_v1, usart_v2))]
 fn tdr(r: crate::pac::usart::Usart) -> *mut u8 {

--- a/embassy-stm32/src/usart/mod.rs
+++ b/embassy-stm32/src/usart/mod.rs
@@ -623,11 +623,7 @@ impl<'d> UartTx<'d, Async> {
         )
     }
 
-    /// Initiate an asynchronous UART write
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
-    /// the low-order bits of each word.
-    pub async fn write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+    async fn write_helper<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         let r = self.info.regs;
@@ -670,6 +666,19 @@ impl<'d> UartTx<'d, Async> {
         }
 
         Ok(())
+    }
+
+    /// Initiate an asynchronous UART write
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.write_helper(buffer).await
+    }
+
+    /// Initiate an asynchronous UART write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub async fn write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.write_helper(buffer).await
     }
 
     /// Wait until transmission complete
@@ -833,11 +842,7 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
         }
     }
 
-    /// Perform a blocking UART write
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
-    /// the low-order bits of each word.
-    pub fn blocking_write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+    fn blocking_write_helper<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
         let r = self.info.regs;
         let half_duplex = r.cr3().read().hdsel();
 
@@ -862,6 +867,19 @@ impl<'d, M: PeriMode> UartTx<'d, M> {
         }
 
         Ok(())
+    }
+
+    /// Perform a blocking UART write
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
+        self.blocking_write_helper(buffer)
+    }
+
+    /// Perform a blocking UART write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub fn blocking_write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.blocking_write_helper(buffer)
     }
 
     /// Block until transmission complete
@@ -1041,10 +1059,19 @@ impl<'d> UartRx<'d, Async> {
     }
 
     /// Initiate an asynchronous UART read
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
+
+        self.inner_read(buffer, false).await?;
+
+        Ok(())
+    }
+
+    /// Initiate an asynchronous UART read of 16 bit words
     ///
-    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
-    /// received word are zero.
-    pub async fn read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.inner_read(buffer, false).await?;
@@ -1056,10 +1083,22 @@ impl<'d> UartRx<'d, Async> {
     ///
     /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
     /// as if you had called [`read(buffer)`](Self::read) instead!
+    pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
+        let _scoped_wake_guard = self.info.rcc.wake_guard();
+
+        self.inner_read(buffer, true).await
+    }
+
+    /// Initiate an asynchronous read of 16 bit words with idle line detection enabled.
     ///
-    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
-    /// received word are zero.
-    pub async fn read_until_idle<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<usize, Error> {
+    /// Returns the number of words received.
+    ///
+    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
+    /// as if you had called [`read_u16(buffer)`](Self::read_u16) instead!
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_until_idle_u16(&mut self, buffer: &mut [u16]) -> Result<usize, Error> {
         let _scoped_wake_guard = self.info.rcc.wake_guard();
 
         self.inner_read(buffer, true).await
@@ -1496,11 +1535,7 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
         }
     }
 
-    /// Perform a blocking read into `buffer`
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
-    /// received word are zero.
-    pub fn blocking_read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+    fn blocking_read_helper<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
         let r = self.info.regs;
 
         // Call flush for Half-Duplex mode if some bytes were written and flush was not called.
@@ -1523,6 +1558,19 @@ impl<'d, M: PeriMode> UartRx<'d, M> {
             unsafe { *b = W::rdr_ptr(r).read_volatile() }
         }
         Ok(())
+    }
+
+    /// Perform a blocking read into `buffer`
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
+        self.blocking_read_helper(buffer)
+    }
+
+    /// Perform a blocking read of 16 bit words into `buffer`
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub fn blocking_read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        self.blocking_read_helper(buffer)
     }
 
     /// Set baudrate
@@ -1886,11 +1934,16 @@ impl<'d> Uart<'d, Async> {
     }
 
     /// Perform an asynchronous write
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
-    /// the low-order bits of each word.
-    pub async fn write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+    pub async fn write(&mut self, buffer: &[u8]) -> Result<(), Error> {
         self.tx.write(buffer).await
+    }
+
+    /// Perform an asynchronous write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub async fn write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.tx.write_u16(buffer).await
     }
 
     /// Wait until transmission complete
@@ -1899,22 +1952,35 @@ impl<'d> Uart<'d, Async> {
     }
 
     /// Perform an asynchronous read into `buffer`
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
-    /// received word are zero.
-    pub async fn read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+    pub async fn read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         self.rx.read(buffer).await
+    }
+
+    /// Perform an asynchronous read into `buffer` using 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        self.rx.read_u16(buffer).await
     }
 
     /// Perform an an asynchronous read with idle line detection enabled.
     ///
     /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
     /// as if you had called [`read(buffer)`](Self::read) instead!
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
-    /// received word are zero.
-    pub async fn read_until_idle<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<usize, Error> {
+    pub async fn read_until_idle(&mut self, buffer: &mut [u8]) -> Result<usize, Error> {
         self.rx.read_until_idle(buffer).await
+    }
+
+    /// Perform an asynchronous read with idle line detection enabled using 16 bit words.
+    ///
+    /// **WARNING:** In synchronous mode, idle detection does not work, and this behaves
+    /// as if you had called [`read_u16(buffer)`](Self::read_u16) instead!
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub async fn read_until_idle_u16(&mut self, buffer: &mut [u16]) -> Result<usize, Error> {
+        self.rx.read_until_idle_u16(buffer).await
     }
 }
 
@@ -2288,11 +2354,16 @@ impl<'d, M: PeriMode> Uart<'d, M> {
     }
 
     /// Perform a blocking write
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the peripheral transmits only
-    /// the low-order bits of each word.
-    pub fn blocking_write<W: UsartWord>(&mut self, buffer: &[W]) -> Result<(), Error> {
+    pub fn blocking_write(&mut self, buffer: &[u8]) -> Result<(), Error> {
         self.tx.blocking_write(buffer)
+    }
+
+    /// Perform a blocking write of 16 bit words
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the peripheral
+    /// transmits only the low-order bits of each word.
+    pub fn blocking_write_u16(&mut self, buffer: &[u16]) -> Result<(), Error> {
+        self.tx.blocking_write_u16(buffer)
     }
 
     /// Block until transmission complete
@@ -2306,11 +2377,16 @@ impl<'d, M: PeriMode> Uart<'d, M> {
     }
 
     /// Perform a blocking read into `buffer`
-    ///
-    /// If `W` is narrower than the configured [`DataBits`], the high-order bits of each
-    /// received word are zero.
-    pub fn blocking_read<W: UsartWord>(&mut self, buffer: &mut [W]) -> Result<(), Error> {
+    pub fn blocking_read(&mut self, buffer: &mut [u8]) -> Result<(), Error> {
         self.rx.blocking_read(buffer)
+    }
+
+    /// Perform a blocking read of 16 bit words into `buffer`
+    ///
+    /// Requires [`DataBits::DataBits9`]; with a narrower word size the high-order
+    /// bits of each received word are zero.
+    pub fn blocking_read_u16(&mut self, buffer: &mut [u16]) -> Result<(), Error> {
+        self.rx.blocking_read_u16(buffer)
     }
 
     /// Split the Uart into a transmitter and receiver, which is
@@ -2855,7 +2931,11 @@ mod buffered;
 mod ringbuffered;
 pub use ringbuffered::RingBufferedUartRx;
 
-pub(crate) trait SealedUsartWord {
+/// The word sizes the USART data register can carry.
+///
+/// Selects the width used to access the data register, so that a 9 bit frame is
+/// read and written as a `u16` while an 8 bit frame stays a `u8`.
+trait UsartWord: Word {
     /// Transmit data register, accessed at this word's width.
     fn tdr_ptr(r: Regs) -> *mut Self;
 
@@ -2863,16 +2943,7 @@ pub(crate) trait SealedUsartWord {
     fn rdr_ptr(r: Regs) -> *mut Self;
 }
 
-/// The word sizes the USART data register can carry.
-///
-/// Selects the width used to access the data register, so that a 9 bit frame is
-/// read and written as a `u16` while an 8 bit frame stays a `u8`.
-///
-/// Implemented for `u8` and `u16`; this trait is sealed.
-#[allow(private_bounds)]
-pub trait UsartWord: Word + SealedUsartWord {}
-
-impl SealedUsartWord for u8 {
+impl UsartWord for u8 {
     fn tdr_ptr(r: Regs) -> *mut u8 {
         tdr(r)
     }
@@ -2882,9 +2953,7 @@ impl SealedUsartWord for u8 {
     }
 }
 
-impl UsartWord for u8 {}
-
-impl SealedUsartWord for u16 {
+impl UsartWord for u16 {
     fn tdr_ptr(r: Regs) -> *mut u16 {
         tdr(r).cast()
     }
@@ -2893,8 +2962,6 @@ impl SealedUsartWord for u16 {
         rdr(r).cast()
     }
 }
-
-impl UsartWord for u16 {}
 
 #[cfg(any(usart_v1, usart_v2))]
 fn tdr(r: crate::pac::usart::Usart) -> *mut u8 {

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -36,25 +36,25 @@ use crate::usart::Regs;
 /// to the function, and the configuration:
 ///
 /// - If the sender sends intermittently, the 'idle line'
-/// condition will be detected when the sender stops, and any
-/// words in the ring buffer will be returned. If there are no
-/// words in the buffer, the check will be repeated each time the
-/// 'idle line' condition is detected, so if the sender sends just
-/// a single word, it will be returned once the 'idle line'
-/// condition is detected.
+///   condition will be detected when the sender stops, and any
+///   words in the ring buffer will be returned. If there are no
+///   words in the buffer, the check will be repeated each time the
+///   'idle line' condition is detected, so if the sender sends just
+///   a single word, it will be returned once the 'idle line'
+///   condition is detected.
 ///
 /// - If the sender sends continuously, the call will wait until
-/// the DMA controller indicates that it has written to either the
-/// middle word or last word of the ring buffer ('half transfer'
-/// or 'transfer complete', respectively). This does not indicate
-/// the buffer is half-full or full, though, because the DMA
-/// controller does not detect those conditions; it sends an
-/// interrupt when those specific buffer addresses have been
-/// written.
+///   the DMA controller indicates that it has written to either the
+///   middle word or last word of the ring buffer ('half transfer'
+///   or 'transfer complete', respectively). This does not indicate
+///   the buffer is half-full or full, though, because the DMA
+///   controller does not detect those conditions; it sends an
+///   interrupt when those specific buffer addresses have been
+///   written.
 ///
 /// - If `eager_reads` is enabled in `config`, the UART interrupt
-/// is enabled on all data reception and the call will only wait
-/// for at least one word to be available before returning.
+///   is enabled on all data reception and the call will only wait
+///   for at least one word to be available before returning.
 ///
 /// In the first two cases this will result in variable latency due to the
 /// buffering effect. For example, if the baudrate is 2400 bps, and

--- a/embassy-stm32/src/usart/ringbuffered.rs
+++ b/embassy-stm32/src/usart/ringbuffered.rs
@@ -7,8 +7,11 @@ use embassy_embedded_hal::SetConfig;
 use embedded_io_async::ReadReady;
 use futures_util::future::{Either, select};
 
+#[cfg(not(any(usart_v3, usart_v4)))]
+use super::rdr;
 use super::{
-    Config, ConfigError, Error, Info, State, UartRx, clear_interrupt_flags, flush, rdr, reconfigure, set_baudrate, sr,
+    Config, ConfigError, Error, Info, State, UartRx, UsartWord, clear_interrupt_flags, flush, reconfigure,
+    set_baudrate, sr,
 };
 use crate::dma::ReadableRingBuffer;
 use crate::gpio::Flex;
@@ -21,28 +24,28 @@ use crate::usart::Regs;
 ///
 /// Created with [UartRx::into_ring_buffered]
 ///
-/// ### Notes on 'waiting for bytes'
+/// ### Notes on 'waiting for words'
 ///
-/// The `read(buf)` (but not `read()`) and `read_exact(buf)` functions
-/// may need to wait for bytes to arrive, if the ring buffer does not
-/// contain enough bytes to fill the buffer passed by the caller of
-/// the function, or is empty.
+/// The `read(buf)` (but not `read()`) function may need to wait for
+/// words to arrive, if the ring buffer does not contain enough words
+/// to fill the buffer passed by the caller of the function, or is
+/// empty.
 ///
-/// Waiting for bytes operates in one of three modes, depending on
+/// Waiting for words operates in one of three modes, depending on
 /// the behavior of the sender, the size of the buffer passed
 /// to the function, and the configuration:
 ///
 /// - If the sender sends intermittently, the 'idle line'
 /// condition will be detected when the sender stops, and any
-/// bytes in the ring buffer will be returned. If there are no
-/// bytes in the buffer, the check will be repeated each time the
+/// words in the ring buffer will be returned. If there are no
+/// words in the buffer, the check will be repeated each time the
 /// 'idle line' condition is detected, so if the sender sends just
-/// a single byte, it will be returned once the 'idle line'
+/// a single word, it will be returned once the 'idle line'
 /// condition is detected.
 ///
 /// - If the sender sends continuously, the call will wait until
 /// the DMA controller indicates that it has written to either the
-/// middle byte or last byte of the ring buffer ('half transfer'
+/// middle word or last word of the ring buffer ('half transfer'
 /// or 'transfer complete', respectively). This does not indicate
 /// the buffer is half-full or full, though, because the DMA
 /// controller does not detect those conditions; it sends an
@@ -51,14 +54,14 @@ use crate::usart::Regs;
 ///
 /// - If `eager_reads` is enabled in `config`, the UART interrupt
 /// is enabled on all data reception and the call will only wait
-/// for at least one byte to be available before returning.
+/// for at least one word to be available before returning.
 ///
 /// In the first two cases this will result in variable latency due to the
 /// buffering effect. For example, if the baudrate is 2400 bps, and
-/// the configuration is 8 data bits, no parity bit, and one stop bit,
-/// then a byte will be received every ~4.16ms. If the ring buffer is
-/// 32 bytes, then a 'wait for bytes' delay may have to wait for 16
-/// bytes in the worst case, resulting in a delay (latency) of
+/// the configuration is 8 data bits (so each word is one byte), no parity
+/// bit, and one stop bit, then a byte will be received every ~4.16ms. If
+/// the ring buffer is 32 bytes, then a 'wait for bytes' delay may have to
+/// wait for 16 bytes in the worst case, resulting in a delay (latency) of
 /// ~62.46ms for the first byte in the ring buffer. If the sender
 /// sends only 6 bytes and then stops, but the buffer was empty when
 /// the read function was called, then those bytes may not be returned
@@ -76,19 +79,19 @@ use crate::usart::Regs;
 ///
 /// Note: Enabling `eager_reads` with `RingBufferedUartRx` will enable
 /// an UART RXNE interrupt, which will cause an interrupt to occur on
-/// every received data byte. The data is still copied using DMA, but
-/// there is nevertheless additional processing overhead for each byte.
-pub struct RingBufferedUartRx<'d> {
+/// every received word. The data is still copied using DMA, but
+/// there is nevertheless additional processing overhead for each word.
+pub struct RingBufferedUartRx<'d, W: UsartWord = u8> {
     info: &'static Info,
     state: &'static State,
     kernel_clock: Hertz,
     _wake_guard: WakeGuard,
     _rx: Option<Flex<'d>>,
     _rts: Option<Flex<'d>>,
-    ring_buf: ReadableRingBuffer<'d, u8>,
+    ring_buf: ReadableRingBuffer<'d, W>,
 }
 
-impl<'d> SetConfig for RingBufferedUartRx<'d> {
+impl<'d, W: UsartWord> SetConfig for RingBufferedUartRx<'d, W> {
     type Config = Config;
     type ConfigError = ConfigError;
 
@@ -98,10 +101,15 @@ impl<'d> SetConfig for RingBufferedUartRx<'d> {
 }
 
 impl<'d> UartRx<'d, Async> {
-    /// Turn the `UartRx` into a buffered uart which can continously receive in the background
-    /// without the possibility of losing bytes. The `dma_buf` is a buffer registered to the
+    /// Turn the `UartRx` into a buffered uart which can continuously receive in the background
+    /// without the possibility of losing words. The `dma_buf` is a buffer registered to the
     /// DMA controller, and must be large enough to prevent overflows.
-    pub fn into_ring_buffered(mut self, dma_buf: &'d mut [u8]) -> RingBufferedUartRx<'d> {
+    ///
+    /// The word type is taken from `dma_buf`: pass a `[u8]` buffer for 7 or 8 data bits, or a
+    /// `[u16]` buffer for 9 data bits. A `[u16]` buffer requires
+    /// [`DataBits::DataBits9`](crate::usart::DataBits::DataBits9) to be useful;
+    /// with a narrower word size the high-order bits of each received word are zero.
+    pub fn into_ring_buffered<W: UsartWord>(mut self, dma_buf: &'d mut [W]) -> RingBufferedUartRx<'d, W> {
         assert!(!dma_buf.is_empty() && dma_buf.len() <= 0xFFFF);
 
         let opts = Default::default();
@@ -114,7 +122,7 @@ impl<'d> UartRx<'d, Async> {
         let info = self.info;
         let state = self.state;
         let kernel_clock = self.kernel_clock;
-        let ring_buf = unsafe { ReadableRingBuffer::new(rx_dma, request, rdr(info.regs), dma_buf, opts) };
+        let ring_buf = unsafe { ReadableRingBuffer::new(rx_dma, request, W::rdr_ptr(info.regs), dma_buf, opts) };
         let rx = unsafe { self.rx.as_ref().map(|x| x.clone_unchecked()) };
         let rts = unsafe { self.rts.as_ref().map(|x| x.clone_unchecked()) };
 
@@ -135,7 +143,7 @@ impl<'d> UartRx<'d, Async> {
     }
 }
 
-impl<'d> RingBufferedUartRx<'d> {
+impl<'d, W: UsartWord> RingBufferedUartRx<'d, W> {
     /// Reconfigure the driver
     pub fn set_config(&mut self, config: &Config) -> Result<(), ConfigError> {
         self.state
@@ -215,8 +223,9 @@ impl<'d> RingBufferedUartRx<'d> {
         Ok(())
     }
 
-    /// Read bytes that are available in the ring buffer, or wait for
-    /// bytes to become available and return them.
+    /// Read words that are available in the ring buffer, or wait for
+    /// words to become available and return them. Returns the number of
+    /// words read into `buf`.
     ///
     /// Background reception is started if necessary (if `start_uart()` had
     /// not previously been called, or if an error was detected which
@@ -225,7 +234,7 @@ impl<'d> RingBufferedUartRx<'d> {
     /// Background reception is terminated when an error is returned.
     /// It must be started again by calling `start_uart()` or by
     /// calling a read function again.
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+    pub async fn read(&mut self, buf: &mut [W]) -> Result<usize, Error> {
         self.start_dma_or_check_errors()?;
 
         // In half-duplex mode, we need to disable the Transmitter and enable the Receiver
@@ -299,7 +308,7 @@ impl<'d> RingBufferedUartRx<'d> {
 
             let mut dma_init = false;
             // Future which completes when the DMA controller indicates it
-            // has written to the ring buffer's middle byte, or last byte
+            // has written to the ring buffer's middle word, or last word
             let dma = poll_fn(|cx| {
                 self.ring_buf.set_waker(cx.waker());
 
@@ -342,7 +351,7 @@ impl<'d> RingBufferedUartRx<'d> {
     }
 }
 
-impl Drop for RingBufferedUartRx<'_> {
+impl<W: UsartWord> Drop for RingBufferedUartRx<'_, W> {
     fn drop(&mut self) {
         self.stop_uart();
         super::drop_tx_rx(self.info, self.state);
@@ -356,7 +365,9 @@ impl Drop for RingBufferedUartRx<'_> {
 /// flag(s) will gone missing unnoticed. The error flags are checked first, the idle flag last.
 ///
 /// For usart_v1 and usart_v2, all status flags must be handled together anyway because all flags
-/// are cleared by a single read to the RDR register.
+/// are cleared by a single read to the RDR register. That read's value is discarded here, so the
+/// byte-wide access this uses to clear the flags is sufficient even when the peripheral is
+/// configured for 9 bit words.
 fn check_idle_and_errors(r: Regs) -> Result<(bool, bool), Error> {
     // SAFETY: read only and we only use Rx related flags
     let sr = sr(r).read();
@@ -382,17 +393,17 @@ fn check_idle_and_errors(r: Regs) -> Result<(bool, bool), Error> {
     }
 }
 
-impl embedded_io_async::ErrorType for RingBufferedUartRx<'_> {
+impl<W: UsartWord> embedded_io_async::ErrorType for RingBufferedUartRx<'_, W> {
     type Error = Error;
 }
 
-impl embedded_io_async::Read for RingBufferedUartRx<'_> {
+impl embedded_io_async::Read for RingBufferedUartRx<'_, u8> {
     async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
         self.read(buf).await
     }
 }
 
-impl embedded_hal_nb::serial::Read for RingBufferedUartRx<'_> {
+impl embedded_hal_nb::serial::Read for RingBufferedUartRx<'_, u8> {
     fn read(&mut self) -> nb::Result<u8, Self::Error> {
         self.start_dma_or_check_errors()?;
 
@@ -411,11 +422,11 @@ impl embedded_hal_nb::serial::Read for RingBufferedUartRx<'_> {
     }
 }
 
-impl embedded_hal_nb::serial::ErrorType for RingBufferedUartRx<'_> {
+impl<W: UsartWord> embedded_hal_nb::serial::ErrorType for RingBufferedUartRx<'_, W> {
     type Error = Error;
 }
 
-impl ReadReady for RingBufferedUartRx<'_> {
+impl<W: UsartWord> ReadReady for RingBufferedUartRx<'_, W> {
     fn read_ready(&mut self) -> Result<bool, Self::Error> {
         let len = self.ring_buf.len().map_err(|e| match e {
             crate::dma::ringbuffer::Error::Overrun => Self::Error::Overrun,


### PR DESCRIPTION
Although the USART config allowed setting the data_bits field to `DataBits9`, the read and write methods only supported u8 data types. In the case of the write methods, this meant that it was impossible to provide data long enough to take advantage of that extra bit. For read methods, only the first 8 bits of the register were read and passed back to the user.

I've made the read/write methods in the standard and ringbuffer modules generic over u8 and u16 to stay backwards compatible with existing code while opening up the ability to work with 9 bit data frames.
`buffered.rs` would have been a much more intrusive refactor because of the dependency on the atomic_ring_buffer module so it's been left as-is.

There are a couple lingering questions before this is ready to be merged:
1. Should I include an example of using 9 bit data mode or is the added documentation to each method enough in this case? Similarly, I'm not sure if the ci tests should be updated.
2. Currently, it's assumed that the user can infer on their own that they'll need more than a u8 to send/receive 9 bits of data. Failing that, there's the method-level documentation. If we wanted to be more hands on, I suppose we could add a debug_assert which checks the width of W and compares it to the cr1 register settings but that feels a little overkill imo.