### PR TITLE
embassy-usb: various typo fixes

### DIFF
--- a/embassy-usb/CHANGELOG.md
+++ b/embassy-usb/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `UAC1`: `Speaker::new` now returns `Self` with the parts inside instead of a tuple
 - `CDC-NCM`: Handle `SetEthernetPacketFilter` and advertise it in `bmNetworkCapabilities`, which also works around a macOS bug that intermittently left the data interface disabled
 - `MIDI`: Allow sender-only or receiver-only configuration
+- Fix various typos in comments and internal variable names
 
 ## 0.6.0 - 2026-03-10
 

--- a/embassy-usb/src/class/uac1/source.rs
+++ b/embassy-usb/src/class/uac1/source.rs
@@ -25,12 +25,12 @@ type SampleRateSub = Subscriber<'static, CriticalSectionRawMutex, u32, SR_CH_CAP
 /// Channel for sharing new sample rates
 static SAMPLE_RATE_CHANNEL: SampleRateChannel = SampleRateChannel::new();
 
-/// API for acces to the channel's publisher
+/// API for access to the channel's publisher
 fn sample_rate_publisher() -> SampleRatePub {
     SAMPLE_RATE_CHANNEL.publisher().unwrap()
 }
 
-/// API for acces to the channel's subscriber
+/// API for access to the channel's subscriber
 pub fn sample_rate_subscriber() -> SampleRateSub {
     SAMPLE_RATE_CHANNEL.subscriber().unwrap()
 }
@@ -100,7 +100,7 @@ impl<'d, D: Driver<'d>> AudioSourceEpOut<'d, D> {
 
 /// Implementation of the Audio Source interface
 pub struct AudioSource<'d, D: Driver<'d>> {
-    /// Audio In Enpoint
+    /// Audio In Endpoint
     pub audio_ep_in: AudioSourceEpIn<'d, D>,
     /// Feedback In Endpoint
     pub feedback_ep_in: AudioSourceEpIn<'d, D>,
@@ -304,12 +304,12 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
         (audio_in_endpoint, feedback_in_endpoint)
     }
 
-    /// Create a new Audio Source interface with control and streaming endpoints    
+    /// Create a new Audio Source interface with control and streaming endpoints
     pub fn new(
         b: &mut Builder<'d, D>,
         sample_rates: &'static [u32],
         sample_width: SampleWidth,
-        fedback_refresh_period_ms: u8,
+        feedback_refresh_period_ms: u8,
         terminal_type: Option<TerminalType>,
     ) -> Self {
         // Create the Audio Function (IAD groups IF0 & IF1)
@@ -340,7 +340,7 @@ impl<'d, D: Driver<'d>> AudioSource<'d, D> {
             &mut alt_setting,
             sample_rates,
             sample_width,
-            fedback_refresh_period_ms,
+            feedback_refresh_period_ms,
         );
 
         let ep_audio_addr = ep_audio_in.info().addr;
@@ -439,7 +439,7 @@ impl AudioSourceControlHandler {
                     }
                 }
             }
-            // Retun MIN/MAX/RES
+            // Return MIN/MAX/RES
             GET_MIN | GET_MAX | GET_RES => {
                 if control_selector == VOLUME_CONTROL && channel < 3 {
                     let value = match req.request {
@@ -707,7 +707,7 @@ impl Handler for AudioSourceControlHandler {
         debug!("AudioSourceControlHandler: USB device suspended: {}", suspended);
     }
 
-    /// Called when a control request is received with direction HostToDevice.    
+    /// Called when a control request is received with direction HostToDevice.
     fn control_out(&mut self, req: Request, buf: &[u8]) -> Option<OutResponse> {
         debug!(
             "AudioSourceControlHandler: USB device control OUT EP({:#02X}): {:?}, Data: {:?}",
@@ -726,7 +726,7 @@ impl Handler for AudioSourceControlHandler {
         }
     }
 
-    /// Called when a control request is received with direction DeviceToHost.    
+    /// Called when a control request is received with direction DeviceToHost.
     fn control_in<'a>(&'a mut self, req: Request, buf: &'a mut [u8]) -> Option<InResponse<'a>> {
         debug!(
             "AudioSourceControlHandler: USB device control IN EP({:#02X}): {:?}, Data: {:?}",

--- a/embassy-usb/src/class/uac1/speaker.rs
+++ b/embassy-usb/src/class/uac1/speaker.rs
@@ -198,7 +198,7 @@ impl<'d, D: Driver<'d>> Speaker<'d, D> {
         feature_unit_descriptor.push(0x00).unwrap(); // iFeature (none)
 
         // ===============================================
-        // Format desciptor [UAC 4.5.3]
+        // Format descriptor [UAC 4.5.3]
         // Used later, for operational streaming interface
         let mut format_descriptor: Vec<u8, { 6 + 3 * MAX_SAMPLE_RATE_COUNT }> = Vec::from_slice(&[
             FORMAT_TYPE,               // bDescriptorSubtype

--- a/embassy-usb/src/class/web_usb.rs
+++ b/embassy-usb/src/class/web_usb.rs
@@ -18,7 +18,7 @@ const WEB_USB_DESCRIPTOR_TYPE_URL: u8 = 0x03;
 
 /// URL descriptor for WebUSB landing page.
 ///
-/// An ecoded URL descriptor to point to a website that is suggested to the user when the device is connected.
+/// An encoded URL descriptor to point to a website that is suggested to the user when the device is connected.
 pub struct Url<'d>(&'d str, u8);
 
 impl<'d> Url<'d> {

--- a/embassy-usb/src/descriptor.rs
+++ b/embassy-usb/src/descriptor.rs
@@ -275,10 +275,10 @@ impl<'a> DescriptorWriter<'a> {
                 assert_eq!(synchronization_type, SynchronizationType::NoSynchronization)
             }
 
-            let synchronization_bm_attibutes: u8 = (synchronization_type as u8) << 2;
-            let usage_bm_attibutes: u8 = (usage_type as u8) << 4;
+            let synchronization_bm_attributes: u8 = (synchronization_type as u8) << 2;
+            let usage_bm_attributes: u8 = (usage_type as u8) << 4;
 
-            bm_attributes |= usage_bm_attibutes | synchronization_bm_attibutes;
+            bm_attributes |= usage_bm_attributes | synchronization_bm_attributes;
         }
 
         self.write(


### PR DESCRIPTION
Fixes a number of typos in comments and internal variable names.