### PR TITLE
Improve `embassy-net-esp-hosted` reliability between resets, add method to reset ESP and get hardware address

### DIFF
--- a/embassy-net-esp-hosted/src/control.rs
+++ b/embassy-net-esp-hosted/src/control.rs
@@ -226,6 +226,14 @@ impl<'a> Control<'a> {
     /// Get hardware address
     ///
     /// Use after `init` method successful execution
+    ///
+    /// This method may be used to update interface hardware address if you have initialized
+    /// network stack before this device
+    ///
+    /// ```rust,no_run
+    /// use embassy_net::wire::HardwareAddress;
+    /// iface.set_hardware_addr(HardwareAddress::from_driver(ctl.hardware_address()).unwrap());
+    /// ```
     pub fn hardware_address(&self) -> HardwareAddress {
         self.state_ch.get_hardware_address()
     }

--- a/embassy-net-esp-hosted/src/control.rs
+++ b/embassy-net-esp-hosted/src/control.rs
@@ -223,6 +223,20 @@ impl<'a> Control<'a> {
         Ok(())
     }
 
+    /// Get hardware address
+    ///
+    /// Use after `init` method successful execution
+    pub fn hardware_address(&self) -> HardwareAddress {
+        self.state_ch.get_hardware_address()
+    }
+
+    /// Reset ESP and initialzation state
+    ///
+    /// `init` should be executed again after reset
+    pub fn reset(&self) {
+        self.shared().reboot();
+    }
+
     /// Get the current status.
     pub async fn get_status(&mut self) -> Result<Status, Error> {
         self.backend.get_status(&mut self.ioctl).await
@@ -295,7 +309,7 @@ impl<'a> Control<'a> {
     /// NOTE: Will reset the wifi adapter after 5 seconds.
     pub async fn ota_end(&mut self) -> Result<(), Error> {
         self.backend.ota_end(&mut self.ioctl).await?;
-        self.shared().ota_done();
+        self.shared().reboot();
         // Wait for re-init
         self.init().await
     }

--- a/embassy-net-esp-hosted/src/ioctl.rs
+++ b/embassy-net-esp-hosted/src/ioctl.rs
@@ -115,8 +115,7 @@ impl Shared {
         }
     }
 
-    // ota
-    pub fn ota_done(&self) {
+    pub fn reboot(&self) {
         let mut this = self.0.borrow_mut();
         this.state = ControlState::Reboot;
     }

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -241,13 +241,13 @@ where
         loop {
             if let ioctl::ControlState::Reboot = self.shared.state() {
                 self.state_ch.set_link_state(LinkState::Down);
-                
+
                 debug!("resetting...");
                 self.reset.set_low().unwrap();
                 Timer::after_millis(100).await;
                 self.reset.set_high().unwrap();
                 Timer::after_millis(1000).await;
-                
+
                 self.heartbeat_deadline = Instant::now() + HEARTBEAT_MAX_GAP;
                 self.backend = Backend::default();
                 self.iface.init(true).await;

--- a/embassy-net-esp-hosted/src/lib.rs
+++ b/embassy-net-esp-hosted/src/lib.rs
@@ -178,7 +178,7 @@ pub struct HostedResources<'a, I, OUT> {
 ///
 /// Returns a device handle for interfacing with embassy-net, a control handle for
 /// interacting with the driver, and a runner for communicating with the WiFi device.
-pub async fn new<'a, I, OUT>(state: &'a mut State, iface: I, reset: OUT) -> HostedResources<'a, I, OUT>
+pub fn new<'a, I, OUT>(state: &'a mut State, iface: I, reset: OUT) -> HostedResources<'a, I, OUT>
 where
     I: Interface,
     OUT: OutputPin,
@@ -235,21 +235,22 @@ where
 {
     /// Run the packet processing.
     pub async fn run(mut self) -> ! {
-        debug!("resetting...");
-        self.reset.set_low().unwrap();
-        Timer::after_millis(100).await;
-        self.reset.set_high().unwrap();
-        Timer::after_millis(1000).await;
-
-        self.iface.init(true).await;
-        self.shared.interface_ready();
-
         let mut buffer = Aligned([0u8; MAX_BUFFER_SIZE]);
 
+        self.shared.reboot();
         loop {
             if let ioctl::ControlState::Reboot = self.shared.state() {
+                self.state_ch.set_link_state(LinkState::Down);
+                
+                debug!("resetting...");
+                self.reset.set_low().unwrap();
+                Timer::after_millis(100).await;
+                self.reset.set_high().unwrap();
+                Timer::after_millis(1000).await;
+                
+                self.heartbeat_deadline = Instant::now() + HEARTBEAT_MAX_GAP;
                 self.backend = Backend::default();
-                self.iface.init(false).await;
+                self.iface.init(true).await;
                 self.shared.interface_ready();
             }
 
@@ -321,7 +322,9 @@ where
                         self.heartbeat_deadline = Instant::now() + HEARTBEAT_MAX_GAP;
                         continue;
                     }
-                    panic!("heartbeat from esp32 stopped")
+                    error!("Heartbeat from ESP32 stopped");
+                    self.shared.reboot();
+                    continue;
                 }
 
                 // Bluetooth HCI packet queued by the host stack.

--- a/examples/nrf52840/src/bin/wifi_esp_hosted.rs
+++ b/examples/nrf52840/src/bin/wifi_esp_hosted.rs
@@ -68,7 +68,7 @@ async fn main(spawner: Spawner) {
         net_device,
         mut control,
         runner,
-    } = embassy_net_esp_hosted::new(ESP_STATE.init(embassy_net_esp_hosted::State::new()), iface, reset).await;
+    } = embassy_net_esp_hosted::new(ESP_STATE.init(embassy_net_esp_hosted::State::new()), iface, reset);
 
     spawner.spawn(unwrap!(wifi_task(runner)));
 

--- a/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
+++ b/tests/nrf/src/bin/wifi_esp_hosted_perf.rs
@@ -73,7 +73,7 @@ async fn main(spawner: Spawner) {
         net_device,
         mut control,
         runner,
-    } = embassy_net_esp_hosted::new(STATE.init(embassy_net_esp_hosted::State::new()), iface, reset).await;
+    } = embassy_net_esp_hosted::new(STATE.init(embassy_net_esp_hosted::State::new()), iface, reset);
 
     spawner.spawn(unwrap!(wifi_task(runner)));
 


### PR DESCRIPTION
Also remove excessive `async` from init function, try to reset ESP instead of panic on heartbeat timeout. 