### PR TITLE
crypto: add high level ec ops

### DIFF
--- a/embassy-crypto-driver/src/lib.rs
+++ b/embassy-crypto-driver/src/lib.rs
@@ -105,6 +105,22 @@ impl<'inp, 'out, T> InOutBuf<'inp, 'out, T> {
     }
 }
 
+// ===========================================================================
+// Randomness source
+// ===========================================================================
+
+/// Caller-provided entropy source for crypto operations that need fresh
+/// randomness (ECDSA nonces, ephemeral key generation).
+///
+/// Object-safe so it can be passed as `&mut dyn Rng` into driver traits.
+/// Production implementations wrap a hardware TRNG or a CSPRNG seeded from
+/// one. Test code may inject a deterministic implementation (seeded DRBG or
+/// fixed bytes) to get reproducible outputs for known-answer tests.
+pub trait Rng {
+    /// Fill `buf` with cryptographically secure random bytes.
+    fn rng_fill(&mut self, buf: &mut [u8]) -> Result<(), CryptoError>;
+}
+
 unitrait::unitrait! {
     /// Md5 trait
     #[symbol_prefix = "_embassy_crypto_md5"]
@@ -1133,4 +1149,107 @@ unitrait::unitrait! {
     pub struct P384LincombImpl;
 
     macro p384_lincomb_impl(path = $crate);
+}
+
+// ===================================================================
+// P-256 high-level protocol operations
+// ===================================================================
+
+/// Raw P-256 ECDSA signature: canonical `(r, s)`, each 32 bytes big-endian.
+///
+/// This is the portable representation that crosses the backend boundary.
+/// `s` is low-S normalized (`s <= n/2`) as produced and as required for
+/// TLS 1.3 interop; verification must accept both low-S and high-S.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct P256Signature {
+    /// `r` component, canonical big-endian.
+    pub r: P256Scalar,
+    /// `s` component, canonical big-endian, low-S normalized.
+    pub s: P256Scalar,
+}
+
+unitrait::unitrait! {
+    /// High-level P-256 operations for TLS 1.3 and BLE Secure Connections.
+    ///
+    /// Each method corresponds to one operation a TLS 1.3 or BLE LE-SC stack
+    /// performs, so a hardware backend can implement it end-to-end where the
+    /// peripheral natively supports the whole operation. Everything below
+    /// this layer (field arithmetic, point encoding, hashing, HKDF) stays in
+    /// software in `embassy-crypto`, composing with [`Sha256`],
+    /// [`HmacSha256`], [`Aes128Gcm`] and [`Aes128Cmac`].
+    ///
+    /// ## Entropy
+    ///
+    /// Methods that need fresh randomness take `rng` and must draw their
+    /// nonce/ephemeral scalar from it, using rejection sampling until the
+    /// value lands in `[1, n-1]`. Hardware whose operation mandates an
+    /// internal entropy source (e.g. peripherals that generate the ECDSA
+    /// nonce on-chip from a TRNG) may ignore `rng`; such implementations must
+    /// document this. For deterministic known-answer tests, callers inject a
+    /// deterministic [`Rng`].
+    ///
+    /// ## Contract
+    ///
+    /// - All private/ephemeral scalars and signature components are canonical
+    ///   (`[1, n-1]`); non-canonical inputs return [`CryptoError::InvalidKey`]
+    ///   or [`CryptoError::InvalidInput`].
+    /// - All points are valid on-curve affine points in canonical big-endian
+    ///   encoding. Callers must run [`P256Ec::validate_point`] on untrusted
+    ///   peer public keys (TLS 1.3 RFC 8446 4.4.3.2, BLE Core Spec Vol 6
+    ///   5.8.4.4) before [`P256Ec::ecdh_shared_secret`] or
+    ///   [`P256Ec::ecdsa_verify`].
+    /// - No secret-dependent timing w.r.t. private keys, nonces, or ephemeral
+    ///   scalars. [`P256Ec::ecdsa_verify`] may be variable-time.
+    /// - Implementations wipe nonce/scalar copies they materialize in RAM.
+    #[symbol_prefix = "_embassy_crypto_p256_ec"]
+    pub trait P256Ec {
+        /// Generate a fresh keypair: `d` uniform in `[1, n-1]`, `Q = d * G`.
+        ///
+        /// Used for TLS 1.3 ECDHE keygen and BLE LE-SC keygen.
+        fn generate_keypair(
+            rng: &mut dyn Rng,
+        ) -> Result<(P256Scalar, P256AffinePoint), CryptoError>;
+
+        /// Derive the public key `k * G` from a known private scalar.
+        ///
+        /// No RNG: used for persistent keys (e.g. a TLS static ECDSA identity
+        /// loaded from flash, or deriving a BLE public key from a stored
+        /// secret) where the caller already holds `k`.
+        fn public_key(k: P256Scalar) -> Result<P256AffinePoint, CryptoError>;
+
+        /// Validate that `p` is a non-identity point on the P-256 curve.
+        fn validate_point(p: &P256AffinePoint) -> bool;
+
+        /// ECDH shared secret: X coordinate of `k * peer`, big-endian.
+        ///
+        /// This is the TLS 1.3 `ecdhe_shared_secret` (fed into HKDF via
+        /// [`HmacSha256`]) and the BLE LE-SC `DHKey`.
+        fn ecdh_shared_secret(
+            k: P256Scalar,
+            peer: P256AffinePoint,
+        ) -> Result<[u8; 32], CryptoError>;
+
+        /// ECDSA sign a pre-hashed message (`ecdsa_secp256r1_sha256`).
+        ///
+        /// The nonce is drawn from `rng` unless the hardware mandates an
+        /// internal entropy source. Returns a low-S normalized signature.
+        fn ecdsa_sign(
+            k: P256Scalar,
+            digest: &[u8; 32],
+            rng: &mut dyn Rng,
+        ) -> Result<P256Signature, CryptoError>;
+
+        /// ECDSA verify a pre-hashed message. All inputs public; may be
+        /// variable-time. `Err(CryptoError::InvalidSignature)` on failure.
+        fn ecdsa_verify(
+            q: P256AffinePoint,
+            digest: &[u8; 32],
+            sig: &P256Signature,
+        ) -> Result<(), CryptoError>;
+    }
+
+    /// The global [`P256Ec`] implementation.
+    pub struct P256EcImpl;
+
+    macro p256_ec_impl(path = $crate);
 }

--- a/embassy-crypto/Cargo.toml
+++ b/embassy-crypto/Cargo.toml
@@ -27,9 +27,9 @@ build = [
 ]
 
 [dependencies]
-signature = { version = "3", default-features = false, features = ["digest"] }
+signature = { version = "3", default-features = false, features = ["digest", "rand_core"] }
 embassy-crypto-driver = { path = "../embassy-crypto-driver" }
-digest = { version = "0.11", default-features = false, features = ["mac"] }
+digest = { version = "0.11", default-features = false, features = ["mac", "zeroize"] }
 crypto-common = "0.2"
 cipher = { version = "0.5", default-features = false }
 aead = { version = "0.6", default-features = false }
@@ -88,6 +88,12 @@ p384-ecdsa = ["p384", "ecdsa", "p384/ecdsa"]
 pkcs8 = ["ec", "elliptic-curve/pkcs8", "p256?/pkcs8", "p384?/pkcs8"]
 
 
+## Software implementation of the `P256Ec` driver trait via `driver_rustcrypto`
+## (p256 crate underneath). Enables the p256 ECDSA machinery; without it, the
+## `p256_ec` high-level API compiles with no software EC stack, so an asm/HAL
+## backend can serve it — smaller code size for that use case.
+driver-p256-ec = ["p256-ecdsa", "p256/ecdh"]
+
 ## Use RustCrypto crates as a software fallback driver.
 driver-rustcrypto = [
     "driver-md5",
@@ -107,6 +113,7 @@ driver-rustcrypto = [
     "driver-aes256ccm",
     "driver-aes128cmac",
     "driver-aes256cmac",
+    "driver-p256-ec",
     "driver-p256-scalar-mul",
     "driver-p256-scalar-invert",
     "driver-p256-lincomb",

--- a/embassy-crypto/src/asymmetric.rs
+++ b/embassy-crypto/src/asymmetric.rs
@@ -1,0 +1,230 @@
+//! High-level P-256 API for TLS 1.3 and BLE Secure Connections.
+//!
+//! Thin layer over the [`embassy_crypto_driver::P256Ec`] driver trait only —
+//! no `elliptic-curve`/`p256` software EC stack is pulled in, so a HAL or asm
+//! backend registering `P256EcImpl` serves this module with minimal code
+//! size. The `driver-p256-ec` feature instead provides the driver in
+//! software (`driver_rustcrypto`).
+//!
+//! Implements the `signature` crate traits (`RandomizedDigestSigner`,
+//! `DigestVerifier`, `hazmat::PrehashVerifier`) so the keys interoperate
+//! with generic signature code.
+
+use digest::typenum::U32;
+use digest::{Digest, Update};
+use embassy_crypto_driver::{CryptoError, P256AffinePoint, P256EcImpl, P256Scalar};
+use signature::rand_core::{CryptoRng, TryCryptoRng};
+use signature::{DigestVerifier, RandomizedDigestSigner};
+
+/// Bridge: adapts an infallible RustCrypto RNG (`CryptoRng`) to the driver's
+/// [`embassy_crypto_driver::Rng`].
+pub struct DriverRng<'a, R: CryptoRng + ?Sized>(&'a mut R);
+
+impl<R: CryptoRng + ?Sized> embassy_crypto_driver::Rng for DriverRng<'_, R> {
+    fn rng_fill(&mut self, buf: &mut [u8]) -> Result<(), CryptoError> {
+        self.0.fill_bytes(buf);
+        Ok(())
+    }
+}
+
+/// Bridge: adapts a fallible RustCrypto RNG (`TryCryptoRng`) to the driver's
+/// [`embassy_crypto_driver::Rng`].
+pub struct TryDriverRng<'a, R: TryCryptoRng + ?Sized>(&'a mut R);
+
+impl<R: TryCryptoRng + ?Sized> embassy_crypto_driver::Rng for TryDriverRng<'_, R> {
+    fn rng_fill(&mut self, buf: &mut [u8]) -> Result<(), CryptoError> {
+        self.0.try_fill_bytes(buf).map_err(|_| CryptoError::HardwareError)
+    }
+}
+
+/// P-256 private key: canonical scalar `d` in `[1, n-1]`.
+#[derive(Clone)]
+pub struct SecretKey(P256Scalar);
+
+/// P-256 public key: uncompressed affine point.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct PublicKey(P256AffinePoint);
+
+/// ECDSA/P-256 signature: canonical low-S `(r, s)`, 64 bytes big-endian.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Signature {
+    r: P256Scalar,
+    s: P256Scalar,
+}
+
+/// ECDH shared secret: the X coordinate of the shared point.
+pub struct SharedSecret([u8; 32]);
+
+impl Drop for SharedSecret {
+    fn drop(&mut self) {
+        use digest::zeroize::Zeroize;
+        self.0.zeroize();
+    }
+}
+
+fn digest32<D: Digest<OutputSize = U32>>(digest: D) -> [u8; 32] {
+    let out = digest.finalize();
+    let mut d = [0u8; 32];
+    d.copy_from_slice(AsRef::<[u8]>::as_ref(&out));
+    d
+}
+
+impl SecretKey {
+    /// Generate a fresh random private key.
+    pub fn generate<R: CryptoRng + ?Sized>(rng: &mut R) -> Result<Self, CryptoError> {
+        let (d, _) = P256EcImpl::generate_keypair(&mut DriverRng(rng))?;
+        Ok(Self(d))
+    }
+
+    /// Load a private key from its canonical big-endian encoding.
+    ///
+    /// `bytes` must encode a scalar in `[1, n-1]` (the driver contract
+    /// assumes canonical input; only the all-zero scalar is rejected here).
+    pub fn from_bytes(bytes: &[u8; 32]) -> Result<Self, CryptoError> {
+        if bytes.iter().all(|&b| b == 0) {
+            return Err(CryptoError::InvalidKey);
+        }
+        Ok(Self(P256Scalar(*bytes)))
+    }
+
+    /// doc
+    pub fn to_bytes(&self) -> [u8; 32] {
+        self.0.0
+    }
+
+    /// Compute the public key `d * G`.
+    pub fn public_key(&self) -> Result<PublicKey, CryptoError> {
+        P256EcImpl::public_key(self.0).map(PublicKey)
+    }
+
+    /// ECDH: X coordinate of `d * peer`.
+    pub fn ecdh(&self, peer: &PublicKey) -> Result<SharedSecret, CryptoError> {
+        P256EcImpl::ecdh_shared_secret(self.0, peer.0).map(SharedSecret)
+    }
+
+    /// ECDSA-sign a pre-hashed message (`digest` = SHA-256 output). The nonce
+    /// comes from `rng`.
+    pub fn sign_prehash<R: CryptoRng + ?Sized>(
+        &self,
+        digest: &[u8; 32],
+        rng: &mut R,
+    ) -> Result<Signature, CryptoError> {
+        let mut rng = DriverRng(rng);
+        P256EcImpl::ecdsa_sign(self.0, digest, &mut rng).map(|s| Signature { r: s.r, s: s.s })
+    }
+}
+
+impl PublicKey {
+    /// Wrap uncompressed affine coordinates (big-endian). Check with
+    /// [`is_valid`](Self::is_valid) before use if the point is untrusted.
+    pub fn from_xy(x: [u8; 32], y: [u8; 32]) -> Self {
+        Self(P256AffinePoint { x, y })
+    }
+
+    /// doc
+    pub fn to_xy(&self) -> ([u8; 32], [u8; 32]) {
+        (self.0.x, self.0.y)
+    }
+
+    /// On-curve and not the identity.
+    pub fn is_valid(&self) -> bool {
+        P256EcImpl::validate_point(&self.0)
+    }
+
+    /// ECDSA-verify a pre-hashed message.
+    pub fn verify_prehash(&self, digest: &[u8; 32], sig: &Signature) -> Result<(), CryptoError> {
+        P256EcImpl::ecdsa_verify(
+            self.0,
+            digest,
+            &embassy_crypto_driver::P256Signature { r: sig.r, s: sig.s },
+        )
+    }
+}
+
+impl SharedSecret {
+    /// doc
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+// ---- `signature` crate traits ----
+//
+// `DigestSigner` is deliberately NOT implemented: ECDSA signing needs nonce
+// entropy, and silently sourcing it from a hidden global RNG is exactly the
+// failure mode this API design avoids. Use the inherent `sign_prehash` or
+// `RandomizedDigestSigner`, which thread the RNG through.
+
+impl<D> RandomizedDigestSigner<D, Signature> for SecretKey
+where
+    D: Digest<OutputSize = U32> + Update,
+{
+    fn try_sign_digest_with_rng<R, F>(&self, rng: &mut R, f: F) -> Result<Signature, signature::Error>
+    where
+        R: TryCryptoRng + ?Sized,
+        F: Fn(&mut D) -> Result<(), signature::Error>,
+    {
+        let mut digest = D::new();
+        f(&mut digest)?;
+        let d = digest32(digest);
+        let mut rng = TryDriverRng(rng);
+        P256EcImpl::ecdsa_sign(self.0, &d, &mut rng)
+            .map(|s| Signature { r: s.r, s: s.s })
+            .map_err(|_| signature::Error::new())
+    }
+}
+
+impl<D> DigestVerifier<D, Signature> for PublicKey
+where
+    D: Digest<OutputSize = U32> + Update,
+{
+    fn verify_digest<F: Fn(&mut D) -> Result<(), signature::Error>>(
+        &self,
+        f: F,
+        signature: &Signature,
+    ) -> Result<(), signature::Error> {
+        let mut digest = D::new();
+        f(&mut digest)?;
+        let d = digest32(digest);
+        PublicKey::verify_prehash(self, &d, signature).map_err(|_| signature::Error::new())
+    }
+}
+
+impl signature::hazmat::PrehashVerifier<Signature> for PublicKey {
+    fn verify_prehash(&self, prehash: &[u8], signature: &Signature) -> Result<(), signature::Error> {
+        let digest: &[u8; 32] = prehash.try_into().map_err(|_| signature::Error::new())?;
+        PublicKey::verify_prehash(self, digest, signature).map_err(|_| signature::Error::new())
+    }
+}
+
+// ---- Signature encoding ----
+
+impl signature::SignatureEncoding for Signature {
+    type Repr = [u8; 64];
+}
+
+impl From<Signature> for [u8; 64] {
+    fn from(sig: Signature) -> [u8; 64] {
+        let mut out = [0u8; 64];
+        out[..32].copy_from_slice(&sig.r.0);
+        out[32..].copy_from_slice(&sig.s.0);
+        out
+    }
+}
+
+impl TryFrom<&[u8]> for Signature {
+    type Error = signature::Error;
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != 64 {
+            return Err(signature::Error::new());
+        }
+        let mut r = [0u8; 32];
+        let mut s = [0u8; 32];
+        r.copy_from_slice(&bytes[..32]);
+        s.copy_from_slice(&bytes[32..]);
+        Ok(Signature {
+            r: P256Scalar(r),
+            s: P256Scalar(s),
+        })
+    }
+}

--- a/embassy-crypto/src/driver_rustcrypto.rs
+++ b/embassy-crypto/src/driver_rustcrypto.rs
@@ -1217,3 +1217,144 @@ impl embassy_crypto_driver::P384Lincomb for P384LincombDriver {
 
 #[cfg(feature = "driver-p384-lincomb")]
 embassy_crypto_driver::p384_lincomb_impl!(P384LincombDriver);
+
+// ===========================================================================
+// P-256 high-level EC operations (software, via the p256 crate)
+// ===========================================================================
+
+#[cfg(feature = "driver-p256-ec")]
+struct P256EcDriver;
+
+#[cfg(feature = "driver-p256-ec")]
+fn field_bytes(bytes: &[u8; 32]) -> p256::FieldBytes {
+    #[allow(deprecated)]
+    p256::FieldBytes::from_slice(bytes).clone()
+}
+
+#[cfg(feature = "driver-p256-ec")]
+fn sec1(p: &embassy_crypto_driver::P256AffinePoint) -> [u8; 65] {
+    let mut out = [0u8; 65];
+    out[0] = 0x04;
+    out[1..33].copy_from_slice(&p.x);
+    out[33..65].copy_from_slice(&p.y);
+    out
+}
+
+#[cfg(feature = "driver-p256-ec")]
+fn scalar(bytes: &[u8; 32]) -> Result<p256::Scalar, CryptoError> {
+    if bytes.iter().all(|&b| b == 0) {
+        return Err(CryptoError::InvalidKey);
+    }
+    use p256::elliptic_curve::PrimeField;
+    Option::<p256::Scalar>::from(p256::Scalar::from_repr(field_bytes(bytes))).ok_or(CryptoError::InvalidKey)
+}
+
+#[cfg(feature = "driver-p256-ec")]
+fn nonzero_scalar(bytes: &[u8; 32]) -> Result<p256::NonZeroScalar, CryptoError> {
+    use p256::elliptic_curve::PrimeField;
+    // from_repr rejects >= n; NonZeroScalar::new rejects zero.
+    let s = Option::<p256::Scalar>::from(p256::Scalar::from_repr(field_bytes(bytes))).ok_or(CryptoError::InvalidKey)?;
+    Option::<p256::NonZeroScalar>::from(p256::NonZeroScalar::new(s)).ok_or(CryptoError::InvalidKey)
+}
+
+#[cfg(feature = "driver-p256-ec")]
+fn point_xy(sk: &p256::SecretKey) -> ([u8; 32], [u8; 32]) {
+    use p256::elliptic_curve::sec1::ToEncodedPoint;
+    let ep = sk.public_key().to_encoded_point(false);
+    let mut x = [0u8; 32];
+    let mut y = [0u8; 32];
+    x.copy_from_slice(ep.x().unwrap());
+    y.copy_from_slice(ep.y().unwrap());
+    (x, y)
+}
+
+#[cfg(feature = "driver-p256-ec")]
+impl embassy_crypto_driver::P256Ec for P256EcDriver {
+    fn generate_keypair(
+        rng: &mut dyn embassy_crypto_driver::Rng,
+    ) -> Result<
+        (
+            embassy_crypto_driver::P256Scalar,
+            embassy_crypto_driver::P256AffinePoint,
+        ),
+        CryptoError,
+    > {
+        let mut b = [0u8; 32];
+        loop {
+            rng.rng_fill(&mut b).map_err(|_| CryptoError::HardwareError)?;
+            if let Ok(sk) = p256::SecretKey::from_slice(&b) {
+                let (x, y) = point_xy(&sk);
+                return Ok((
+                    embassy_crypto_driver::P256Scalar(b),
+                    embassy_crypto_driver::P256AffinePoint { x, y },
+                ));
+            }
+        }
+    }
+
+    fn public_key(k: embassy_crypto_driver::P256Scalar) -> Result<embassy_crypto_driver::P256AffinePoint, CryptoError> {
+        let sk = p256::SecretKey::from_slice(&k.0).map_err(|_| CryptoError::InvalidKey)?;
+        let (x, y) = point_xy(&sk);
+        Ok(embassy_crypto_driver::P256AffinePoint { x, y })
+    }
+
+    fn validate_point(p: &embassy_crypto_driver::P256AffinePoint) -> bool {
+        p256::PublicKey::from_sec1_bytes(&sec1(p)).is_ok()
+    }
+
+    fn ecdh_shared_secret(
+        k: embassy_crypto_driver::P256Scalar,
+        peer: embassy_crypto_driver::P256AffinePoint,
+    ) -> Result<[u8; 32], CryptoError> {
+        let nz = nonzero_scalar(&k.0)?;
+        let pk = p256::PublicKey::from_sec1_bytes(&sec1(&peer)).map_err(|_| CryptoError::InvalidKey)?;
+        let secret = p256::elliptic_curve::ecdh::diffie_hellman(&nz, pk.as_affine());
+        let mut out = [0u8; 32];
+        out.copy_from_slice(secret.raw_secret_bytes());
+        Ok(out)
+    }
+
+    fn ecdsa_sign(
+        k: embassy_crypto_driver::P256Scalar,
+        digest: &[u8; 32],
+        rng: &mut dyn embassy_crypto_driver::Rng,
+    ) -> Result<embassy_crypto_driver::P256Signature, CryptoError> {
+        use ecdsa::hazmat::SignPrimitive;
+        let d = scalar(&k.0)?;
+        let mut nb = [0u8; 32];
+        let nonce = loop {
+            rng.rng_fill(&mut nb).map_err(|_| CryptoError::HardwareError)?;
+            if let Ok(n) = scalar(&nb) {
+                break n;
+            }
+        };
+        let prehash = field_bytes(digest);
+        let (sig, _rid) = d
+            .try_sign_prehashed(nonce, &prehash)
+            .map_err(|_| CryptoError::InvalidSignature)?;
+        let sig = sig.normalize_s().unwrap_or(sig);
+        let (mut r, mut s) = ([0u8; 32], [0u8; 32]);
+        r.copy_from_slice(&sig.r().to_bytes());
+        s.copy_from_slice(&sig.s().to_bytes());
+        Ok(embassy_crypto_driver::P256Signature {
+            r: embassy_crypto_driver::P256Scalar(r),
+            s: embassy_crypto_driver::P256Scalar(s),
+        })
+    }
+
+    fn ecdsa_verify(
+        q: embassy_crypto_driver::P256AffinePoint,
+        digest: &[u8; 32],
+        sig: &embassy_crypto_driver::P256Signature,
+    ) -> Result<(), CryptoError> {
+        use ecdsa::signature::hazmat::PrehashVerifier;
+        let vk = p256::ecdsa::VerifyingKey::from_sec1_bytes(&sec1(&q)).map_err(|_| CryptoError::InvalidKey)?;
+        let signature = p256::ecdsa::Signature::from_scalars(field_bytes(&sig.r.0), field_bytes(&sig.s.0))
+            .map_err(|_| CryptoError::InvalidSignature)?;
+        vk.verify_prehash(digest, &signature)
+            .map_err(|_| CryptoError::InvalidSignature)
+    }
+}
+
+#[cfg(feature = "driver-p256-ec")]
+embassy_crypto_driver::p256_ec_impl!(P256EcDriver);

--- a/embassy-crypto/src/lib.rs
+++ b/embassy-crypto/src/lib.rs
@@ -28,6 +28,7 @@ use cipher::InOutBuf;
     feature = "driver-p384-scalar-mul",
     feature = "driver-p384-scalar-invert",
     feature = "driver-p384-lincomb",
+    feature = "driver-p256-ec",
 ))]
 mod driver_rustcrypto;
 
@@ -45,6 +46,8 @@ mod hash;
 
 pub use aes::*;
 pub use hash::*;
+
+pub mod asymmetric;
 
 #[allow(dead_code)]
 #[inline]

--- a/tests/stm32/src/bin/eth.rs
+++ b/tests/stm32/src/bin/eth.rs
@@ -124,7 +124,7 @@ async fn main(spawner: Spawner) {
             #[cfg(not(feature = "stm32h755zi"))]
             updown_kbps: 1000,
             #[cfg(feature = "stm32h755zi")]
-            updown_kbps: 800,
+            updown_kbps: 500,
         },
     )
     .await;


### PR DESCRIPTION
allows cutting out elliptic-curve entirely to reduce code size.