### PR TITLE
stm32/rcc: allow the PLL to be overclocked

### DIFF
--- a/embassy-stm32/src/rcc/f247.rs
+++ b/embassy-stm32/src/rcc/f247.rs
@@ -449,13 +449,13 @@ fn init_pll(instance: PllInstance, config: Option<Pll>, input: &PllInput) -> Pll
     let pll_src = pll_src.unwrap();
 
     let in_freq = pll_src / pll.prediv;
-    assert!(max::PLL_IN.contains(&in_freq));
+    rcc_assert!(max::PLL_IN.contains(&in_freq));
 
     let vco_num = u64::from(pll_src.0) * u64::from(pll.mul.num()) * u64::from(pll.prediv.denom());
     let vco_denom = u64::from(pll.mul.denom()) * u64::from(pll.prediv.num());
 
     let vco_freq = Hertz(unwrap!((vco_num / vco_denom).try_into()));
-    assert!(max::PLL_VCO.contains(&vco_freq));
+    rcc_assert!(max::PLL_VCO.contains(&vco_freq));
 
     // stm32f2 plls are like swiss cheese
     #[cfg(stm32f2)]


### PR DESCRIPTION
I am currently trying to overclock an STM32F767ZI and found the `unchecked-overclocking` feature to disable hard panics when frequencies are deemed to be out of specification for the used chip.

However, the PLL init code does not make use of `rcc_assert!` which respects the mentioned feature, but the normal `assert!` macro which panics hard.

To be able to overclock, I think the PLL init code should allow for `unchecked-overclocking` as well, so this PR replaces the normal `assert!` macros in `pll_init()` with `rcc_assert!` like in other places.