### PR TITLE
nrf: make the GRTC time-driver channel configurable

### DIFF
--- a/embassy-nrf/Cargo.toml
+++ b/embassy-nrf/Cargo.toml
@@ -95,8 +95,35 @@ gpiote = []
 ## Use RTC1 as the time driver for `embassy-time`, with a tick rate of 32.768khz
 time-driver-rtc1 = ["_time-driver", "embassy-time-driver?/tick-hz-32_768"]
 
-## Use GRTC (CC n=1, GRTC_1 irq) as the time driver for `embassy-time`, with a tick rate of 1 MHz
+## Use GRTC as the time driver for `embassy-time`, with a tick rate of 1 MHz.
+## Defaults to CC11. Select at most one `time-driver-grtc-ccN` feature to choose a channel.
+## The interrupt follows the security domain: GRTC_1 for non-secure, GRTC_2 for secure.
 time-driver-grtc = ["_time-driver", "embassy-time-driver?/tick-hz-1_000_000"]
+
+## Use GRTC CC0 for the time driver.
+time-driver-grtc-cc0 = ["time-driver-grtc"]
+## Use GRTC CC1 for the time driver.
+time-driver-grtc-cc1 = ["time-driver-grtc"]
+## Use GRTC CC2 for the time driver.
+time-driver-grtc-cc2 = ["time-driver-grtc"]
+## Use GRTC CC3 for the time driver.
+time-driver-grtc-cc3 = ["time-driver-grtc"]
+## Use GRTC CC4 for the time driver.
+time-driver-grtc-cc4 = ["time-driver-grtc"]
+## Use GRTC CC5 for the time driver.
+time-driver-grtc-cc5 = ["time-driver-grtc"]
+## Use GRTC CC6 for the time driver.
+time-driver-grtc-cc6 = ["time-driver-grtc"]
+## Use GRTC CC7 for the time driver.
+time-driver-grtc-cc7 = ["time-driver-grtc"]
+## Use GRTC CC8 for the time driver.
+time-driver-grtc-cc8 = ["time-driver-grtc"]
+## Use GRTC CC9 for the time driver.
+time-driver-grtc-cc9 = ["time-driver-grtc"]
+## Use GRTC CC10 for the time driver.
+time-driver-grtc-cc10 = ["time-driver-grtc"]
+## Use GRTC CC11 for the time driver.
+time-driver-grtc-cc11 = ["time-driver-grtc"]
 
 ## Enable embassy-net 802.15.4 driver
 net-driver = ["_net-driver"]

--- a/embassy-nrf/src/time_driver.rs
+++ b/embassy-nrf/src/time_driver.rs
@@ -23,13 +23,39 @@ fn rtc() -> pac::rtc::Rtc {
     pac::RTC1
 }
 
-// The nRF54 series (which has the GRTC) uses asymmetric channels
-// Namely, CC[0] is the only channel which supports "periodic interval" (page 298 in the datasheet),
-// which supports periodic alarms by adding the value in the INTERVAL register when EVENTS_COMPARE[0] triggers
-// Because the time driver does not make use of periodic alarms (but always reprograms it), it does not need to make use of this.
-// This selects the last CC channel (CC[11]) instead of CC[0] to keep CC[0] free for application use,
-// specifically for PPI-driven events that aim to avoid CPU intervention in periodic tasks.
-const TIME_DRIVER_CC_N: usize = if cfg!(feature = "_grtc") { 11 } else { 0 };
+#[cfg(feature = "time-driver-grtc")]
+const _: () = {
+    let selected = cfg!(feature = "time-driver-grtc-cc0") as u8
+        + cfg!(feature = "time-driver-grtc-cc1") as u8
+        + cfg!(feature = "time-driver-grtc-cc2") as u8
+        + cfg!(feature = "time-driver-grtc-cc3") as u8
+        + cfg!(feature = "time-driver-grtc-cc4") as u8
+        + cfg!(feature = "time-driver-grtc-cc5") as u8
+        + cfg!(feature = "time-driver-grtc-cc6") as u8
+        + cfg!(feature = "time-driver-grtc-cc7") as u8
+        + cfg!(feature = "time-driver-grtc-cc8") as u8
+        + cfg!(feature = "time-driver-grtc-cc9") as u8
+        + cfg!(feature = "time-driver-grtc-cc10") as u8
+        + cfg!(feature = "time-driver-grtc-cc11") as u8;
+    core::assert!(selected <= 1, "select at most one time-driver-grtc-ccN feature");
+};
+
+// GRTC defaults to CC11; RTC1 uses CC0. The selected channel must be reserved for the driver.
+const TIME_DRIVER_CC_N: usize = core::cfg_select! {
+    not(feature = "_grtc") => 0,
+    feature = "time-driver-grtc-cc0" => 0,
+    feature = "time-driver-grtc-cc1" => 1,
+    feature = "time-driver-grtc-cc2" => 2,
+    feature = "time-driver-grtc-cc3" => 3,
+    feature = "time-driver-grtc-cc4" => 4,
+    feature = "time-driver-grtc-cc5" => 5,
+    feature = "time-driver-grtc-cc6" => 6,
+    feature = "time-driver-grtc-cc7" => 7,
+    feature = "time-driver-grtc-cc8" => 8,
+    feature = "time-driver-grtc-cc9" => 9,
+    feature = "time-driver-grtc-cc10" => 10,
+    _ => 11,
+};
 
 // On nRF54L/LM GRTC, SYSCOUNTER[n], INTENSETn/INTENCLRn/INTENn, and the
 // GRTC_n interrupt all index by "domain":


### PR DESCRIPTION
Add time-driver-grtc-cc0 through cc11 to allow applications to avoid channel conflicts with other components, such as MPSL.

CC11 remains the default. Multiple channel selections are rejected at compile time.