### PR TITLE
stm32: require 100m only for v2a

### DIFF
--- a/embassy-stm32/src/eth/generic_phy.rs
+++ b/embassy-stm32/src/eth/generic_phy.rs
@@ -119,11 +119,14 @@ impl<SM: StationManagement> Phy for GenericPhy<SM> {
         // Clear WU CSR
         self.smi_write_ext(PHY_REG_WUCSR, 0);
 
-        // Enable auto-negotiation
-        let antx = self.sm.smi_read(self.phy_addr, PHY_REG_ANTX);
-        let antx = (antx & !PHY_REG_ANTX_TECH) | PHY_REG_ANTX_100BTX_FD;
-        self.sm.smi_write(self.phy_addr, PHY_REG_ANTX, antx);
-        self.sm.smi_write(self.phy_addr, PHY_REG_GBCR, 0);
+        #[cfg(eth_v2a)]
+        {
+            // The v2a MAC is fixed at 100M full duplex; advertise only that.
+            let antx = self.sm.smi_read(self.phy_addr, PHY_REG_ANTX);
+            let antx = (antx & !PHY_REG_ANTX_TECH) | PHY_REG_ANTX_100BTX_FD;
+            self.sm.smi_write(self.phy_addr, PHY_REG_ANTX, antx);
+            self.sm.smi_write(self.phy_addr, PHY_REG_GBCR, 0);
+        }
         self.sm
             .smi_write(self.phy_addr, PHY_REG_BCR, PHY_REG_BCR_AN | PHY_REG_BCR_ANRST);
     }


### PR DESCRIPTION
this disabled 10m on chips that support a slower speed.