### PR TITLE
embassy-sync: wake the next waiter when a FairSemaphore acquire is canceled

### DIFF
--- a/embassy-sync/CHANGELOG.md
+++ b/embassy-sync/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `Signal::poll_wait` public.
 - Made `Subscriber::poll_next_message` public.
 - Made `watch::Receiver::poll_changed` public.
+- Fix `FairSemaphore` not waking the next waiter when a queued `acquire`/`acquire_all` future is
+  dropped. Dropping the waiter at the head of the queue left the tasks behind it pending until an
+  unrelated `release` happened to wake them, even when enough permits were already available.
 
 ## 0.8.0 - 2026-03-10
 - Fix wakers getting dropped by `Signal::reset`

--- a/embassy-sync/src/semaphore.rs
+++ b/embassy-sync/src/semaphore.rs
@@ -429,6 +429,13 @@ impl<const N: usize> FairSemaphoreState<N> {
     fn cancel(&mut self, ticket: Option<usize>) {
         if let Some(ticket) = ticket {
             self.set_waker(ticket, None);
+
+            // If the canceled waiter was at the head of the queue, it was holding back everyone
+            // behind it. Wake the new head so it can retry, otherwise it stays pending until some
+            // unrelated `release` happens to wake it.
+            if let Some(None) = self.wakers.front() {
+                self.wake();
+            }
         }
     }
 
@@ -613,9 +620,11 @@ mod tests {
 
     mod fair {
         use core::pin::pin;
+        use core::task::Context;
         use core::time::Duration;
 
         use futures_executor::ThreadPool;
+        use futures_test::task::new_count_waker;
         use futures_timer::Delay;
         use futures_util::poll;
         use futures_util::task::SpawnExt;
@@ -743,6 +752,32 @@ mod tests {
 
             let c = poll!(c_fut.as_mut());
             assert!(c.is_ready());
+        }
+
+        #[test]
+        fn cancel_wakes_next_waiter() {
+            let semaphore = FairSemaphore::<NoopRawMutex, 2>::new(1);
+
+            let (c_waker, c_count) = new_count_waker();
+            let mut c_fut = pin!(semaphore.acquire(1));
+
+            {
+                // `b` wants more permits than the semaphore has, so it waits at the head of the queue.
+                let (b_waker, _b_count) = new_count_waker();
+                let mut b_fut = pin!(semaphore.acquire(2));
+                assert!(b_fut.as_mut().poll(&mut Context::from_waker(&b_waker)).is_pending());
+
+                // `c` only wants the permit that is already free, but fairness queues it behind `b`.
+                assert!(c_fut.as_mut().poll(&mut Context::from_waker(&c_waker)).is_pending());
+                assert_eq!(c_count.get(), 0);
+            }
+
+            // `b` was canceled when it went out of scope, so nothing holds `c` back anymore.
+            assert_eq!(c_count.get(), 1);
+            assert!(matches!(
+                c_fut.as_mut().poll(&mut Context::from_waker(&c_waker)),
+                Poll::Ready(Ok(_))
+            ));
         }
 
         #[futures_test::test]


### PR DESCRIPTION
`FairSemaphore` hands out permits in FIFO order, so a task asking for more permits than are currently available parks at the head of the queue and holds back everyone behind it. That part is intended. The problem is what happens when that head waiter goes away without ever acquiring: if its `acquire` future is dropped, nothing wakes the waiters behind it, and they stay pending even though there are already enough permits to satisfy them. Anything that cancels an acquire runs into this, `select` or `with_timeout` around `sema.acquire(n)` being the obvious cases. The queue only starts moving again if some unrelated `release` happens to come along.

The cause is `FairSemaphoreState::cancel` at embassy-sync/src/semaphore.rs:429. It clears the canceled waiter's slot with `set_waker(ticket, None)` and stops there. Every other place that changes who is at the head of the queue wakes the new head: `take` does it after popping a satisfied waiter, `release` and `set` do it after adding permits. Cancel was the one path that skipped it. #2766 fixed the same shape of lost wakeup on the completion path in 2024, so this is the half that was left.

The fix is to wake the new head from `cancel` when the head slot has become empty. `wake()` already pops canceled entries off the front and wakes whoever is next, so it comes to three lines. Checking the head first keeps cancelling a waiter that was not at the head free of spurious wakes.

The regression test is `cancel_wakes_next_waiter`, next to the existing `fairness` test. It builds a semaphore with one permit, queues a waiter for two permits and then a waiter for one, drops the first, and asserts the second gets woken and then completes. It uses a counting waker from `futures-test` instead of threads or timers, so there is nothing timing or platform dependent in it.

Verification, on an aarch64 Mac with the pinned 1.97 toolchain. `cargo test --manifest-path ./embassy-sync/Cargo.toml`, the command `.github/ci/test.sh` runs for this crate, gives 108 passed and 0 failed, plus the trybuild ui test and 9 doctests. Reverting only the `cancel` change and keeping the test gives `cancel_wakes_next_waiter ... FAILED` with `assertion left == right failed, left: 0, right: 1` on the wake count, so the test does pin the behaviour. `rustfmt --check --skip-children --unstable-features --edition 2024` under nightly-2026-08-26 from `rust-toolchain-nightly.toml` reports no changes. `cargo build --target thumbv7em-none-eabi` and `cargo build --target thumbv6m-none-eabi --features defmt` both succeed, so the crate still cross compiles.
