### PR TITLE
rcc: fix L4+ and L5 high-speed clock setup

### DIFF
--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -218,11 +218,11 @@ heapless = "0.9.3"
 once_cell = { version = "1.21.4", default-features = false, features=["critical-section"] }
 
 # stm32-metapac = { version = "21" }
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-b98e71c0587d052b1a10e79c5e958a2fe9207c91" }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-f8d4db59f2671310e856cbb00611eee6a92e4183" }
 
 [build-dependencies]
 # stm32-metapac = { version = "21", default-features = false, features = ["metadata"]}
-stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-b98e71c0587d052b1a10e79c5e958a2fe9207c91" , default-features = false, features = ["metadata"] }
+stm32-metapac = { git = "https://github.com/embassy-rs/stm32-data-generated", tag = "stm32-data-f8d4db59f2671310e856cbb00611eee6a92e4183" , default-features = false, features = ["metadata"] }
 
 proc-macro2 = "1.0.107"
 quote = "1.0.47"

--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -7,12 +7,8 @@ use crate::pac::pwr::vals::Retention;
 #[cfg(all(stm32h7, backup_sram))]
 use crate::pac::pwr::vals::Retention;
 pub use crate::pac::rcc::vals::Rtcsel as RtcClockSource;
+use crate::rcc::LSI_FREQ;
 use crate::time::Hertz;
-
-#[cfg(any(stm32f0, stm32f1, stm32f3))]
-pub const LSI_FREQ: Hertz = Hertz(40_000);
-#[cfg(not(any(stm32f0, stm32f1, stm32f3)))]
-pub const LSI_FREQ: Hertz = Hertz(32_000);
 
 #[allow(dead_code)]
 #[derive(Clone, Copy)]

--- a/embassy-stm32/src/rcc/l.rs
+++ b/embassy-stm32/src/rcc/l.rs
@@ -196,9 +196,9 @@ pub(crate) unsafe fn init(config: Config) {
     // voltage range.
     #[cfg(any(stm32l4, stm32l5, stm32wb, stm32wl, stm32u0))]
     {
-        #[cfg(any(stm32l4, stm32wb))]
+        #[cfg(any(all(stm32l4, not(rcc_l4plus)), stm32wb))]
         const MAX_LATENCY: u8 = 4;
-        #[cfg(stm32l5)]
+        #[cfg(any(rcc_l4plus, stm32l5))]
         const MAX_LATENCY: u8 = 5;
         #[cfg(any(stm32wl, stm32u0))]
         const MAX_LATENCY: u8 = 2;
@@ -216,9 +216,13 @@ pub(crate) unsafe fn init(config: Config) {
     }
 
     #[cfg(stm32l5)]
-    crate::pac::PWR.cr1().modify(|w| {
-        w.set_vos(crate::pac::pwr::vals::Vos::Range0);
-    });
+    {
+        crate::pac::PWR.cr1().modify(|w| {
+            w.set_vos(crate::pac::pwr::vals::Vos::Range0);
+        });
+        // RM0438 8.2.5: VOS resets to Range 2, so no clock may be raised until VOSF reports the new range.
+        while crate::pac::PWR.sr2().read().vosf() {}
+    }
 
     let rtc = config.ls.init();
 
@@ -335,6 +339,8 @@ pub(crate) unsafe fn init(config: Config) {
     assert!(sys_clk.0 <= 120_000_000);
     #[cfg(all(stm32l4, not(rcc_l4plus)))]
     assert!(sys_clk.0 <= 80_000_000);
+    #[cfg(stm32l5)]
+    assert!(sys_clk.0 <= 110_000_000);
 
     let hclk1 = sys_clk / config.ahb_pre;
     let (pclk1, pclk1_tim) = super::util::calc_pclk(hclk1, config.apb1_pre);
@@ -357,13 +363,23 @@ pub(crate) unsafe fn init(config: Config) {
         (VoltageScale::Range3, ..=4_200_000) => false,
         _ => true,
     };
-    #[cfg(stm32l4)]
+    #[cfg(all(stm32l4, not(rcc_l4plus)))]
     let latency = match hclk1.0 {
         0..=16_000_000 => 0,
         0..=32_000_000 => 1,
         0..=48_000_000 => 2,
         0..=64_000_000 => 3,
         _ => 4,
+    };
+    #[cfg(rcc_l4plus)]
+    let latency = match hclk1.0 {
+        // RM0432 Table 12, VCORE Range 1 (boost and normal share these steps).
+        0..=20_000_000 => 0,
+        0..=40_000_000 => 1,
+        0..=60_000_000 => 2,
+        0..=80_000_000 => 3,
+        0..=100_000_000 => 4,
+        _ => 5,
     };
     #[cfg(stm32l5)]
     let latency = match hclk1.0 {
@@ -399,6 +415,12 @@ pub(crate) unsafe fn init(config: Config) {
         _ => 2,
     };
 
+    // RM0432 5.1.8: PWR_CR5 resets to Range 1 normal, which stops at 80 MHz; going above needs boost.
+    #[cfg(rcc_l4plus)]
+    if sys_clk.0 > 80_000_000 {
+        crate::pac::PWR.cr5().modify(|w| w.set_r1mode(false));
+    }
+
     #[cfg(stm32l1)]
     FLASH.acr().write(|w| w.set_acc64(true));
 
@@ -409,9 +431,19 @@ pub(crate) unsafe fn init(config: Config) {
     #[cfg(not(stm32l5))]
     FLASH.acr().modify(|w| w.set_prften(true));
 
+    // RM0432 5.1.8 / RM0438 8.2.5: above 80 MHz the AHB prescaler must divide by two across the switch.
+    #[cfg(any(rcc_l4plus, stm32l5))]
+    let (hpre_stepped, ahb_pre) = if sys_clk.0 > 80_000_000 && config.ahb_pre == AHBPrescaler::Div1 {
+        (true, AHBPrescaler::Div2)
+    } else {
+        (false, config.ahb_pre)
+    };
+    #[cfg(not(any(rcc_l4plus, stm32l5)))]
+    let (hpre_stepped, ahb_pre) = (false, config.ahb_pre);
+
     RCC.cfgr().modify(|w| {
         w.set_sw(config.sys);
-        w.set_hpre(config.ahb_pre);
+        w.set_hpre(ahb_pre);
         #[cfg(stm32u0)]
         w.set_ppre(config.apb1_pre);
         #[cfg(not(stm32u0))]
@@ -420,6 +452,10 @@ pub(crate) unsafe fn init(config: Config) {
         w.set_ppre2(config.apb2_pre);
     });
     while RCC.cfgr().read().sws() != config.sys {}
+
+    if hpre_stepped {
+        RCC.cfgr().modify(|w| w.set_hpre(config.ahb_pre));
+    }
 
     #[cfg(any(stm32wl, stm32wb))]
     {

--- a/embassy-stm32/src/rcc/mod.rs
+++ b/embassy-stm32/src/rcc/mod.rs
@@ -10,6 +10,11 @@ mod bd;
 #[cfg(not(stm32c5))]
 pub use bd::*;
 
+#[cfg(any(stm32f0, stm32f1, stm32f3))]
+pub const LSI_FREQ: crate::time::Hertz = crate::time::Hertz(40_000);
+#[cfg(not(any(stm32f0, stm32f1, stm32f3)))]
+pub const LSI_FREQ: crate::time::Hertz = crate::time::Hertz(32_000);
+
 #[cfg(any(mco, mco1, mco2))]
 mod mco;
 use critical_section::CriticalSection;

--- a/embassy-stm32/src/rcc/n6.rs
+++ b/embassy-stm32/src/rcc/n6.rs
@@ -2,7 +2,7 @@ use stm32_metapac::pwr::vals::{
     Vddio2rdy, Vddio2sv, Vddio2vrsel, Vddio3rdy, Vddio3sv, Vddio3vrsel, Vddio4sv, Vddio5sv, Vos,
 };
 use stm32_metapac::rcc::vals::{
-    Cpusw, Cpusws, Hseext, Hsitrim, Msifreqsel, Persel, Pllmodssdis, Syssw, Syssws, Timpre,
+    Cpusw, Cpusws, Hsediv2sel, Hseext, Hsitrim, Msifreqsel, Persel, Pllmodssdis, Syssw, Syssws, Timpre,
 };
 pub use stm32_metapac::rcc::vals::{
     Hpre as AhbPrescaler, Hsidiv as HsiPrescaler, Hsitrim as HsiCalibration, Icint, Icsel, Plldivm, Pllpdiv, Pllsel,
@@ -872,6 +872,7 @@ struct OscOutput {
     hsi_div: Option<Hertz>,
     hse: Option<Hertz>,
     hse_rtc: Option<Hertz>,
+    hse_div2_osc: Option<Hertz>,
     msi: Option<Hertz>,
     lsi: Option<Hertz>,
     lse: Option<Hertz>,
@@ -952,6 +953,14 @@ fn init_osc(config: Config) -> OscOutput {
     };
     // hse rtc configuration
     let hse_rtc = hse.map(|freq| freq / (RCC.ccipr7().read().rtcpre().to_bits() + 1));
+
+    // hse_div2_osc_ck per RM0486 rev 4 14.10.14 - tapped straight off the oscillator,
+    // before the tempo delay, and halved only when HSEDIV2SEL is set. It feeds the OTG
+    // PHY reference clock mux.
+    let hse_div2_osc = hse.map(|freq| match RCC.hsecfgr().read().hsediv2sel() {
+        Hsediv2sel::Div1 => freq,
+        Hsediv2sel::Div2 => freq / 2u32,
+    });
 
     // hsi configuration
     //
@@ -1117,6 +1126,7 @@ fn init_osc(config: Config) -> OscOutput {
         hsi_div,
         hse,
         hse_rtc,
+        hse_div2_osc,
         msi,
         lsi,
         lse,
@@ -1384,6 +1394,7 @@ pub(crate) unsafe fn init(config: Config) {
         hsi_div: clock_inputs.hsi_div,
         hse: clock_inputs.hse,
         hse_rtc: osc.hse_rtc,
+        hse_div2_osc: osc.hse_div2_osc,
         msi: clock_inputs.msi,
         lsi: osc.lsi,
         lse: None,


### PR DESCRIPTION
I tested these changes on stm32l552 and stm32l4r5. without these changes I experienced intermittent crashes on startup. these changes put init more inline with spec. This pull request requires https://github.com/embassy-rs/stm32-data/pull/912


### stm32 hal references
- **AHB /2 across the switch up** — [`stm32l4xx_hal_rcc.c#L1161-L1171`](https://github.com/STMicroelectronics/stm32l4xx-hal-driver/blob/75ad523db1684b4ef1ddc4f8515a9c969ff20a8f/Src/stm32l4xx_hal_rcc.c#L1161-L1171) ("Undershoot management … above 80Mhz"), restored right after the switch at [`#L1235-L1239`](https://github.com/STMicroelectronics/stm32l4xx-hal-driver/blob/75ad523db1684b4ef1ddc4f8515a9c969ff20a8f/Src/stm32l4xx_hal_rcc.c#L1235-L1239).
- **PWR_CR5 Range 1 boost** — [`stm32l4xx_hal_pwr_ex.c#L169-L197`](https://github.com/STMicroelectronics/stm32l4xx-hal-driver/blob/75ad523db1684b4ef1ddc4f8515a9c969ff20a8f/Src/stm32l4xx_hal_pwr_ex.c#L169-L197) (`CLEAR_BIT(PWR->CR5, PWR_CR5_R1MODE)`).
- **VOSF wait** — [`stm32l4xx_hal_pwr_ex.c#L181-L190`](https://github.com/STMicroelectronics/stm32l4xx-hal-driver/blob/75ad523db1684b4ef1ddc4f8515a9c969ff20a8f/Src/stm32l4xx_hal_pwr_ex.c#L181-L190).
