### PR TITLE
stm32: more complete crypto drivers

### DIFF
--- a/embassy-stm32/CHANGELOG.md
+++ b/embassy-stm32/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Crypto:
 - feat: stm32/hash, stm32/aes, stm32/cryp: the `embassy-crypto` drivers are now registered per operation behind `embassy-crypto-<operation>` features (`embassy-crypto-sha256`, `embassy-crypto-aes128-gcm`, ...) instead of unconditionally.
+- feat: stm32/aes: enable the driver on STM32U3 and STM32U5
 
 CAN:
 - fix: stm32/can/fdcan: write `FilterType::Range` bounds in the correct order (`from`→SFID1/EFID1, `to`→SFID2/EFID2). The swapped order prevented normal multi-ID ranges from matching, breaking both accepting and rejecting range filters.
@@ -59,6 +60,11 @@ QEI:
 
 PKA:
 - feat: stm32/pka: extend ECC point buffer support to 640-bit operands (80-byte coordinates) in public point types and Jacobian conversion paths
+- feat: stm32/pka: register `embassy-crypto` P-256 and P-384 arithmetic drivers behind the `embassy-crypto-p256-arith` and `embassy-crypto-p384-arith` features
+- feat: stm32/pka: add `EcdsaCurveParams::nist_p384()`
+- feat: stm32/pka: add `Pka::is_limited()`, reporting a PKA that only verifies ECDSA signatures
+- feat: stm32/pka: enable the driver on STM32U3 and STM32U5
+- fix: stm32/pka: `point_check` writes the Montgomery parameter the operation needs, and no longer reports points off the curve as on it
 
 CRYP:
 - feat: stm32/cryp: batch full-block DMA in payload and use 4-beat bursts on GPDMA

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -296,6 +296,11 @@ embassy-crypto-aes256-cbc = []
 embassy-crypto-aes256-ctr = []
 embassy-crypto-aes256-gcm = []
 embassy-crypto-aes256-ccm = []
+## Serve the `embassy-crypto-aes*` operations with the SAES peripheral instead of
+## the AES one, on chips that have both. The SAES needs the RNG running: with
+## `embassy-crypto-rng` the driver starts it, otherwise keep an
+## [`Rng`](crate::rng::Rng) alive. See [`saes`](crate::saes).
+embassy-crypto-saes = []
 ## Register the hardware driver for random numbers, served by the RNG. See the
 ## `embassy-crypto` documentation. The driver takes the peripheral over and keeps
 ## it running.

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -165,6 +165,7 @@ embassy-hal-internal = { version = "0.5.0", path = "../embassy-hal-internal", fe
 embassy-embedded-hal = { version = "0.6.0", path = "../embassy-embedded-hal", default-features = false }
 xarxa-driver = { git = "https://github.com/embassy-rs/xarxa", rev = "14c369bbcbe8ee7167488ac9c9e18be059d83555", features = ["async", "packet-buf-align-8"] }
 embassy-crypto = { version = "0.1.0", path = "../embassy-crypto", features = ["large-contexts"] }
+crypto-bigint = { version = "0.7.5", default-features = false, optional = true }
 embassy-ptp-driver = { version = "0.1.0", path = "../embassy-ptp-driver", optional = true }
 embassy-usb-driver = { version = "0.2.2", path = "../embassy-usb-driver" }
 embassy-usb-synopsys-otg = { version = "0.4.0", path = "../embassy-usb-synopsys-otg" }
@@ -295,6 +296,24 @@ embassy-crypto-aes256-cbc = []
 embassy-crypto-aes256-ctr = []
 embassy-crypto-aes256-gcm = []
 embassy-crypto-aes256-ccm = []
+## Register the hardware driver for P-256 arithmetic, served by the PKA. See the
+## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
+embassy-crypto-p256-arith = ["dep:crypto-bigint"]
+## Register the hardware driver for P-256 ECDH, served by the PKA. See the
+## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
+embassy-crypto-p256-ecdh = ["dep:crypto-bigint"]
+## Register the hardware driver for P-256 ECDSA, served by the PKA. See the
+## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
+embassy-crypto-p256-ecdsa = ["dep:crypto-bigint"]
+## Register the hardware driver for P-384 arithmetic, served by the PKA. See the
+## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
+embassy-crypto-p384-arith = ["dep:crypto-bigint"]
+## Register the hardware driver for P-384 ECDH, served by the PKA. See the
+## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
+embassy-crypto-p384-ecdh = ["dep:crypto-bigint"]
+## Register the hardware driver for P-384 ECDSA, served by the PKA. See the
+## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
+embassy-crypto-p384-ecdsa = ["dep:crypto-bigint"]
 
 exti = []
 low-power = [ "time" ]

--- a/embassy-stm32/Cargo.toml
+++ b/embassy-stm32/Cargo.toml
@@ -296,6 +296,10 @@ embassy-crypto-aes256-cbc = []
 embassy-crypto-aes256-ctr = []
 embassy-crypto-aes256-gcm = []
 embassy-crypto-aes256-ccm = []
+## Register the hardware driver for random numbers, served by the RNG. See the
+## `embassy-crypto` documentation. The driver takes the peripheral over and keeps
+## it running.
+embassy-crypto-rng = []
 ## Register the hardware driver for P-256 arithmetic, served by the PKA. See the
 ## `embassy-crypto` documentation and [`pka`](crate::pka) for the RNG dependency.
 embassy-crypto-p256-arith = ["dep:crypto-bigint"]

--- a/embassy-stm32/build.rs
+++ b/embassy-stm32/build.rs
@@ -66,6 +66,11 @@ fn main() {
 
     for p in METADATA.peripherals {
         if let Some(r) = &p.registers {
+            // The AES driver enables the peripheral's clock, which the metadata does not
+            // know for the AES of some chips (STM32L0, L1, F423): no driver there.
+            if r.kind == "aes" && p.rcc.is_none() {
+                continue;
+            }
             cfgs.enable(r.kind);
             foreach_version_cfg(&mut cfgs, r.kind, r.version, |cfgs, cfg_name| {
                 cfgs.enable(cfg_name);

--- a/embassy-stm32/src/aes/common.rs
+++ b/embassy-stm32/src/aes/common.rs
@@ -1,11 +1,11 @@
-//! Register-agnostic AES layer shared by the `aes_v2` and `aes_v3b` drivers.
+//! Register-agnostic AES layer shared by the `aes_v2` and `aes_v3` drivers.
 //!
 //! This module holds the cipher-mode types, the [`Cipher`] trait and its cipher
 //! implementations, the operation [`Context`], and the GCM/CCM state machine
 //! ([`op_start`], [`op_aad`], [`op_payload`], [`op_finish`]). The two hardware
 //! revisions are identical at this level; they differ only in a handful of
 //! register primitives, which are selected with `#[cfg(aes_v2)]` /
-//! `#[cfg(aes_v3b)]` below. The version modules (`v2`, `v3b`) provide the
+//! `#[cfg(any(aes_v3a, aes_v3b))]` below. The version modules (`v2`, `v3b`) provide the
 //! `Aes` driver shell, instance wiring, and constructors, and delegate the
 //! algorithm here. The types `saes` also needs (`Error`, `Direction`,
 //! `KeySize`, and the marker traits) come from [`crate::crypto`] and are
@@ -20,7 +20,7 @@ use crate::{pac, peripherals};
 /// AES block size in bytes (128 bits).
 pub(crate) const AES_BLOCK_SIZE: usize = 16;
 
-// Register primitives — the only points where aes_v2 and aes_v3b diverge.
+// Register primitives — the only points where aes_v2 and aes_v3a/aes_v3b diverge.
 
 /// Clear the computation-complete flag (CCF).
 #[cfg(aes_v2)]
@@ -29,7 +29,7 @@ pub(crate) fn clear_ccf(p: pac::aes::Aes) {
     // aes_v2 has no ICR; CCF is cleared through the CCFC bit of CR.
     p.cr().modify(|w| w.set_ccfc(true));
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 pub(crate) fn clear_ccf(p: pac::aes::Aes) {
     p.icr().write(|w| w.0 = 0xFFFF_FFFF);
@@ -44,7 +44,7 @@ pub(crate) fn clear_flags(p: pac::aes::Aes) {
         w.set_errc(true);
     });
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 pub(crate) fn clear_flags(p: pac::aes::Aes) {
     p.icr().write(|w| w.0 = 0xFFFF_FFFF);
@@ -56,7 +56,7 @@ pub(crate) fn clear_flags(p: pac::aes::Aes) {
 pub(crate) fn write_din(p: pac::aes::Aes, word: u32) {
     p.dinr().write_value(Dinr(word));
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 pub(crate) fn write_din(p: pac::aes::Aes, word: u32) {
     p.dinr().write_value(word);
@@ -68,7 +68,7 @@ pub(crate) fn write_din(p: pac::aes::Aes, word: u32) {
 pub(crate) fn read_dout(p: pac::aes::Aes) -> u32 {
     p.doutr().read().0
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 pub(crate) fn read_dout(p: pac::aes::Aes) -> u32 {
     p.doutr().read()
@@ -80,7 +80,7 @@ pub(crate) fn read_dout(p: pac::aes::Aes) -> u32 {
 fn read_ivr(p: pac::aes::Aes, i: usize) -> u32 {
     p.ivr(i).read().0
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 fn read_ivr(p: pac::aes::Aes, i: usize) -> u32 {
     p.ivr(i).read()
@@ -92,7 +92,7 @@ fn read_ivr(p: pac::aes::Aes, i: usize) -> u32 {
 fn write_keyr(p: pac::aes::Aes, i: usize, word: u32) {
     p.keyr(i).write_value(Keyr(word));
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 fn write_keyr(p: pac::aes::Aes, i: usize, word: u32) {
     p.keyr(i).write_value(word);
@@ -104,7 +104,7 @@ fn write_keyr(p: pac::aes::Aes, i: usize, word: u32) {
 fn write_ivr(p: pac::aes::Aes, i: usize, word: u32) {
     p.ivr(i).write_value(Ivr(word));
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 fn write_ivr(p: pac::aes::Aes, i: usize, word: u32) {
     p.ivr(i).write_value(word);
@@ -120,7 +120,7 @@ fn set_chmod(p: pac::aes::Aes, bits: u8) {
         w.set_chmod2((bits & 0b100) != 0);
     });
 }
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 #[inline]
 fn set_chmod(p: pac::aes::Aes, bits: u8) {
     p.cr().modify(|w| w.set_chmod(pac::aes::vals::Chmod::from_bits(bits)));

--- a/embassy-stm32/src/aes/common.rs
+++ b/embassy-stm32/src/aes/common.rs
@@ -1,29 +1,31 @@
-//! Register-agnostic AES layer shared by the `aes_v2` and `aes_v3` drivers.
+//! Register-agnostic AES layer shared by the `aes_v1`, `aes_v2` and `aes_v3` drivers.
 //!
-//! This module holds the cipher-mode types, the [`Cipher`] trait and its cipher
-//! implementations, the operation [`Context`], and the GCM/CCM state machine
-//! ([`op_start`], [`op_aad`], [`op_payload`], [`op_finish`]). The two hardware
+//! This module holds the register primitives, the key/IV/block data movement,
+//! and the GCM/CCM state machine ([`op_start`], [`op_aad`], [`op_payload`],
+//! [`op_finish`]). The hardware
 //! revisions are identical at this level; they differ only in a handful of
-//! register primitives, which are selected with `#[cfg(aes_v2)]` /
-//! `#[cfg(any(aes_v3a, aes_v3b))]` below. The version modules (`v2`, `v3b`) provide the
-//! `Aes` driver shell, instance wiring, and constructors, and delegate the
-//! algorithm here. The types `saes` also needs (`Error`, `Direction`,
-//! `KeySize`, and the marker traits) come from [`crate::crypto`] and are
-//! re-exported.
+//! register primitives, which are selected with `#[cfg(any(aes_v1, aes_v2, aes_f7))]` /
+//! `#[cfg(any(aes_v3a, aes_v3b))]` below, and in `aes_v1` lacking the GCM/CCM
+//! phases, the 256-bit key size and the `BUSY` flag altogether, so that
+//! everything authenticated is compiled out there. The version modules (`v2`,
+//! `v3`) provide the `Aes` driver shell, instance wiring, and constructors, and
+//! delegate the algorithm here. The cipher-mode types themselves (`Cipher`,
+//! the `Aes*` modes, `Context`, `Error`, `Direction`, `KeySize` and the marker
+//! traits) are register-agnostic and live in [`crate::crypto`], shared with
+//! `saes`; they are re-exported here.
 
-pub use crate::crypto::{CipherAuthenticated, CipherSized, Direction, Error, IVSized, KeySize};
-#[cfg(aes_v2)]
+pub use crate::crypto::*;
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 use crate::pac::aes::regs::{Dinr, Ivr, Keyr};
-use crate::pac::aes::vals::{Datatype, Gcmph, Mode};
+#[cfg(not(aes_v1))]
+use crate::pac::aes::vals::Gcmph;
+use crate::pac::aes::vals::{Datatype, Mode};
 use crate::{pac, peripherals};
-
-/// AES block size in bytes (128 bits).
-pub(crate) const AES_BLOCK_SIZE: usize = 16;
 
 // Register primitives — the only points where aes_v2 and aes_v3a/aes_v3b diverge.
 
 /// Clear the computation-complete flag (CCF).
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 pub(crate) fn clear_ccf(p: pac::aes::Aes) {
     // aes_v2 has no ICR; CCF is cleared through the CCFC bit of CR.
@@ -36,7 +38,7 @@ pub(crate) fn clear_ccf(p: pac::aes::Aes) {
 }
 
 /// Clear the computation-complete and read/write error flags together.
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 pub(crate) fn clear_flags(p: pac::aes::Aes) {
     p.cr().modify(|w| {
@@ -51,7 +53,7 @@ pub(crate) fn clear_flags(p: pac::aes::Aes) {
 }
 
 /// Write a 32-bit word to the data input register.
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 pub(crate) fn write_din(p: pac::aes::Aes, word: u32) {
     p.dinr().write_value(Dinr(word));
@@ -63,7 +65,7 @@ pub(crate) fn write_din(p: pac::aes::Aes, word: u32) {
 }
 
 /// Read a 32-bit word from the data output register.
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 pub(crate) fn read_dout(p: pac::aes::Aes) -> u32 {
     p.doutr().read().0
@@ -75,7 +77,7 @@ pub(crate) fn read_dout(p: pac::aes::Aes) -> u32 {
 }
 
 /// Read a 32-bit word from an initialization-vector register.
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 fn read_ivr(p: pac::aes::Aes, i: usize) -> u32 {
     p.ivr(i).read().0
@@ -87,7 +89,7 @@ fn read_ivr(p: pac::aes::Aes, i: usize) -> u32 {
 }
 
 /// Write a 32-bit word to a key register.
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 fn write_keyr(p: pac::aes::Aes, i: usize, word: u32) {
     p.keyr(i).write_value(Keyr(word));
@@ -99,7 +101,7 @@ fn write_keyr(p: pac::aes::Aes, i: usize, word: u32) {
 }
 
 /// Write a 32-bit word to an initialization-vector register.
-#[cfg(aes_v2)]
+#[cfg(any(aes_v1, aes_v2, aes_f7))]
 #[inline]
 fn write_ivr(p: pac::aes::Aes, i: usize, word: u32) {
     p.ivr(i).write_value(Ivr(word));
@@ -111,7 +113,14 @@ fn write_ivr(p: pac::aes::Aes, i: usize, word: u32) {
 }
 
 /// Set the cipher mode (`CHMOD`).
-#[cfg(aes_v2)]
+#[cfg(aes_v1)]
+#[inline]
+fn set_chmod(p: pac::aes::Aes, bits: u8) {
+    // aes_v1 only has the ECB, CBC and CTR modes, in CHMOD[1:0].
+    debug_assert!(bits < 0b100);
+    p.cr().modify(|w| w.set_chmod10(bits & 0b11));
+}
+#[cfg(any(aes_v2, aes_f7))]
 #[inline]
 fn set_chmod(p: pac::aes::Aes, bits: u8) {
     // aes_v2 splits CHMOD into CHMOD[1:0] and CHMOD[2].
@@ -124,426 +133,6 @@ fn set_chmod(p: pac::aes::Aes, bits: u8) {
 #[inline]
 fn set_chmod(p: pac::aes::Aes, bits: u8) {
     p.cr().modify(|w| w.set_chmod(pac::aes::vals::Chmod::from_bits(bits)));
-}
-
-// Public types
-
-/// This trait encapsulates all cipher-specific behavior.
-pub trait Cipher<'c> {
-    /// Processing block size (always 16 bytes for AES).
-    const BLOCK_SIZE: usize = AES_BLOCK_SIZE;
-
-    /// Indicates whether the cipher requires the application to provide padding.
-    const REQUIRES_PADDING: bool = false;
-
-    /// Returns the symmetric key.
-    fn key(&self) -> &[u8];
-
-    /// Returns the initialization vector.
-    fn iv(&self) -> &[u8];
-
-    /// Returns the key size.
-    fn key_size(&self) -> KeySize {
-        match self.key().len() {
-            16 => KeySize::Bits128,
-            32 => KeySize::Bits256,
-            _ => panic!("Invalid key size"),
-        }
-    }
-
-    /// Returns the data type setting for this cipher mode.
-    ///
-    /// This driver uses NO_SWAP (0) consistently with big-endian byte
-    /// conversion (`from_be_bytes`/`to_be_bytes`) for direct NIST test-vector
-    /// compatibility.
-    fn datatype(&self) -> u8 {
-        0
-    }
-
-    /// Returns the raw `CHMOD` field value for this cipher mode.
-    fn chmod_bits(&self) -> u8 {
-        0 // ECB default
-    }
-
-    /// Sets the cipher mode (`CHMOD` field).
-    fn set_mode(&self, p: pac::aes::Aes) {
-        set_chmod(p, self.chmod_bits());
-    }
-
-    /// Performs any key preparation within the processor, if necessary.
-    fn prepare_key(&self, _p: pac::aes::Aes, _dir: Direction) {}
-
-    /// Performs any cipher-specific initialization (blocking).
-    fn init_phase_blocking(&self, _p: pac::aes::Aes) {}
-
-    /// Indicates whether this cipher mode uses GCM/CCM phases (init, header, payload, final).
-    fn uses_gcm_phases(&self) -> bool {
-        false
-    }
-
-    /// Indicates whether this is CCM mode (which has different final phase handling).
-    fn is_ccm_mode(&self) -> bool {
-        false
-    }
-
-    /// CCM only: the encoded associated-data length that precedes the
-    /// associated data in the first header block (NIST SP 800-38C A.2.2), and
-    /// its size. Empty for other modes and when there is no associated data.
-    fn ccm_aad_header(&self) -> ([u8; 10], usize) {
-        ([0; 10], 0)
-    }
-}
-
-/// AES-ECB Cipher Mode
-pub struct AesEcb<'c, const KEY_SIZE: usize> {
-    iv: &'c [u8; 0],
-    key: &'c [u8; KEY_SIZE],
-}
-
-impl<'c, const KEY_SIZE: usize> AesEcb<'c, KEY_SIZE> {
-    /// Constructs a new AES-ECB cipher for a cryptographic operation.
-    pub fn new(key: &'c [u8; KEY_SIZE]) -> Self {
-        Self { key, iv: &[0; 0] }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = true;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        0
-    }
-
-    fn prepare_key(&self, p: pac::aes::Aes, dir: Direction) {
-        // For ECB decryption, derive the decryption key first (RM key-derivation sequence).
-        if dir == Direction::Decrypt {
-            p.cr().modify(|w| w.set_mode(Mode::from_bits(1)));
-            p.cr().modify(|w| w.set_en(true));
-            while !p.sr().read().ccf() {}
-            clear_ccf(p);
-        }
-    }
-}
-
-impl<'c> CipherSized for AesEcb<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesEcb<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesEcb<'c, KEY_SIZE> {}
-
-/// AES-CBC Cipher Mode
-pub struct AesCbc<'c, const KEY_SIZE: usize> {
-    iv: &'c [u8; 16],
-    key: &'c [u8; KEY_SIZE],
-}
-
-impl<'c, const KEY_SIZE: usize> AesCbc<'c, KEY_SIZE> {
-    /// Constructs a new AES-CBC cipher for a cryptographic operation.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
-        Self { key, iv }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = true;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        1
-    }
-
-    fn prepare_key(&self, p: pac::aes::Aes, dir: Direction) {
-        if dir == Direction::Decrypt {
-            p.cr().modify(|w| w.set_mode(Mode::from_bits(1)));
-            p.cr().modify(|w| w.set_en(true));
-            while !p.sr().read().ccf() {}
-            clear_ccf(p);
-        }
-    }
-}
-
-impl<'c> CipherSized for AesCbc<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesCbc<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesCbc<'c, KEY_SIZE> {}
-
-/// AES-CTR Cipher Mode
-pub struct AesCtr<'c, const KEY_SIZE: usize> {
-    iv: &'c [u8; 16],
-    key: &'c [u8; KEY_SIZE],
-}
-
-impl<'c, const KEY_SIZE: usize> AesCtr<'c, KEY_SIZE> {
-    /// Constructs a new AES-CTR cipher for a cryptographic operation.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
-        Self { key, iv }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        2
-    }
-}
-
-impl<'c> CipherSized for AesCtr<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesCtr<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesCtr<'c, KEY_SIZE> {}
-
-/// AES-GCM Cipher Mode
-pub struct AesGcm<'c, const KEY_SIZE: usize> {
-    key: &'c [u8; KEY_SIZE],
-    iv: [u8; 16],
-}
-
-impl<'c, const KEY_SIZE: usize> AesGcm<'c, KEY_SIZE> {
-    /// Constructs a new AES-GCM cipher for a cryptographic operation.
-    /// The IV should be 12 bytes long (96 bits).
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
-        let mut iv_full = [0u8; 16];
-        iv_full[..12].copy_from_slice(iv);
-        iv_full[15] = 2; // Initial counter value
-        Self { key, iv: iv_full }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGcm<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        &self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        3
-    }
-
-    fn init_phase_blocking(&self, p: pac::aes::Aes) {
-        // GCMPH was set to init in op_start() before key loading. Enable EN to
-        // start the hash-key (H) calculation, then wait and clear.
-        p.cr().modify(|w| w.set_en(true));
-        while !p.sr().read().ccf() {}
-        clear_ccf(p);
-    }
-
-    fn uses_gcm_phases(&self) -> bool {
-        true
-    }
-}
-
-impl<'c> CipherSized for AesGcm<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesGcm<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesGcm<'c, KEY_SIZE> {}
-impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGcm<'c, KEY_SIZE> {}
-
-/// AES-GMAC Cipher Mode (Galois Message Authentication Code)
-///
-/// GMAC provides message authentication without encryption. The data remains
-/// in plaintext but any tampering is detected via the authentication tag.
-pub struct AesGmac<'c, const KEY_SIZE: usize> {
-    key: &'c [u8; KEY_SIZE],
-    iv: [u8; 16],
-}
-
-impl<'c, const KEY_SIZE: usize> AesGmac<'c, KEY_SIZE> {
-    /// Constructs a new AES-GMAC cipher for message authentication.
-    /// The IV should be 12 bytes long (96 bits) and unique per message.
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 12]) -> Self {
-        let mut iv_full = [0u8; 16];
-        iv_full[..12].copy_from_slice(iv);
-        iv_full[15] = 2; // Initial counter value (same as GCM)
-        Self { key, iv: iv_full }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesGmac<'c, KEY_SIZE> {
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        &self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        // GMAC uses the same hardware mode as GCM.
-        3
-    }
-
-    fn init_phase_blocking(&self, p: pac::aes::Aes) {
-        p.cr().modify(|w| w.set_en(true));
-        while !p.sr().read().ccf() {}
-        clear_ccf(p);
-    }
-
-    fn uses_gcm_phases(&self) -> bool {
-        true
-    }
-}
-
-impl<'c> CipherSized for AesGmac<'c, { 128 / 8 }> {}
-impl<'c> CipherSized for AesGmac<'c, { 256 / 8 }> {}
-impl<'c, const KEY_SIZE: usize> IVSized for AesGmac<'c, KEY_SIZE> {}
-impl<'c, const KEY_SIZE: usize> CipherAuthenticated<16> for AesGmac<'c, KEY_SIZE> {}
-
-/// AES-CCM Cipher Mode (Counter with CBC-MAC)
-pub struct AesCcm<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> {
-    key: &'c [u8; KEY_SIZE],
-    iv: [u8; 16],
-    aad_len: usize,
-}
-
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE> {
-    /// Constructs a new AES-CCM cipher for a cryptographic operation.
-    /// - `key`: The encryption key (16 or 32 bytes)
-    /// - `iv`: The nonce/IV (7-13 bytes)
-    /// - `aad_len`: Length of additional authenticated data (known in advance)
-    /// - `payload_len`: Length of payload data (known in advance)
-    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; IV_SIZE], aad_len: usize, payload_len: usize) -> Self {
-        assert!(IV_SIZE >= 7 && IV_SIZE <= 13, "CCM IV must be 7-13 bytes");
-        assert!(
-            TAG_SIZE >= 4 && TAG_SIZE <= 16 && TAG_SIZE % 2 == 0,
-            "CCM tag must be 4-16 bytes and even"
-        );
-
-        // Format the B0 block for CCM.
-        let mut iv_full = [0u8; 16];
-        let l = 15 - IV_SIZE; // size of the length field
-        iv_full[0] = ((l - 1) as u8) | ((((TAG_SIZE - 2) / 2) as u8) << 3);
-        if aad_len > 0 {
-            iv_full[0] |= 0x40; // Adata flag
-        }
-        iv_full[1..1 + IV_SIZE].copy_from_slice(iv);
-
-        let payload_bytes = (payload_len as u64).to_be_bytes();
-        let offset = 16 - l;
-        iv_full[offset..].copy_from_slice(&payload_bytes[8 - l..]);
-
-        Self {
-            key,
-            iv: iv_full,
-            aad_len,
-        }
-    }
-}
-
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> Cipher<'c>
-    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
-{
-    const REQUIRES_PADDING: bool = false;
-
-    fn key(&self) -> &[u8] {
-        self.key
-    }
-
-    fn iv(&self) -> &[u8] {
-        &self.iv
-    }
-
-    fn chmod_bits(&self) -> u8 {
-        4
-    }
-
-    fn init_phase_blocking(&self, p: pac::aes::Aes) {
-        p.cr().modify(|w| w.set_en(true));
-        while !p.sr().read().ccf() {}
-        clear_ccf(p);
-    }
-
-    fn uses_gcm_phases(&self) -> bool {
-        true
-    }
-
-    fn is_ccm_mode(&self) -> bool {
-        true
-    }
-
-    fn ccm_aad_header(&self) -> ([u8; 10], usize) {
-        let mut header = [0u8; 10];
-        let len = if self.aad_len == 0 {
-            0
-        } else if self.aad_len < (1 << 16) - (1 << 8) {
-            header[..2].copy_from_slice(&(self.aad_len as u16).to_be_bytes());
-            2
-        } else if (self.aad_len as u64) < (1u64 << 32) {
-            header[..2].copy_from_slice(&[0xff, 0xfe]);
-            header[2..6].copy_from_slice(&(self.aad_len as u32).to_be_bytes());
-            6
-        } else {
-            header[..2].copy_from_slice(&[0xff, 0xff]);
-            header[2..10].copy_from_slice(&(self.aad_len as u64).to_be_bytes());
-            10
-        };
-        (header, len)
-    }
-}
-
-impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 128 / 8 }, IV_SIZE, TAG_SIZE> {}
-impl<'c, const IV_SIZE: usize, const TAG_SIZE: usize> CipherSized for AesCcm<'c, { 256 / 8 }, IV_SIZE, TAG_SIZE> {}
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> IVSized
-    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
-{
-}
-impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> CipherAuthenticated<TAG_SIZE>
-    for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
-{
-}
-
-/// Stores the state of the AES peripheral for a cipher operation.
-#[derive(Clone)]
-pub struct Context<'c, C: Cipher<'c>> {
-    /// The cipher configuration
-    pub cipher: &'c C,
-    /// Encryption or decryption direction
-    pub dir: Direction,
-    /// Whether the last block has been processed
-    pub last_block_processed: bool,
-    /// Whether this is a GCM/CCM authenticated mode
-    pub is_gcm_ccm: bool,
-    /// Whether the header (AAD) has been processed
-    pub header_processed: bool,
-    /// Total length of additional authenticated data
-    pub header_len: u64,
-    /// Total length of payload data
-    pub payload_len: u64,
-    /// Buffer for partial AAD blocks
-    pub aad_buffer: [u8; 16],
-    /// Number of bytes in the AAD buffer
-    pub aad_buffer_len: usize,
-    /// Control register state
-    pub cr: u32,
-    /// Initialization vector state
-    pub iv: [u32; 4],
-    /// Suspend registers for GCM/CCM
-    pub suspr: [u32; 8],
 }
 
 // Instance plumbing (register access, shared by all AES peripherals)
@@ -618,6 +207,15 @@ pub(crate) fn read_out_block(p: pac::aes::Aes, block: &mut [u8]) {
     }
 }
 
+/// Run the ECB/CBC decryption-key derivation (RM key-derivation sequence),
+/// blocking until it completes. The key must already be loaded.
+pub(crate) fn derive_key(p: pac::aes::Aes) {
+    p.cr().modify(|w| w.set_mode(Mode::from_bits(1)));
+    p.cr().modify(|w| w.set_en(true));
+    while !p.sr().read().ccf() {}
+    clear_ccf(p);
+}
+
 // State machine (shared). The blocking init-phase wait is the only hardware
 // wait these entry points perform; async drivers reuse `setup`/`make_context`
 // and the low-level helpers above with their own wait strategy.
@@ -633,23 +231,28 @@ where
     // Clear the padding length. NPBLB is only written when a final partial
     // block needs it, but the hardware keeps the last value, so a leftover
     // count from an earlier operation would corrupt this one's tag.
+    #[cfg(not(any(aes_v1, aes_f7)))]
     p.cr().modify(|w| w.set_npblb(0));
 
     // Data type (NO_SWAP) and key size.
     p.cr()
         .modify(|w| w.set_datatype(Datatype::from_bits(cipher.datatype())));
     let keysize = cipher.key_size();
+    #[cfg(not(aes_v1))]
     p.cr().modify(|w| w.set_keysize(keysize == KeySize::Bits256));
+    #[cfg(aes_v1)]
+    assert!(keysize == KeySize::Bits128, "aes_v1 only takes 128-bit keys");
 
     // Direction.
     p.cr().modify(|w| w.set_mode(Mode::from_bits(dir as u8)));
 
     // Cipher mode (CHMOD).
-    cipher.set_mode(p);
+    set_chmod(p, cipher.chmod_bits());
 
     let is_gcm_ccm = cipher.uses_gcm_phases();
 
     // For GCM/CCM, select the init phase BEFORE loading the key.
+    #[cfg(not(aes_v1))]
     if is_gcm_ccm {
         p.cr().modify(|w| w.set_gcmph(Gcmph::from_bits(0)));
     }
@@ -663,13 +266,16 @@ where
             load_iv(p, cipher.iv());
         }
     } else if needs_key_prep {
-        // ECB/CBC decryption: key preparation, then IV. Key derivation is a
-        // one-shot hardware step; it is polled even on the async path.
+        // ECB/CBC decryption: key derivation, then IV. Key derivation is a
+        // one-shot hardware step; it is polled even on the async path. CTR
+        // does not need it.
         load_key(p, cipher.key());
-        cipher.prepare_key(p, dir);
+        if matches!(cipher.chmod_bits(), 0 | 1) {
+            derive_key(p);
+        }
 
         p.cr().modify(|w| w.set_mode(Mode::from_bits(dir as u8)));
-        cipher.set_mode(p);
+        set_chmod(p, cipher.chmod_bits());
 
         if !cipher.iv().is_empty() {
             load_iv(p, cipher.iv());
@@ -714,16 +320,19 @@ where
     let is_gcm_ccm = setup(p, cipher, dir);
 
     // Init phase for GCM/CCM (computes the hash key H); otherwise just enable.
+    // GCMPH was set to init in `setup` before key loading, so enabling starts
+    // the H calculation; wait for it and clear the flag.
+    p.cr().modify(|w| w.set_en(true));
     if is_gcm_ccm {
-        cipher.init_phase_blocking(p);
-    } else {
-        p.cr().modify(|w| w.set_en(true));
+        while !p.sr().read().ccf() {}
+        clear_ccf(p);
     }
 
     make_context(p, cipher, dir, is_gcm_ccm)
 }
 
 /// Process authenticated additional data (AAD) for GCM/CCM modes (blocking).
+#[cfg(not(aes_v1))]
 pub(crate) fn op_aad<'c, C, const TAG_SIZE: usize>(
     p: pac::aes::Aes,
     ctx: &mut Context<'c, C>,
@@ -804,6 +413,7 @@ where
 }
 
 /// Switch to the payload phase for GCM/CCM (shared by blocking and async).
+#[cfg(not(aes_v1))]
 pub(crate) fn begin_payload<'c, C>(p: pac::aes::Aes, ctx: &mut Context<'c, C>)
 where
     C: Cipher<'c>,
@@ -814,6 +424,7 @@ where
             ctx.header_processed = true;
         }
         p.cr().modify(|w| w.set_gcmph(Gcmph::from_bits(2)));
+        #[cfg(not(aes_f7))]
         p.cr().modify(|w| w.set_npblb(0));
         if header_was_skipped {
             p.cr().modify(|w| w.set_en(true));
@@ -822,7 +433,8 @@ where
 }
 
 /// Set `NPBLB` for a final partial payload block, per GCM/CCM rules.
-pub(crate) fn set_final_npblb<'c, C>(p: pac::aes::Aes, ctx: &Context<'c, C>, remaining: usize)
+#[cfg(not(aes_v1))]
+pub(crate) fn set_final_npblb<'c, C>(p: pac::aes::Aes, ctx: &Context<'c, C>, remaining: usize) -> Result<(), Error>
 where
     C: Cipher<'c>,
 {
@@ -833,8 +445,35 @@ where
         true
     };
     if should_set_npblb {
+        // aes_f7 has the GCM/CCM phases but no NPBLB field, so the hardware
+        // always authenticates the whole padded block. The cases that need the
+        // padding masked out are rejected instead of returning a wrong tag.
+        #[cfg(aes_f7)]
+        {
+            let _ = remaining;
+            return Err(Error::ConfigError);
+        }
+        #[cfg(not(aes_f7))]
         p.cr().modify(|w| w.set_npblb((16 - remaining) as u8));
     }
+    let _ = p;
+    Ok(())
+}
+
+// aes_v1 has neither the GCM/CCM phases nor NPBLB: a final partial block is
+// only ever a CTR one, which the zero padding of the caller takes care of.
+#[cfg(aes_v1)]
+pub(crate) fn begin_payload<'c, C>(_p: pac::aes::Aes, _ctx: &mut Context<'c, C>)
+where
+    C: Cipher<'c>,
+{
+}
+#[cfg(aes_v1)]
+pub(crate) fn set_final_npblb<'c, C>(_p: pac::aes::Aes, _ctx: &Context<'c, C>, _remaining: usize) -> Result<(), Error>
+where
+    C: Cipher<'c>,
+{
+    Ok(())
 }
 
 /// Process payload data (blocking).
@@ -883,7 +522,7 @@ where
         let mut partial_block = [0u8; 16];
         partial_block[..remaining].copy_from_slice(&input[processed..]);
 
-        set_final_npblb(p, ctx, remaining);
+        set_final_npblb(p, ctx, remaining)?;
 
         write_block(p, &partial_block)?;
         read_block_blocking(p, &mut partial_block)?;
@@ -901,6 +540,7 @@ where
 
 /// Write the GCM length block (AAD bits || payload bits, big-endian) or, for
 /// CCM, enable the peripheral to trigger the final tag computation.
+#[cfg(not(aes_v1))]
 pub(crate) fn begin_final<'c, C>(p: pac::aes::Aes, ctx: &Context<'c, C>)
 where
     C: Cipher<'c>,
@@ -928,6 +568,9 @@ pub(crate) fn op_finish<'c, C>(p: pac::aes::Aes, ctx: Context<'c, C>) -> Result<
 where
     C: Cipher<'c>,
 {
+    #[cfg(aes_v1)]
+    let _ = &ctx;
+    #[cfg(not(aes_v1))]
     if ctx.is_gcm_ccm {
         begin_final(p, &ctx);
 
@@ -939,9 +582,9 @@ where
         clear_ccf(p);
         p.cr().modify(|w| w.set_en(false));
 
-        Ok(Some(tag))
-    } else {
-        p.cr().modify(|w| w.set_en(false));
-        Ok(None)
+        return Ok(Some(tag));
     }
+
+    p.cr().modify(|w| w.set_en(false));
+    Ok(None)
 }

--- a/embassy-stm32/src/aes/driver.rs
+++ b/embassy-stm32/src/aes/driver.rs
@@ -1,23 +1,57 @@
+//! `embassy-crypto` AES drivers, one per `embassy-crypto-aes*` feature, served by the AES
+//! peripheral or, with the `embassy-crypto-saes` feature, by the SAES one.
+//!
+//! Both peripherals expose the same blocking cipher flow, so the drivers are written once
+//! against whichever of the two is selected. Nothing is registered for what the selected
+//! peripheral cannot do: the 256-bit key size and the authenticated modes on `aes_v1`, CTR
+//! and the authenticated modes on `saes_v1b`.
+
 use embassy_crypto::Error as CryptoError;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
-use embassy_sync::mutex::Mutex;
+use embassy_sync::mutex::{Mutex, MutexGuard};
 
-use super::{Aes, AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Direction};
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
+use super::AesCtr;
+use super::{AesCbc, AesEcb, Direction};
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
+use super::{AesCcm, AesGcm};
 #[cfg(any(aes_v3a, aes_v3b))]
 use crate::mode::Blocking;
 use crate::suspend::ResumablePeripheral;
 
+#[cfg(all(feature = "embassy-crypto-saes", not(saes)))]
+compile_error!("the `embassy-crypto-saes` feature needs a chip with a SAES peripheral");
+
+#[cfg(not(feature = "embassy-crypto-saes"))]
 foreach_peripheral!(
     (aes, $inst:ident) => {
-        #[cfg(aes_v2)]
-        type BlockingAes = Aes<'static, crate::peripherals::$inst>;
+        #[cfg(any(aes_v1, aes_v2, aes_f7))]
+        type BlockingAes = super::Aes<'static, crate::peripherals::$inst>;
         #[cfg(any(aes_v3a, aes_v3b))]
-        type BlockingAes = Aes<'static, crate::peripherals::$inst, Blocking>;
+        type BlockingAes = super::Aes<'static, crate::peripherals::$inst, Blocking>;
 
         static DRIVER: Mutex<CriticalSectionRawMutex, ResumablePeripheral<BlockingAes>> =
             Mutex::new(ResumablePeripheral::new_suspended(unsafe { crate::peripherals::$inst::steal() }));
     };
 );
+
+#[cfg(feature = "embassy-crypto-saes")]
+foreach_peripheral!(
+    (saes, $inst:ident) => {
+        type BlockingAes = crate::saes::Saes<'static, crate::peripherals::$inst, Blocking>;
+
+        static DRIVER: Mutex<CriticalSectionRawMutex, ResumablePeripheral<BlockingAes>> =
+            Mutex::new(ResumablePeripheral::new_suspended(unsafe { crate::peripherals::$inst::steal() }));
+    };
+);
+
+/// Takes the peripheral, which is clocked for as long as the guard's borrow lives.
+fn lock() -> MutexGuard<'static, CriticalSectionRawMutex, ResumablePeripheral<BlockingAes>> {
+    // The SAES fetches random numbers from the RNG whenever it is reset.
+    #[cfg(all(feature = "embassy-crypto-saes", feature = "embassy-crypto-rng"))]
+    crate::rng::driver::ensure_running();
+    DRIVER.try_lock().expect("the AES is in use")
+}
 
 fn map_error(error: super::Error) -> CryptoError {
     match error {
@@ -66,6 +100,7 @@ where
     aes.finish_blocking(context).map(|_| ()).map_err(map_error)
 }
 
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 fn run_authenticated<'c, C, const TAG_SIZE: usize>(
     aes: &mut BlockingAes,
     cipher: &'c C,
@@ -101,6 +136,7 @@ where
     Ok(())
 }
 
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 macro_rules! define_gcm_runner {
     ($name:ident, $key_size:expr) => {
         fn $name(
@@ -120,9 +156,12 @@ macro_rules! define_gcm_runner {
     };
 }
 
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 define_gcm_runner!(run_gcm128, 16);
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 define_gcm_runner!(run_gcm256, 32);
 
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 macro_rules! run_ccm {
     ($key_size:expr, $tag_size:expr, $aes:expr, $key:expr, $nonce:expr, $aad:expr, $input:expr, $output:expr, $tag:expr, $tag_output:expr, $direction:expr $(,)?) => {{
         match $nonce.len() {
@@ -166,6 +205,7 @@ macro_rules! run_ccm {
     }};
 }
 
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 macro_rules! aes_ccm_dispatch {
     ($key_size:literal, $aes:expr, $ctx:expr, $nonce:expr, $aad:expr, $input:expr, $output:expr, $tag:expr, $direction:expr, encrypt) => {
         match $tag.len() {
@@ -417,7 +457,7 @@ impl embassy_crypto::driver::Aes128Ecb for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let cipher = AesEcb::new(ctx);
         let len = blocks.len();
@@ -436,7 +476,7 @@ impl embassy_crypto::driver::Aes128Ecb for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let cipher = AesEcb::new(ctx);
         let len = blocks.len();
@@ -453,6 +493,7 @@ impl embassy_crypto::driver::Aes128Ecb for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes256-ecb")]
+#[cfg(not(aes_v1))]
 impl embassy_crypto::driver::Aes256Ecb for AesDriver {
     type Context = [u8; 32];
 
@@ -464,7 +505,7 @@ impl embassy_crypto::driver::Aes256Ecb for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let cipher = AesEcb::new(ctx);
         let len = blocks.len();
@@ -483,7 +524,7 @@ impl embassy_crypto::driver::Aes256Ecb for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let cipher = AesEcb::new(ctx);
         let len = blocks.len();
@@ -500,6 +541,7 @@ impl embassy_crypto::driver::Aes256Ecb for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes128-gcm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 impl embassy_crypto::driver::Aes128Gcm for AesDriver {
     type Context = [u8; 16];
 
@@ -514,7 +556,7 @@ impl embassy_crypto::driver::Aes128Gcm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &mut [u8; 16],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -530,7 +572,7 @@ impl embassy_crypto::driver::Aes128Gcm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &[u8; 16],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -541,6 +583,7 @@ impl embassy_crypto::driver::Aes128Gcm for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes256-gcm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 impl embassy_crypto::driver::Aes256Gcm for AesDriver {
     type Context = [u8; 32];
 
@@ -555,7 +598,7 @@ impl embassy_crypto::driver::Aes256Gcm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &mut [u8; 16],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -571,7 +614,7 @@ impl embassy_crypto::driver::Aes256Gcm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &[u8; 16],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -582,6 +625,7 @@ impl embassy_crypto::driver::Aes256Gcm for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes128-ccm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 impl embassy_crypto::driver::Aes128Ccm for AesDriver {
     type Context = [u8; 16];
 
@@ -596,7 +640,7 @@ impl embassy_crypto::driver::Aes128Ccm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &mut [u8],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -623,7 +667,7 @@ impl embassy_crypto::driver::Aes128Ccm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &[u8],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -645,6 +689,7 @@ impl embassy_crypto::driver::Aes128Ccm for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes256-ccm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 impl embassy_crypto::driver::Aes256Ccm for AesDriver {
     type Context = [u8; 32];
 
@@ -659,7 +704,7 @@ impl embassy_crypto::driver::Aes256Ccm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &mut [u8],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -686,7 +731,7 @@ impl embassy_crypto::driver::Aes256Ccm for AesDriver {
         buffer: embassy_crypto::driver::InOutBuf<'_, '_, u8>,
         tag: &[u8],
     ) -> Result<(), CryptoError> {
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let len = buffer.len();
         let (in_ptr, out_ptr) = buffer.into_raw();
@@ -724,7 +769,7 @@ impl embassy_crypto::driver::Aes128Cbc for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let (key, iv) = ctx;
         let cipher = AesCbc::new(key, iv);
@@ -748,7 +793,7 @@ impl embassy_crypto::driver::Aes128Cbc for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let (key, iv) = ctx;
         let cipher = AesCbc::new(key, iv);
@@ -770,6 +815,7 @@ impl embassy_crypto::driver::Aes128Cbc for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes256-cbc")]
+#[cfg(not(aes_v1))]
 impl embassy_crypto::driver::Aes256Cbc for AesDriver {
     type EncryptContext = ([u8; 32], [u8; 16]);
     type DecryptContext = ([u8; 32], [u8; 16]);
@@ -786,7 +832,7 @@ impl embassy_crypto::driver::Aes256Cbc for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let (key, iv) = ctx;
         let cipher = AesCbc::new(key, iv);
@@ -810,7 +856,7 @@ impl embassy_crypto::driver::Aes256Cbc for AesDriver {
         if blocks.is_empty() {
             return;
         }
-        let mut driver = DRIVER.try_lock().unwrap();
+        let mut driver = lock();
         let aes = &mut driver.borrow();
         let (key, iv) = ctx;
         let cipher = AesCbc::new(key, iv);
@@ -842,6 +888,7 @@ impl embassy_crypto::driver::Aes256Cbc for AesDriver {
 /// (NIST SP 800-38A). A run therefore stops where the low word would wrap, and
 /// the carry into the upper bits is applied by software before the next run.
 #[cfg(any(feature = "embassy-crypto-aes128-ctr", feature = "embassy-crypto-aes256-ctr"))]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
 fn ctr_run_blocks(iv: &[u8; 16], blocks: usize) -> usize {
     let low = u32::from_be_bytes(iv[12..].try_into().unwrap());
     let until_wrap = u64::from(u32::MAX - low) + 1;
@@ -854,11 +901,13 @@ fn ctr_run_blocks(iv: &[u8; 16], blocks: usize) -> usize {
 
 /// Advance the 128-bit big-endian counter block by `blocks`.
 #[cfg(any(feature = "embassy-crypto-aes128-ctr", feature = "embassy-crypto-aes256-ctr"))]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
 fn ctr_advance(iv: &mut [u8; 16], blocks: usize) {
     *iv = u128::from_be_bytes(*iv).wrapping_add(blocks as u128).to_be_bytes();
 }
 
 #[cfg(feature = "embassy-crypto-aes128-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
 fn ctr_block_in_place_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16], buffer: &mut [u8]) {
     let mut buffer = buffer;
     while buffer.len() >= 16 {
@@ -880,6 +929,7 @@ fn ctr_block_in_place_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16
 }
 
 #[cfg(feature = "embassy-crypto-aes128-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
 fn ctr_block_separate_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16], input: &[u8], output: &mut [u8]) {
     assert_eq!(input.len(), output.len());
     let mut input = input;
@@ -901,6 +951,8 @@ fn ctr_block_separate_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16
 }
 
 #[cfg(feature = "embassy-crypto-aes256-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
+#[cfg(not(aes_v1))]
 fn ctr_block_in_place_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16], buffer: &mut [u8]) {
     let mut buffer = buffer;
     while buffer.len() >= 16 {
@@ -922,6 +974,8 @@ fn ctr_block_in_place_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16
 }
 
 #[cfg(feature = "embassy-crypto-aes256-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
+#[cfg(not(aes_v1))]
 fn ctr_block_separate_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16], input: &[u8], output: &mut [u8]) {
     assert_eq!(input.len(), output.len());
     let mut input = input;
@@ -943,6 +997,7 @@ fn ctr_block_separate_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16
 }
 
 #[cfg(feature = "embassy-crypto-aes128-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
 impl embassy_crypto::driver::Aes128Ctr for AesDriver {
     type Context = ([u8; 16], [u8; 16], [u8; 16], u8);
     // (key, iv/counter, partial_keystream_buffer, partial_len)
@@ -972,7 +1027,7 @@ impl embassy_crypto::driver::Aes128Ctr for AesDriver {
             // 2. Process full 16-byte blocks via hardware.
             let full_len = (buf.len() / 16) * 16;
             if full_len > 0 {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 ctr_block_in_place_16(aes, key, iv, &mut buf[..full_len]);
             }
@@ -980,7 +1035,7 @@ impl embassy_crypto::driver::Aes128Ctr for AesDriver {
             // 3. Generate one extra keystream block for any trailing partial data.
             let tail = &mut buf[full_len..];
             if !tail.is_empty() {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 let mut keystream = [0u8; 16];
                 // Advances the counter, unlike a bare hardware run would.
@@ -1011,7 +1066,7 @@ impl embassy_crypto::driver::Aes128Ctr for AesDriver {
             // 2. Process full 16-byte blocks via hardware.
             let full_len = (input.len() / 16) * 16;
             if full_len > 0 {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 ctr_block_separate_16(aes, key, iv, &input[..full_len], &mut output[..full_len]);
             }
@@ -1020,7 +1075,7 @@ impl embassy_crypto::driver::Aes128Ctr for AesDriver {
             let tail_in = &input[full_len..];
             let tail_out = &mut output[full_len..];
             if !tail_in.is_empty() {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 let mut keystream = [0u8; 16];
                 // Advances the counter, unlike a bare hardware run would.
@@ -1037,6 +1092,8 @@ impl embassy_crypto::driver::Aes128Ctr for AesDriver {
 }
 
 #[cfg(feature = "embassy-crypto-aes256-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
+#[cfg(not(aes_v1))]
 impl embassy_crypto::driver::Aes256Ctr for AesDriver {
     type Context = ([u8; 32], [u8; 16], [u8; 16], u8);
 
@@ -1063,14 +1120,14 @@ impl embassy_crypto::driver::Aes256Ctr for AesDriver {
 
             let full_len = (buf.len() / 16) * 16;
             if full_len > 0 {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 ctr_block_in_place_32(aes, key, iv, &mut buf[..full_len]);
             }
 
             let tail = &mut buf[full_len..];
             if !tail.is_empty() {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 let mut keystream = [0u8; 16];
                 // Advances the counter, unlike a bare hardware run would.
@@ -1099,7 +1156,7 @@ impl embassy_crypto::driver::Aes256Ctr for AesDriver {
 
             let full_len = (input.len() / 16) * 16;
             if full_len > 0 {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 ctr_block_separate_32(aes, key, iv, &input[..full_len], &mut output[..full_len]);
             }
@@ -1107,7 +1164,7 @@ impl embassy_crypto::driver::Aes256Ctr for AesDriver {
             let tail_in = &input[full_len..];
             let tail_out = &mut output[full_len..];
             if !tail_in.is_empty() {
-                let mut driver = DRIVER.try_lock().unwrap();
+                let mut driver = lock();
                 let aes = &mut driver.borrow();
                 let mut keystream = [0u8; 16];
                 // Advances the counter, unlike a bare hardware run would.
@@ -1125,20 +1182,29 @@ impl embassy_crypto::driver::Aes256Ctr for AesDriver {
 #[cfg(feature = "embassy-crypto-aes128-ecb")]
 embassy_crypto::aes128_ecb_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes256-ecb")]
+#[cfg(not(aes_v1))]
 embassy_crypto::aes256_ecb_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes128-cbc")]
 embassy_crypto::aes128_cbc_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes256-cbc")]
+#[cfg(not(aes_v1))]
 embassy_crypto::aes256_cbc_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes128-gcm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 embassy_crypto::aes128_gcm_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes256-gcm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 embassy_crypto::aes256_gcm_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes128-ccm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 embassy_crypto::aes128_ccm_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes256-ccm")]
+#[cfg(not(any(aes_v1, all(feature = "embassy-crypto-saes", saes_v1b))))]
 embassy_crypto::aes256_ccm_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes128-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
 embassy_crypto::aes128_ctr_impl!(AesDriver);
 #[cfg(feature = "embassy-crypto-aes256-ctr")]
+#[cfg(not(all(feature = "embassy-crypto-saes", saes_v1b)))]
+#[cfg(not(aes_v1))]
 embassy_crypto::aes256_ctr_impl!(AesDriver);

--- a/embassy-stm32/src/aes/driver.rs
+++ b/embassy-stm32/src/aes/driver.rs
@@ -3,7 +3,7 @@ use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::mutex::Mutex;
 
 use super::{Aes, AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Direction};
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 use crate::mode::Blocking;
 use crate::suspend::ResumablePeripheral;
 
@@ -11,7 +11,7 @@ foreach_peripheral!(
     (aes, $inst:ident) => {
         #[cfg(aes_v2)]
         type BlockingAes = Aes<'static, crate::peripherals::$inst>;
-        #[cfg(aes_v3b)]
+        #[cfg(any(aes_v3a, aes_v3b))]
         type BlockingAes = Aes<'static, crate::peripherals::$inst, Blocking>;
 
         static DRIVER: Mutex<CriticalSectionRawMutex, ResumablePeripheral<BlockingAes>> =
@@ -841,6 +841,7 @@ impl embassy_crypto::driver::Aes256Cbc for AesDriver {
 /// CTR mode as exposed by `embassy_crypto` uses a 128-bit big-endian counter
 /// (NIST SP 800-38A). A run therefore stops where the low word would wrap, and
 /// the carry into the upper bits is applied by software before the next run.
+#[cfg(any(feature = "embassy-crypto-aes128-ctr", feature = "embassy-crypto-aes256-ctr"))]
 fn ctr_run_blocks(iv: &[u8; 16], blocks: usize) -> usize {
     let low = u32::from_be_bytes(iv[12..].try_into().unwrap());
     let until_wrap = u64::from(u32::MAX - low) + 1;
@@ -852,10 +853,12 @@ fn ctr_run_blocks(iv: &[u8; 16], blocks: usize) -> usize {
 }
 
 /// Advance the 128-bit big-endian counter block by `blocks`.
+#[cfg(any(feature = "embassy-crypto-aes128-ctr", feature = "embassy-crypto-aes256-ctr"))]
 fn ctr_advance(iv: &mut [u8; 16], blocks: usize) {
     *iv = u128::from_be_bytes(*iv).wrapping_add(blocks as u128).to_be_bytes();
 }
 
+#[cfg(feature = "embassy-crypto-aes128-ctr")]
 fn ctr_block_in_place_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16], buffer: &mut [u8]) {
     let mut buffer = buffer;
     while buffer.len() >= 16 {
@@ -876,6 +879,7 @@ fn ctr_block_in_place_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16
     }
 }
 
+#[cfg(feature = "embassy-crypto-aes128-ctr")]
 fn ctr_block_separate_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16], input: &[u8], output: &mut [u8]) {
     assert_eq!(input.len(), output.len());
     let mut input = input;
@@ -896,6 +900,7 @@ fn ctr_block_separate_16(aes: &mut BlockingAes, key: &[u8; 16], iv: &mut [u8; 16
     }
 }
 
+#[cfg(feature = "embassy-crypto-aes256-ctr")]
 fn ctr_block_in_place_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16], buffer: &mut [u8]) {
     let mut buffer = buffer;
     while buffer.len() >= 16 {
@@ -916,6 +921,7 @@ fn ctr_block_in_place_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16
     }
 }
 
+#[cfg(feature = "embassy-crypto-aes256-ctr")]
 fn ctr_block_separate_32(aes: &mut BlockingAes, key: &[u8; 32], iv: &mut [u8; 16], input: &[u8], output: &mut [u8]) {
     assert_eq!(input.len(), output.len());
     let mut input = input;

--- a/embassy-stm32/src/aes/mod.rs
+++ b/embassy-stm32/src/aes/mod.rs
@@ -1,17 +1,25 @@
 //! Advanced Encryption Standard (AES) hardware accelerator.
 //!
-//! This module drives the on-chip AES block. Two hardware revisions are
+//! This module drives the on-chip AES block. The hardware revisions below are
 //! supported, selected automatically from the target chip:
 //!
-//! - **`aes_v2`** (STM32G0, G4, L5, U0, WL) — blocking driver. On these parts
-//!   the AES engine either shares its interrupt line with another peripheral
-//!   (e.g. RNG) or has no dedicated line at all, so only a polling/blocking API
+//! - **`aes_v1`** (STM32L0, L1, L4, F423) — blocking driver, plus an
+//!   interrupt-driven async API where the engine has its own interrupt (L4).
+//!   This revision only does ECB, CBC and CTR with 128-bit keys.
+//! - **`aes_v2`** (STM32G0, G4, L5, U0, WL) — blocking driver, plus an
+//!   interrupt-driven async API where the engine has its own interrupt (L5, WL).
+//!   Elsewhere the engine shares its interrupt line with another peripheral
+//!   (e.g. RNG) or has no dedicated line at all, so only the blocking API
 //!   is offered.
+//! - **`aes_f7`** (STM32F72x, F73x) — same register map as `aes_v2` minus the
+//!   `NPBLB` field, so a final partial payload block cannot be masked out of
+//!   the authentication: GCM (both directions) and CCM decryption return
+//!   [`Error::ConfigError`] when the payload is not a multiple of 16 bytes.
 //! - **`aes_v3a`** (STM32U5) and **`aes_v3b`** (STM32H5, WBA) — blocking driver
 //!   plus an interrupt/DMA-backed async API. The two revisions have the same
 //!   register map.
 //!
-//! Both revisions expose the same cipher types and the same
+//! All revisions expose the same cipher types and the same
 //! [`start`](Aes::start) / [`aad_blocking`](Aes::aad_blocking) /
 //! [`payload_blocking`](Aes::payload_blocking) / [`finish_blocking`](Aes::finish_blocking)
 //! blocking flow, so blocking code is portable across them.
@@ -27,9 +35,11 @@
 //! | GMAC | No       | Yes  | Authentication without encryption       |
 //! | CCM  | No       | Yes  | Resource‑constrained devices            |
 //!
+//! GCM, GMAC and CCM are not available on `aes_v1`.
+//!
 //! # Key sizes
 //!
-//! - 128-bit (16 bytes) and 256-bit (32 bytes).
+//! - 128-bit (16 bytes) and 256-bit (32 bytes); only 128-bit on `aes_v1`.
 //! - 192-bit keys are **not** supported by this hardware.
 //!
 //! # IV / nonce requirements
@@ -46,13 +56,12 @@
 mod common;
 pub use common::*;
 
-#[cfg_attr(aes_v2, path = "v2.rs")]
+#[cfg_attr(any(aes_v1, aes_v2, aes_f7), path = "v2.rs")]
 #[cfg_attr(any(aes_v3a, aes_v3b), path = "v3.rs")]
 mod _version;
 
 pub use _version::*;
 
-#[cfg(any(aes_v2, aes_v3a, aes_v3b))]
 #[cfg(any(
     feature = "embassy-crypto-aes128-ecb",
     feature = "embassy-crypto-aes128-cbc",

--- a/embassy-stm32/src/aes/mod.rs
+++ b/embassy-stm32/src/aes/mod.rs
@@ -7,8 +7,9 @@
 //!   the AES engine either shares its interrupt line with another peripheral
 //!   (e.g. RNG) or has no dedicated line at all, so only a polling/blocking API
 //!   is offered.
-//! - **`aes_v3b`** (STM32H5, WBA) — blocking driver plus an interrupt/DMA-backed
-//!   async API.
+//! - **`aes_v3a`** (STM32U5) and **`aes_v3b`** (STM32H5, WBA) — blocking driver
+//!   plus an interrupt/DMA-backed async API. The two revisions have the same
+//!   register map.
 //!
 //! Both revisions expose the same cipher types and the same
 //! [`start`](Aes::start) / [`aad_blocking`](Aes::aad_blocking) /
@@ -46,12 +47,12 @@ mod common;
 pub use common::*;
 
 #[cfg_attr(aes_v2, path = "v2.rs")]
-#[cfg_attr(aes_v3b, path = "v3b.rs")]
+#[cfg_attr(any(aes_v3a, aes_v3b), path = "v3.rs")]
 mod _version;
 
 pub use _version::*;
 
-#[cfg(any(aes_v2, aes_v3b))]
+#[cfg(any(aes_v2, aes_v3a, aes_v3b))]
 #[cfg(any(
     feature = "embassy-crypto-aes128-ecb",
     feature = "embassy-crypto-aes128-cbc",

--- a/embassy-stm32/src/aes/v2.rs
+++ b/embassy-stm32/src/aes/v2.rs
@@ -1,12 +1,14 @@
-//! Driver shell for the `aes_v2` hardware revision (STM32G0, G4, L5, U0, WL).
+//! Driver shell for the `aes_v1` (STM32L0, L1, L4, F423), `aes_v2`
+//! (STM32G0, G4, L5, U0, WL) and `aes_f7` (STM32F72x, F73x) hardware revisions.
 //!
 //! The cipher types and the GCM/CCM state machine live in [`super::common`];
 //! this module provides the [`Aes`] driver, instance wiring, and constructors.
+//! `aes_v1` has no GCM/CCM phases, so the AAD entry points do not exist there.
 //!
 //! A blocking API is always available. An interrupt-driven async API is also
-//! offered on parts whose AES engine has a dedicated interrupt vector (L5, WL),
-//! gated on [`InterruptableInstance`]; on parts where the engine shares its
-//! vector or has none (U0, G0, G4) only the blocking API compiles in.
+//! offered on parts whose AES engine has a dedicated interrupt vector (L4, L5,
+//! WL), gated on [`InterruptableInstance`]; on parts where the engine shares its
+//! vector or has none (L0, U0, G0, G4) only the blocking API compiles in.
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
@@ -15,9 +17,9 @@ use core::task::Poll;
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
-use super::common::{
-    self, Cipher, CipherAuthenticated, CipherSized, Context, Direction, Error, IVSized, SealedInstance,
-};
+#[cfg(not(aes_v1))]
+use super::common::CipherAuthenticated;
+use super::common::{self, Cipher, CipherSized, Context, Direction, Error, IVSized, SealedInstance};
 use crate::interrupt::typelevel::Interrupt;
 use crate::{interrupt, pac, peripherals, rcc};
 
@@ -79,6 +81,7 @@ impl<'d, T: Instance> Aes<'d, T> {
     /// Process authenticated additional data (AAD) for GCM/CCM modes.
     /// Must be called after `start` and before `payload_blocking`.
     /// Set `last` to true for the final AAD block.
+    #[cfg(not(aes_v1))]
     pub fn aad_blocking<'c, C, const TAG_SIZE: usize>(
         &mut self,
         ctx: &mut Context<'c, C>,
@@ -183,6 +186,7 @@ impl<'d, T: InterruptableInstance> Aes<'d, T> {
         let is_gcm_ccm = common::setup(p, cipher, dir);
 
         p.cr().modify(|w| w.set_en(true));
+        #[cfg(not(aes_v1))]
         if is_gcm_ccm {
             wait_ccf(p).await;
             common::clear_ccf(p);
@@ -194,6 +198,7 @@ impl<'d, T: InterruptableInstance> Aes<'d, T> {
     /// Processes authenticated additional data (AAD) for GCM/CCM modes.
     /// Must be called after [`start_async`](Aes::start_async) and before
     /// [`payload_async`](Aes::payload_async). Set `last` to true for the final block.
+    #[cfg(not(aes_v1))]
     pub async fn aad_async<'c, C, const TAG_SIZE: usize>(
         &mut self,
         ctx: &mut Context<'c, C>,
@@ -311,7 +316,7 @@ impl<'d, T: InterruptableInstance> Aes<'d, T> {
             let mut partial_block = [0u8; 16];
             partial_block[..remaining].copy_from_slice(&input[processed..]);
 
-            common::set_final_npblb(p, ctx, remaining);
+            common::set_final_npblb(p, ctx, remaining)?;
 
             common::write_block(p, &partial_block)?;
             self.read_block_async(&mut partial_block).await?;
@@ -334,6 +339,9 @@ impl<'d, T: InterruptableInstance> Aes<'d, T> {
     {
         let p = T::regs();
 
+        #[cfg(aes_v1)]
+        let _ = &ctx;
+        #[cfg(not(aes_v1))]
         if ctx.is_gcm_ccm {
             common::begin_final(p, &ctx);
 
@@ -345,11 +353,11 @@ impl<'d, T: InterruptableInstance> Aes<'d, T> {
             common::clear_ccf(p);
             p.cr().modify(|w| w.set_en(false));
 
-            Ok(Some(tag))
-        } else {
-            p.cr().modify(|w| w.set_en(false));
-            Ok(None)
+            return Ok(Some(tag));
         }
+
+        p.cr().modify(|w| w.set_en(false));
+        Ok(None)
     }
 
     /// Reads a 16-byte block from the AES peripheral, awaiting completion.

--- a/embassy-stm32/src/aes/v3.rs
+++ b/embassy-stm32/src/aes/v3.rs
@@ -1,4 +1,4 @@
-//! Driver shell for the `aes_v3b` hardware revision (STM32H5, WBA).
+//! Driver shell for the `aes_v3a`/`aes_v3b` hardware revisions (STM32U5, H5, WBA).
 //!
 //! The cipher types and the GCM/CCM state machine live in [`super::common`];
 //! this module provides the [`Aes`] driver, its interrupt handler, instance

--- a/embassy-stm32/src/crypto.rs
+++ b/embassy-stm32/src/crypto.rs
@@ -47,9 +47,9 @@ pub trait CipherAuthenticated<const TAG_SIZE: usize> {
 }
 
 // The cipher-mode types below are only reachable through `crate::saes`'s N6
-// re-export (this module is private, and `aes_v3b` chips use `crate::aes`'s
+// re-export (this module is private, and `aes_v3` chips use `crate::aes`'s
 // copy instead), so they only need to exist for that configuration.
-#[cfg(all(saes_n6, not(aes_v3b)))]
+#[cfg(all(saes_n6, not(any(aes_v3a, aes_v3b))))]
 mod ciphers {
     use super::{CipherAuthenticated, CipherSized, Direction, IVSized, KeySize};
 
@@ -461,5 +461,5 @@ mod ciphers {
     }
 }
 
-#[cfg(all(saes_n6, not(aes_v3b)))]
+#[cfg(all(saes_n6, not(any(aes_v3a, aes_v3b))))]
 pub use ciphers::{AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, AesGmac, Cipher, Context};

--- a/embassy-stm32/src/crypto.rs
+++ b/embassy-stm32/src/crypto.rs
@@ -1,4 +1,8 @@
-//! Shared AES cipher mode types used by [`crate::aes`] and [`crate::saes`].
+//! Cipher-mode types shared by [`crate::aes`] and [`crate::saes`].
+//!
+//! Everything here is register-agnostic: the [`Cipher`] trait only describes a
+//! mode (key, IV, `CHMOD` value, whether it has GCM/CCM phases, ...), and the
+//! drivers turn that description into register writes.
 
 /// AES error
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -46,190 +50,170 @@ pub trait CipherAuthenticated<const TAG_SIZE: usize> {
     const TAG_SIZE: usize = TAG_SIZE;
 }
 
-// The cipher-mode types below are only reachable through `crate::saes`'s N6
-// re-export (this module is private, and `aes_v3` chips use `crate::aes`'s
-// copy instead), so they only need to exist for that configuration.
-#[cfg(all(saes_n6, not(any(aes_v3a, aes_v3b))))]
-mod ciphers {
-    use super::{CipherAuthenticated, CipherSized, Direction, IVSized, KeySize};
+/// AES block size in bytes (128 bits).
+const AES_BLOCK_SIZE: usize = 16;
 
-    const AES_BLOCK_SIZE: usize = 16;
+/// This trait encapsulates all cipher-specific behavior.
+pub trait Cipher<'c> {
+    /// Processing block size (always 16 bytes for AES).
+    const BLOCK_SIZE: usize = AES_BLOCK_SIZE;
 
-    /// This trait encapsulates all cipher-specific behavior.
-    pub trait Cipher<'c> {
-        /// Processing block size (always 16 bytes for AES).
-        const BLOCK_SIZE: usize = AES_BLOCK_SIZE;
+    /// Indicates whether the cipher requires the application to provide padding.
+    const REQUIRES_PADDING: bool = false;
 
-        /// Indicates whether the cipher requires the application to provide padding.
-        const REQUIRES_PADDING: bool = false;
+    /// Returns the symmetric key.
+    fn key(&self) -> &[u8];
 
-        /// Returns the symmetric key.
-        fn key(&self) -> &[u8];
+    /// Returns the initialization vector.
+    fn iv(&self) -> &[u8];
 
-        /// Returns the initialization vector.
-        fn iv(&self) -> &[u8];
-
-        /// Returns the key size.
-        fn key_size(&self) -> KeySize {
-            match self.key().len() {
-                16 => KeySize::Bits128,
-                32 => KeySize::Bits256,
-                _ => panic!("Invalid key size"),
-            }
-        }
-
-        /// Returns the data type setting for this cipher mode.
-        fn datatype(&self) -> u8 {
-            0
-        }
-
-        /// Returns the raw CHMOD field value for this cipher mode.
-        fn chmod_bits(&self) -> u8 {
-            0
-        }
-
-        /// Returns the AAD header block as required by the cipher (for authenticated modes).
-        fn get_header_block(&self) -> &[u8] {
-            [0; 0].as_slice()
-        }
-
-        /// Indicates whether this cipher mode uses GCM/CCM phases (init, header, payload, final).
-        fn uses_gcm_phases(&self) -> bool {
-            false
-        }
-
-        /// Indicates whether this is CCM mode (which has different final phase handling).
-        fn is_ccm_mode(&self) -> bool {
-            false
-        }
-
-        /// Returns the pre-computed B0 block for CCM mode (None for other modes).
-        fn ccm_b0(&self) -> Option<&[u8; 16]> {
-            None
-        }
-
-        /// Returns the formatted AAD length prefix for CCM mode.
-        fn ccm_format_aad_header(&self, aad_len: usize) -> ([u8; 10], usize) {
-            let mut header = [0u8; 10];
-            let len = if aad_len == 0 {
-                0
-            } else if aad_len < (1 << 16) - (1 << 8) {
-                header[0] = (aad_len >> 8) as u8;
-                header[1] = aad_len as u8;
-                2
-            } else if aad_len < (1u64 << 32) as usize {
-                header[0] = 0xFF;
-                header[1] = 0xFE;
-                header[2..6].copy_from_slice(&(aad_len as u32).to_be_bytes());
-                6
-            } else {
-                header[0] = 0xFF;
-                header[1] = 0xFF;
-                header[2..10].copy_from_slice(&(aad_len as u64).to_be_bytes());
-                10
-            };
-            (header, len)
+    /// Returns the key size.
+    fn key_size(&self) -> KeySize {
+        match self.key().len() {
+            16 => KeySize::Bits128,
+            32 => KeySize::Bits256,
+            _ => panic!("Invalid key size"),
         }
     }
 
-    /// AES-ECB Cipher Mode
-    pub struct AesEcb<'c, const KEY_SIZE: usize> {
-        iv: &'c [u8; 0],
-        key: &'c [u8; KEY_SIZE],
+    /// Returns the data type setting for this cipher mode.
+    ///
+    /// The drivers use NO_SWAP (0) consistently with big-endian byte
+    /// conversion (`from_be_bytes`/`to_be_bytes`) for direct NIST test-vector
+    /// compatibility.
+    fn datatype(&self) -> u8 {
+        0
     }
 
-    impl<'c, const KEY_SIZE: usize> AesEcb<'c, KEY_SIZE> {
-        /// Constructs a new AES-ECB cipher for a cryptographic operation.
-        pub fn new(key: &'c [u8; KEY_SIZE]) -> Self {
-            Self { key, iv: &[0; 0] }
-        }
+    /// Returns the raw `CHMOD` field value for this cipher mode.
+    fn chmod_bits(&self) -> u8 {
+        0 // ECB default
     }
 
-    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
-        const REQUIRES_PADDING: bool = true;
-
-        fn key(&self) -> &[u8] {
-            self.key
-        }
-
-        fn iv(&self) -> &[u8] {
-            self.iv
-        }
-
-        fn chmod_bits(&self) -> u8 {
-            0
-        }
+    /// Indicates whether this cipher mode uses GCM/CCM phases (init, header, payload, final).
+    fn uses_gcm_phases(&self) -> bool {
+        false
     }
 
-    impl<'c> CipherSized for AesEcb<'c, { 128 / 8 }> {}
-    impl<'c> CipherSized for AesEcb<'c, { 256 / 8 }> {}
-    impl<'c, const KEY_SIZE: usize> IVSized for AesEcb<'c, KEY_SIZE> {}
-
-    /// AES-CBC Cipher Mode
-    pub struct AesCbc<'c, const KEY_SIZE: usize> {
-        iv: &'c [u8; 16],
-        key: &'c [u8; KEY_SIZE],
+    /// Indicates whether this is CCM mode (which has different final phase handling).
+    fn is_ccm_mode(&self) -> bool {
+        false
     }
 
-    impl<'c, const KEY_SIZE: usize> AesCbc<'c, KEY_SIZE> {
-        /// Constructs a new AES-CBC cipher for a cryptographic operation.
-        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
-            Self { key, iv }
-        }
+    /// CCM only: the encoded associated-data length that precedes the
+    /// associated data in the first header block (NIST SP 800-38C A.2.2), and
+    /// its size. Empty for other modes and when there is no associated data.
+    fn ccm_aad_header(&self) -> ([u8; 10], usize) {
+        ([0; 10], 0)
+    }
+}
+
+/// AES-ECB Cipher Mode
+pub struct AesEcb<'c, const KEY_SIZE: usize> {
+    iv: &'c [u8; 0],
+    key: &'c [u8; KEY_SIZE],
+}
+
+impl<'c, const KEY_SIZE: usize> AesEcb<'c, KEY_SIZE> {
+    /// Constructs a new AES-ECB cipher for a cryptographic operation.
+    pub fn new(key: &'c [u8; KEY_SIZE]) -> Self {
+        Self { key, iv: &[0; 0] }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesEcb<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = true;
+
+    fn key(&self) -> &[u8] {
+        self.key
     }
 
-    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
-        const REQUIRES_PADDING: bool = true;
-
-        fn key(&self) -> &[u8] {
-            self.key
-        }
-
-        fn iv(&self) -> &[u8] {
-            self.iv
-        }
-
-        fn chmod_bits(&self) -> u8 {
-            1
-        }
+    fn iv(&self) -> &[u8] {
+        self.iv
     }
 
-    impl<'c> CipherSized for AesCbc<'c, { 128 / 8 }> {}
-    impl<'c> CipherSized for AesCbc<'c, { 256 / 8 }> {}
-    impl<'c, const KEY_SIZE: usize> IVSized for AesCbc<'c, KEY_SIZE> {}
+    fn chmod_bits(&self) -> u8 {
+        0
+    }
+}
 
-    /// AES-CTR Cipher Mode
-    pub struct AesCtr<'c, const KEY_SIZE: usize> {
-        iv: &'c [u8; 16],
-        key: &'c [u8; KEY_SIZE],
+impl<'c> CipherSized for AesEcb<'c, { 128 / 8 }> {}
+#[cfg(not(aes_v1))]
+impl<'c> CipherSized for AesEcb<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesEcb<'c, KEY_SIZE> {}
+
+/// AES-CBC Cipher Mode
+pub struct AesCbc<'c, const KEY_SIZE: usize> {
+    iv: &'c [u8; 16],
+    key: &'c [u8; KEY_SIZE],
+}
+
+impl<'c, const KEY_SIZE: usize> AesCbc<'c, KEY_SIZE> {
+    /// Constructs a new AES-CBC cipher for a cryptographic operation.
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCbc<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = true;
+
+    fn key(&self) -> &[u8] {
+        self.key
     }
 
-    impl<'c, const KEY_SIZE: usize> AesCtr<'c, KEY_SIZE> {
-        /// Constructs a new AES-CTR cipher for a cryptographic operation.
-        pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
-            Self { key, iv }
-        }
+    fn iv(&self) -> &[u8] {
+        self.iv
     }
 
-    impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
-        const REQUIRES_PADDING: bool = false; // Stream cipher, no padding needed
+    fn chmod_bits(&self) -> u8 {
+        1
+    }
+}
 
-        fn key(&self) -> &[u8] {
-            self.key
-        }
+impl<'c> CipherSized for AesCbc<'c, { 128 / 8 }> {}
+#[cfg(not(aes_v1))]
+impl<'c> CipherSized for AesCbc<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesCbc<'c, KEY_SIZE> {}
 
-        fn iv(&self) -> &[u8] {
-            self.iv
-        }
+/// AES-CTR Cipher Mode
+pub struct AesCtr<'c, const KEY_SIZE: usize> {
+    iv: &'c [u8; 16],
+    key: &'c [u8; KEY_SIZE],
+}
 
-        fn chmod_bits(&self) -> u8 {
-            2
-        }
+impl<'c, const KEY_SIZE: usize> AesCtr<'c, KEY_SIZE> {
+    /// Constructs a new AES-CTR cipher for a cryptographic operation.
+    pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+}
+
+impl<'c, const KEY_SIZE: usize> Cipher<'c> for AesCtr<'c, KEY_SIZE> {
+    const REQUIRES_PADDING: bool = false;
+
+    fn key(&self) -> &[u8] {
+        self.key
     }
 
-    impl<'c> CipherSized for AesCtr<'c, { 128 / 8 }> {}
-    impl<'c> CipherSized for AesCtr<'c, { 256 / 8 }> {}
-    impl<'c, const KEY_SIZE: usize> IVSized for AesCtr<'c, KEY_SIZE> {}
+    fn iv(&self) -> &[u8] {
+        self.iv
+    }
+
+    fn chmod_bits(&self) -> u8 {
+        2
+    }
+}
+
+impl<'c> CipherSized for AesCtr<'c, { 128 / 8 }> {}
+#[cfg(not(aes_v1))]
+impl<'c> CipherSized for AesCtr<'c, { 256 / 8 }> {}
+impl<'c, const KEY_SIZE: usize> IVSized for AesCtr<'c, KEY_SIZE> {}
+
+// The authenticated modes need the GCM/CCM phases, which aes_v1 lacks.
+#[cfg(not(aes_v1))]
+mod authenticated {
+    use super::*;
 
     /// AES-GCM Cipher Mode
     pub struct AesGcm<'c, const KEY_SIZE: usize> {
@@ -275,27 +259,8 @@ mod ciphers {
 
     /// AES-GMAC Cipher Mode (Galois Message Authentication Code)
     ///
-    /// GMAC provides message authentication without encryption. Use this when you need
-    /// to authenticate data integrity without confidentiality - the data remains in
-    /// plaintext but any tampering will be detected.
-    ///
-    /// # Use Cases
-    /// - Authenticating packet headers in network protocols
-    /// - Verifying integrity of publicly-readable metadata
-    /// - Any scenario requiring authentication without encryption
-    ///
-    /// # Example
-    /// ```no_run
-    /// let key = [0u8; 16];
-    /// let iv = [0u8; 12];  // 96-bit nonce
-    /// let cipher = AesGmac::new(&key, &iv);
-    ///
-    /// let mut ctx = aes.start(&cipher, Direction::Encrypt);
-    /// aes.aad_blocking(&mut ctx, &header_data, true);
-    /// if let Ok(Some(tag)) = aes.finish_blocking(ctx) {
-    ///     // Use tag to verify integrity
-    /// }
-    /// ```
+    /// GMAC provides message authentication without encryption. The data remains
+    /// in plaintext but any tampering is detected via the authentication tag.
     pub struct AesGmac<'c, const KEY_SIZE: usize> {
         key: &'c [u8; KEY_SIZE],
         iv: [u8; 16],
@@ -324,6 +289,7 @@ mod ciphers {
         }
 
         fn chmod_bits(&self) -> u8 {
+            // GMAC uses the same hardware mode as GCM.
             3
         }
 
@@ -341,40 +307,31 @@ mod ciphers {
     pub struct AesCcm<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> {
         key: &'c [u8; KEY_SIZE],
         iv: [u8; 16],
-        #[allow(dead_code)] // Stored for potential future use in verification
         aad_len: usize,
-        #[allow(dead_code)] // Stored for potential future use in verification
-        payload_len: usize,
     }
 
     impl<'c, const KEY_SIZE: usize, const IV_SIZE: usize, const TAG_SIZE: usize> AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE> {
         /// Constructs a new AES-CCM cipher for a cryptographic operation.
         /// - `key`: The encryption key (16 or 32 bytes)
-        /// - `iv`: The nonce/IV (7-13 bytes recommended, typically 12 bytes)
+        /// - `iv`: The nonce/IV (7-13 bytes)
         /// - `aad_len`: Length of additional authenticated data (known in advance)
         /// - `payload_len`: Length of payload data (known in advance)
-        ///
-        /// Note: CCM requires knowing the data lengths in advance.
         pub fn new(key: &'c [u8; KEY_SIZE], iv: &'c [u8; IV_SIZE], aad_len: usize, payload_len: usize) -> Self {
-            // Validate IV size (7-13 bytes per NIST SP 800-38C)
             assert!(IV_SIZE >= 7 && IV_SIZE <= 13, "CCM IV must be 7-13 bytes");
-            // Validate tag size (4, 6, 8, 10, 12, 14, or 16 bytes)
             assert!(
                 TAG_SIZE >= 4 && TAG_SIZE <= 16 && TAG_SIZE % 2 == 0,
                 "CCM tag must be 4-16 bytes and even"
             );
 
+            // Format the B0 block for CCM.
             let mut iv_full = [0u8; 16];
-            // Format B0 block for CCM
-            let l = 15 - IV_SIZE; // l = size of length field
+            let l = 15 - IV_SIZE; // size of the length field
             iv_full[0] = ((l - 1) as u8) | ((((TAG_SIZE - 2) / 2) as u8) << 3);
             if aad_len > 0 {
-                iv_full[0] |= 0x40; // Set Adata flag
+                iv_full[0] |= 0x40; // Adata flag
             }
             iv_full[1..1 + IV_SIZE].copy_from_slice(iv);
 
-            // Encode payload length in the last l bytes (as big-endian)
-            // Use u64 to ensure consistent handling on 32-bit and 64-bit platforms
             let payload_bytes = (payload_len as u64).to_be_bytes();
             let offset = 16 - l;
             iv_full[offset..].copy_from_slice(&payload_bytes[8 - l..]);
@@ -383,7 +340,6 @@ mod ciphers {
                 key,
                 iv: iv_full,
                 aad_len,
-                payload_len,
             }
         }
     }
@@ -413,8 +369,23 @@ mod ciphers {
             true
         }
 
-        fn ccm_b0(&self) -> Option<&[u8; 16]> {
-            Some(&self.iv)
+        fn ccm_aad_header(&self) -> ([u8; 10], usize) {
+            let mut header = [0u8; 10];
+            let len = if self.aad_len == 0 {
+                0
+            } else if self.aad_len < (1 << 16) - (1 << 8) {
+                header[..2].copy_from_slice(&(self.aad_len as u16).to_be_bytes());
+                2
+            } else if (self.aad_len as u64) < (1u64 << 32) {
+                header[..2].copy_from_slice(&[0xff, 0xfe]);
+                header[2..6].copy_from_slice(&(self.aad_len as u32).to_be_bytes());
+                6
+            } else {
+                header[..2].copy_from_slice(&[0xff, 0xff]);
+                header[2..10].copy_from_slice(&(self.aad_len as u64).to_be_bytes());
+                10
+            };
+            (header, len)
         }
     }
 
@@ -428,38 +399,35 @@ mod ciphers {
         for AesCcm<'c, KEY_SIZE, IV_SIZE, TAG_SIZE>
     {
     }
-
-    /// Stores the state of the AES peripheral for suspending/resuming operations.
-    #[derive(Clone)]
-    pub struct Context<'c, C: Cipher<'c>> {
-        /// The cipher configuration
-        pub cipher: &'c C,
-        /// Encryption or decryption direction
-        pub dir: Direction,
-        /// Whether the last block has been processed
-        pub last_block_processed: bool,
-        /// Whether this is a GCM/CCM authenticated mode
-        pub is_gcm_ccm: bool,
-        // For GCM/CCM authenticated modes
-        /// Whether the header (AAD) has been processed
-        pub header_processed: bool,
-        /// Total length of additional authenticated data
-        pub header_len: u64,
-        /// Total length of payload data
-        pub payload_len: u64,
-        /// Buffer for partial AAD blocks
-        pub aad_buffer: [u8; 16],
-        /// Number of bytes in AAD buffer
-        pub aad_buffer_len: usize,
-        // Hardware state
-        /// Control register state
-        pub cr: u32,
-        /// Initialization vector state
-        pub iv: [u32; 4],
-        /// Suspend registers for GCM/CCM
-        pub suspr: [u32; 8],
-    }
 }
+#[cfg(not(aes_v1))]
+pub use authenticated::*;
 
-#[cfg(all(saes_n6, not(any(aes_v3a, aes_v3b))))]
-pub use ciphers::{AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, AesGmac, Cipher, Context};
+/// Stores the state of the AES peripheral for a cipher operation.
+#[derive(Clone)]
+pub struct Context<'c, C: Cipher<'c>> {
+    /// The cipher configuration
+    pub cipher: &'c C,
+    /// Encryption or decryption direction
+    pub dir: Direction,
+    /// Whether the last block has been processed
+    pub last_block_processed: bool,
+    /// Whether this is a GCM/CCM authenticated mode
+    pub is_gcm_ccm: bool,
+    /// Whether the header (AAD) has been processed
+    pub header_processed: bool,
+    /// Total length of additional authenticated data
+    pub header_len: u64,
+    /// Total length of payload data
+    pub payload_len: u64,
+    /// Buffer for partial AAD blocks
+    pub aad_buffer: [u8; 16],
+    /// Number of bytes in the AAD buffer
+    pub aad_buffer_len: usize,
+    /// Control register state
+    pub cr: u32,
+    /// Initialization vector state
+    pub iv: [u32; 4],
+    /// Suspend registers for GCM/CCM
+    pub suspr: [u32; 8],
+}

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -206,7 +206,7 @@ pub mod npu;
 pub mod opamp;
 #[cfg(octospi)]
 pub mod ospi;
-#[cfg(any(pka_v1a, pka_n6))]
+#[cfg(pka)]
 pub mod pka;
 #[cfg(pssi)]
 pub mod pssi;

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -84,7 +84,7 @@ pub(crate) mod dflt;
 pub mod adc;
 #[cfg(adf)]
 pub mod adf;
-#[cfg(any(aes_v2, aes_v3b))]
+#[cfg(any(aes_v2, aes_v3a, aes_v3b))]
 pub mod aes;
 #[cfg(backup_sram)]
 pub mod backup_sram;
@@ -94,7 +94,7 @@ pub mod can;
 pub mod comp;
 #[cfg(all(cordic, not(stm32c5)))]
 pub mod cordic;
-#[cfg(any(aes_v2, aes_v3b, saes_n6))]
+#[cfg(any(aes_v2, aes_v3a, aes_v3b, saes_n6))]
 mod crypto;
 
 #[cfg(not(any(comp_u5, comp_v1, comp_v2, comp_u0)))]

--- a/embassy-stm32/src/lib.rs
+++ b/embassy-stm32/src/lib.rs
@@ -84,7 +84,7 @@ pub(crate) mod dflt;
 pub mod adc;
 #[cfg(adf)]
 pub mod adf;
-#[cfg(any(aes_v2, aes_v3a, aes_v3b))]
+#[cfg(aes)]
 pub mod aes;
 #[cfg(backup_sram)]
 pub mod backup_sram;
@@ -94,7 +94,7 @@ pub mod can;
 pub mod comp;
 #[cfg(all(cordic, not(stm32c5)))]
 pub mod cordic;
-#[cfg(any(aes_v2, aes_v3a, aes_v3b, saes_n6))]
+#[cfg(any(aes, saes))]
 mod crypto;
 
 #[cfg(not(any(comp_u5, comp_v1, comp_v2, comp_u0)))]
@@ -220,7 +220,7 @@ pub mod rif;
 pub mod rng;
 #[cfg(all(rtc, not(rtc_v1)))]
 pub mod rtc;
-#[cfg(any(saes_v1a, saes_n6))]
+#[cfg(saes)]
 pub mod saes;
 #[cfg(sai)]
 pub mod sai;

--- a/embassy-stm32/src/pka/driver.rs
+++ b/embassy-stm32/src/pka/driver.rs
@@ -1,0 +1,632 @@
+//! `embassy-crypto` drivers over the PKA: curve arithmetic, ECDH and ECDSA for P-256 and
+//! P-384, one per `embassy-crypto-p*-*` feature.
+//!
+//! - Scalar arithmetic is done on the host with `crypto-bigint`, in constant time. It is
+//!   cheaper than an engine setup, and the manual does not mark the engine's modular
+//!   operations as side-channel protected. Points go through the engine.
+//! - Points are affine or infinity. The engine takes and returns affine, so projective buys nothing.
+//! - Point addition uses the engine's complete addition (covers doubling), converted back to
+//!   affine via the Jacobian conversion. `P + (-P)` is caught on the host: the engine cannot
+//!   represent infinity.
+//! - `pka_v1c` has no point addition and no double base ladder. Addition is done on the host
+//!   with one field inversion, and linear combinations as separate multiplications.
+//! - Scalar multiplication uses the protected operation. The manual marks it, ECDSA sign and
+//!   protected exponentiation as side-channel protected. It erases engine RAM when done, so no
+//!   copy of a private scalar survives there.
+//! - Secret linear combinations: one protected multiplication per scalar, then add.
+//! - Variable-time linear combinations: the double base ladder. It errors when the result is
+//!   infinity, then we fall back to separate multiplications.
+//! - ECDSA sign uses the engine's protected signing with a nonce from the `embassy-crypto` RNG
+//!   driver. Verify uses the engine's verification.
+//! - One peripheral shared by all drivers, behind a critical-section mutex, clocked only during
+//!   an operation.
+//! - The engine seeds its RAM from the RNG on every enable, so the RNG must be running: with
+//!   `embassy-crypto-rng` the drivers start it, otherwise an [`Rng`](crate::rng::Rng) must be
+//!   alive.
+
+#![allow(dead_code)]
+
+use crypto_bigint::modular::{FixedMontyForm, FixedMontyParams};
+use crypto_bigint::{NonZero, Uint};
+use embassy_crypto::Error as CryptoError;
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::mutex::Mutex;
+
+#[cfg(not(pka_v1c))]
+use super::EccProjectivePoint;
+use super::{EccPoint, EcdsaCurveParams, EcdsaPublicKey, EcdsaSignature, Error, Pka};
+use crate::mode::Blocking;
+use crate::suspend::ResumablePeripheral;
+
+foreach_peripheral!(
+    (pka, $inst:ident) => {
+        type BlockingPka = Pka<'static, crate::peripherals::$inst, Blocking>;
+
+        static DRIVER: Mutex<CriticalSectionRawMutex, ResumablePeripheral<BlockingPka>> =
+            Mutex::new(ResumablePeripheral::new_suspended(unsafe { crate::peripherals::$inst::steal() }));
+    };
+);
+
+/// Runs `f` with the engine enabled and initialized.
+fn with_pka<R>(f: impl FnOnce(&mut BlockingPka) -> R) -> R {
+    #[cfg(feature = "embassy-crypto-rng")]
+    crate::rng::driver::ensure_running();
+    let mut driver = DRIVER.try_lock().expect("the PKA is in use");
+    let mut pka = driver.borrow();
+    #[cfg(any(pka_v1a, pka_n6))]
+    assert!(
+        !pka.is_limited(),
+        "the PKA of this chip only verifies ECDSA signatures (limited mode)"
+    );
+    f(&mut pka)
+}
+
+/// How many nonces ECDSA signing tries before giving up on the hardware.
+const SIGN_ATTEMPTS: usize = 8;
+
+/// Montgomery constants of an odd big-endian modulus of exactly `L` limbs.
+const fn monty<const L: usize>(n_be: &[u8]) -> FixedMontyParams<L> {
+    FixedMontyParams::new_vartime(Uint::from_be_slice(n_be).to_odd().expect_copied("odd modulus"))
+}
+
+/// Big-endian bytes to an integer, `N == L * Limb::BYTES`.
+fn uint<const N: usize, const L: usize>(v: &[u8; N]) -> Uint<L> {
+    Uint::from_be_slice(v)
+}
+
+/// An integer to big-endian bytes, `N == L * Limb::BYTES`.
+fn bytes<const N: usize, const L: usize>(v: &Uint<L>) -> [u8; N] {
+    let mut out = [0u8; N];
+    out.copy_from_slice(&v.to_be_bytes());
+    out
+}
+
+/// An affine point of `N`-byte coordinates.
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct Aff<const N: usize> {
+    x: [u8; N],
+    y: [u8; N],
+}
+
+impl<const N: usize> Aff<N> {
+    fn from_ecc_point(p: &EccPoint) -> Self {
+        Self {
+            x: p.x[..N].try_into().unwrap(),
+            y: p.y[..N].try_into().unwrap(),
+        }
+    }
+}
+
+/// The arithmetic driver's point: affine coordinates, or `None` for the point at infinity.
+type Pt<const N: usize> = Option<Aff<N>>;
+
+/// Every value crossing the arithmetic driver boundary is valid, so the engine can only fail
+/// on a hardware fault, which there is no way to report through the driver traits.
+fn expect<T>(r: Result<T, Error>) -> T {
+    match r {
+        Ok(v) => v,
+        Err(e) => panic!("PKA error: {:?}", e),
+    }
+}
+
+fn is_zero(v: &[u8]) -> bool {
+    v.iter().all(|&b| b == 0)
+}
+
+/// Returns whether `v < limit`, both big-endian and of the same length.
+fn less_than(v: &[u8], limit: &[u8]) -> bool {
+    for (a, b) in v.iter().zip(limit) {
+        if a != b {
+            return a < b;
+        }
+    }
+    false
+}
+
+/// Returns whether `v` is zero, in constant time.
+fn ct_is_zero(v: &[u8]) -> bool {
+    v.iter().fold(0u8, |acc, &b| acc | b) == 0
+}
+
+/// Returns whether `v < limit`, both big-endian and of the same length, in constant time.
+fn ct_less_than(v: &[u8], limit: &[u8]) -> bool {
+    // A borrow out of the most significant byte of `v - limit` means `v < limit`.
+    let mut borrow = 0u16;
+    for (&a, &b) in v.iter().rev().zip(limit.iter().rev()) {
+        let d = (a as u16).wrapping_sub(b as u16).wrapping_sub(borrow);
+        borrow = (d >> 15) & 1;
+    }
+    borrow == 1
+}
+
+/// Returns whether `0 < k < n`, in constant time.
+fn ct_in_range(k: &[u8], n: &[u8]) -> bool {
+    // Both checks run to completion whatever the value.
+    let nonzero = !ct_is_zero(k);
+    let below = ct_less_than(k, n);
+    nonzero & below
+}
+
+/// Overwrites a secret.
+fn zeroize(buf: &mut [u8]) {
+    for b in buf {
+        unsafe { core::ptr::write_volatile(b, 0) };
+    }
+}
+
+/// Whether `(x, y)` is a point on the curve, other than the point at infinity.
+fn is_on_curve(pka: &mut BlockingPka, curve: &EcdsaCurveParams, x: &[u8], y: &[u8]) -> bool {
+    // The point at infinity has no affine coordinates, and coordinates outside the field are
+    // not a valid encoding even where they reduce onto the curve.
+    if is_zero(x) && is_zero(y) {
+        return false;
+    }
+    if !less_than(x, curve.p_modulus) || !less_than(y, curve.p_modulus) {
+        return false;
+    }
+    expect(pka.point_check_blocking(curve, x, y))
+}
+
+/// `k * P` for `k` in `1..n` and `P` on the curve, which is never the point at infinity.
+///
+/// The engine reports the point at infinity as an error, which such inputs never produce.
+fn try_mul<const N: usize>(
+    pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    k: &[u8; N],
+    p: &Aff<N>,
+) -> Result<Aff<N>, Error> {
+    let mut r = EccPoint::new(N);
+    pka.ecc_mul_blocking(curve, k, &p.x, &p.y, &mut r)?;
+    Ok(Aff::from_ecc_point(&r))
+}
+
+/// `k * P` for `k` in `1..n`, which is never the point at infinity.
+fn mul<const N: usize>(pka: &mut BlockingPka, curve: &EcdsaCurveParams, k: &[u8; N], p: &Aff<N>) -> Aff<N> {
+    expect(try_mul(pka, curve, k, p))
+}
+
+/// `k * P`, with `k` possibly zero and `P` possibly at infinity.
+fn mul_pt<const N: usize>(pka: &mut BlockingPka, curve: &EcdsaCurveParams, k: &[u8; N], p: &Pt<N>) -> Pt<N> {
+    if is_zero(k) {
+        return None;
+    }
+    p.map(|p| mul(pka, curve, k, &p))
+}
+
+/// `P + Q`, or `None` for the point at infinity, through the engine's complete addition.
+#[cfg(not(pka_v1c))]
+fn add<const N: usize, const L: usize>(
+    pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    _field: &FixedMontyParams<L>,
+    p: &Aff<N>,
+    q: &Aff<N>,
+) -> Pt<N> {
+    if p.x == q.x && p.y != q.y {
+        // Same X and different Y: the points are opposite.
+        return None;
+    }
+    let pp = EccProjectivePoint::from_affine(&p.x, &p.y);
+    let qq = EccProjectivePoint::from_affine(&q.x, &q.y);
+    let mut sum = EccProjectivePoint::new(N);
+    expect(pka.ecc_complete_add_blocking(curve, &pp, &qq, &mut sum));
+    let mut r = EccPoint::new(N);
+    expect(pka.jacobian_to_affine_blocking(curve.p_modulus, &sum, &mut r));
+    Some(Aff::from_ecc_point(&r))
+}
+
+/// `P + Q`, or `None` for the point at infinity, on the host: the `pka_v1c` engine has no
+/// point addition. The affine formulas, with one field inversion, in constant time.
+#[cfg(pka_v1c)]
+fn add<const N: usize, const L: usize>(
+    _pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    field: &FixedMontyParams<L>,
+    p: &Aff<N>,
+    q: &Aff<N>,
+) -> Pt<N> {
+    let fe = |v: &[u8; N]| FixedMontyForm::new(&uint(v), field);
+    let (x1, y1, x2, y2) = (fe(&p.x), fe(&p.y), fe(&q.x), fe(&q.y));
+    let (num, den) = if p.x == q.x {
+        if p.y != q.y || is_zero(&p.y) {
+            // Opposite points, or a point of order two, which a prime-order curve does not have.
+            return None;
+        }
+        // Doubling: λ = (3x² + a) / 2y.
+        let mut a = FixedMontyForm::new(&Uint::from_be_slice(curve.a_coefficient), field);
+        if curve.a_coefficient_sign != 0 {
+            a = a.neg();
+        }
+        let xx = x1.square();
+        (xx.double().add(&xx).add(&a), y1.double())
+    } else {
+        // λ = (y2 - y1) / (x2 - x1).
+        (y2.sub(&y1), x2.sub(&x1))
+    };
+    // `den` is nonzero here, so the inverse exists.
+    let lambda = num.mul(&den.invert().unwrap_or(FixedMontyForm::zero(field)));
+    // x3 = λ² - x1 - x2, y3 = λ(x1 - x3) - y1.
+    let x3 = lambda.square().sub(&x1).sub(&x2);
+    let y3 = lambda.mul(&x1.sub(&x3)).sub(&y1);
+    Some(Aff {
+        x: bytes(&x3.retrieve()),
+        y: bytes(&y3.retrieve()),
+    })
+}
+
+/// `P + Q`, either possibly at infinity.
+fn add_pt<const N: usize, const L: usize>(
+    pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    field: &FixedMontyParams<L>,
+    p: &Pt<N>,
+    q: &Pt<N>,
+) -> Pt<N> {
+    match (p, q) {
+        (None, q) => *q,
+        (p, None) => *p,
+        (Some(p), Some(q)) => add(pka, curve, field, p, q),
+    }
+}
+
+/// `a*P + b*Q` for public values, through the engine's double base ladder.
+#[cfg(not(pka_v1c))]
+fn lincomb<const N: usize, const L: usize>(
+    pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    field: &FixedMontyParams<L>,
+    a: &[u8; N],
+    p: &Pt<N>,
+    b: &[u8; N],
+    q: &Pt<N>,
+) -> Pt<N> {
+    let (Some(pa), Some(qa)) = (p, q) else {
+        return lincomb_separate(pka, curve, field, a, p, b, q);
+    };
+    if is_zero(a) || is_zero(b) {
+        return lincomb_separate(pka, curve, field, a, p, b, q);
+    }
+    let pp = EccProjectivePoint::from_affine(&pa.x, &pa.y);
+    let qq = EccProjectivePoint::from_affine(&qa.x, &qa.y);
+    let mut r = EccPoint::new(N);
+    match pka.double_base_ladder_blocking(curve, a, &pp, b, &qq, &mut r) {
+        Ok(()) => Some(Aff::from_ecc_point(&r)),
+        // The ladder reports an error when the result is the point at infinity, which it has
+        // no way to express. Separate multiplications handle it, and anything else the ladder
+        // may object to.
+        Err(_) => lincomb_separate(pka, curve, field, a, p, b, q),
+    }
+}
+
+/// `a*P + b*Q` for public values: the `pka_v1c` engine has no double base ladder.
+#[cfg(pka_v1c)]
+fn lincomb<const N: usize, const L: usize>(
+    pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    field: &FixedMontyParams<L>,
+    a: &[u8; N],
+    p: &Pt<N>,
+    b: &[u8; N],
+    q: &Pt<N>,
+) -> Pt<N> {
+    lincomb_separate(pka, curve, field, a, p, b, q)
+}
+
+/// `a*P + b*Q` as two multiplications and an addition, which handle every special case.
+fn lincomb_separate<const N: usize, const L: usize>(
+    pka: &mut BlockingPka,
+    curve: &EcdsaCurveParams,
+    field: &FixedMontyParams<L>,
+    a: &[u8; N],
+    p: &Pt<N>,
+    b: &[u8; N],
+    q: &Pt<N>,
+) -> Pt<N> {
+    let ap = mul_pt(pka, curve, a, p);
+    let bq = mul_pt(pka, curve, b, q);
+    add_pt(pka, curve, field, &ap, &bq)
+}
+
+/// The public key `k * G` of a private scalar, checked to be in `1..n`.
+fn public_key<const N: usize>(
+    curve: &EcdsaCurveParams,
+    generator: &Aff<N>,
+    k: &[u8; N],
+) -> Result<Aff<N>, CryptoError> {
+    if !ct_in_range(k, curve.order) {
+        return Err(CryptoError::InvalidKey);
+    }
+    with_pka(|pka| try_mul(pka, curve, k, generator)).map_err(|_| CryptoError::HardwareError)
+}
+
+/// The X coordinate of `k * peer`, for a private scalar in `1..n` and an untrusted peer point.
+fn shared_secret<const N: usize>(curve: &EcdsaCurveParams, k: &[u8; N], peer: &Aff<N>) -> Result<[u8; N], CryptoError> {
+    if !ct_in_range(k, curve.order) {
+        return Err(CryptoError::InvalidKey);
+    }
+    with_pka(|pka| {
+        if !is_on_curve(pka, curve, &peer.x, &peer.y) {
+            return Err(CryptoError::InvalidKey);
+        }
+        let r = try_mul(pka, curve, k, peer).map_err(|_| CryptoError::HardwareError)?;
+        Ok(r.x)
+    })
+}
+
+/// Signs a digest with a private scalar in `1..n`: `(r, s)`, low-S normalized.
+fn sign<const N: usize, const L: usize>(
+    curve: &EcdsaCurveParams,
+    order: &NonZero<Uint<L>>,
+    half_order: &[u8; N],
+    k: &[u8; N],
+    digest: &[u8; N],
+) -> Result<([u8; N], [u8; N]), CryptoError> {
+    if !ct_in_range(k, curve.order) {
+        return Err(CryptoError::InvalidKey);
+    }
+    let mut nonce = [0u8; N];
+    let mut r = [0u8; N];
+    let mut s = [0u8; N];
+    let result = with_pka(|pka| {
+        for _ in 0..SIGN_ATTEMPTS {
+            // Rejection sampling into `1..n`.
+            loop {
+                embassy_crypto::driver::RngImpl::fill_bytes(&mut nonce)?;
+                if ct_in_range(&nonce, curve.order) {
+                    break;
+                }
+            }
+            match pka.ecdsa_sign_blocking(curve, k, &nonce, digest, &mut r, &mut s) {
+                Ok(()) => return Ok(()),
+                // The engine reports a zero `r` or `s`, which another nonce fixes, the same
+                // way as an operation error.
+                Err(Error::OperationError) => continue,
+                Err(_) => return Err(CryptoError::HardwareError),
+            }
+        }
+        Err(CryptoError::HardwareError)
+    });
+    zeroize(&mut nonce);
+    result?;
+    // Low-S normalization: `s` is public, so its comparison need not be constant-time.
+    if !less_than(&s, half_order) && s != *half_order {
+        s = bytes(&uint(&s).neg_mod(order));
+    }
+    Ok((r, s))
+}
+
+/// Verifies the signature `(r, s)` of a digest with an untrusted public key.
+fn verify<const N: usize>(
+    curve: &EcdsaCurveParams,
+    q: &Aff<N>,
+    digest: &[u8; N],
+    r: &[u8; N],
+    s: &[u8; N],
+) -> Result<(), CryptoError> {
+    with_pka(|pka| {
+        if !is_on_curve(pka, curve, &q.x, &q.y) {
+            return Err(CryptoError::InvalidKey);
+        }
+        // A zero or out-of-range component is invalid, and the engine is not required to
+        // notice.
+        if !ct_in_range(r, curve.order) || !ct_in_range(s, curve.order) {
+            return Err(CryptoError::InvalidSignature);
+        }
+        let public_key = EcdsaPublicKey { x: &q.x, y: &q.y };
+        let signature = EcdsaSignature { r, s };
+        match pka.ecdsa_verify_blocking(curve, &public_key, &signature, digest) {
+            Ok(true) => Ok(()),
+            _ => Err(CryptoError::InvalidSignature),
+        }
+    })
+}
+
+macro_rules! impl_curve {
+    (
+        $curve_mod:ident, $curve:expr, $n:literal,
+        scalar = $scalar:ident, point = $point:ident, signature = $signature:ident,
+        arith = ($arith_feature:literal, $arith_trait:ident, $arith_register:ident),
+        ecdh = ($ecdh_feature:literal, $ecdh_trait:ident, $ecdh_register:ident),
+        ecdsa = ($ecdsa_feature:literal, $ecdsa_trait:ident, $ecdsa_register:ident),
+    ) => {
+        mod $curve_mod {
+            #[allow(unused_imports)]
+            use embassy_crypto::driver::{$point, $scalar, $signature};
+
+            use super::*;
+
+            const N: usize = $n;
+            const L: usize = N / crypto_bigint::Limb::BYTES;
+            const CURVE: EcdsaCurveParams = $curve;
+            static ORDER: FixedMontyParams<L> = monty(CURVE.order);
+            static FIELD: FixedMontyParams<L> = monty(CURVE.p_modulus);
+            /// `n / 2`, the largest low `s`.
+            static HALF_ORDER: [u8; N] = half(CURVE.order);
+
+            const fn half(v: &[u8]) -> [u8; N] {
+                let mut out = [0u8; N];
+                let mut carry = 0u8;
+                let mut i = 0;
+                while i < N {
+                    out[i] = (v[i] >> 1) | (carry << 7);
+                    carry = v[i] & 1;
+                    i += 1;
+                }
+                out
+            }
+
+            fn generator() -> Aff<N> {
+                Aff {
+                    x: CURVE.generator_x.try_into().unwrap(),
+                    y: CURVE.generator_y.try_into().unwrap(),
+                }
+            }
+
+            fn to_point(p: &Aff<N>) -> $point {
+                $point { x: p.x, y: p.y }
+            }
+
+            fn from_point(p: &$point) -> Aff<N> {
+                Aff { x: p.x, y: p.y }
+            }
+
+            #[cfg(feature = $arith_feature)]
+            mod arith {
+                use super::*;
+
+                struct Driver;
+
+                impl embassy_crypto::driver::$arith_trait for Driver {
+                    type Point = Pt<N>;
+
+                    fn scalar_add(a: &$scalar, b: &$scalar) -> $scalar {
+                        $scalar(bytes(
+                            &uint(&a.0).add_mod(&uint(&b.0), ORDER.modulus().as_nz_ref()),
+                        ))
+                    }
+
+                    fn scalar_sub(a: &$scalar, b: &$scalar) -> $scalar {
+                        $scalar(bytes(
+                            &uint(&a.0).sub_mod(&uint(&b.0), ORDER.modulus().as_nz_ref()),
+                        ))
+                    }
+
+                    fn scalar_mul(a: &$scalar, b: &$scalar) -> $scalar {
+                        // mont(a, R²) = a·R, and mont(a·R, b) = a·b: two Montgomery products.
+                        let ar = FixedMontyForm::new(&uint(&a.0), &ORDER);
+                        let b = FixedMontyForm::from_montgomery(uint(&b.0), &ORDER);
+                        $scalar(bytes(ar.mul(&b).as_montgomery()))
+                    }
+
+                    fn scalar_invert(a: &$scalar) -> $scalar {
+                        // A constant-time select, not a branch on the input. Zero for zero.
+                        $scalar(bytes(
+                            &uint(&a.0).invert_odd_mod(ORDER.modulus()).unwrap_or(Uint::ZERO),
+                        ))
+                    }
+
+                    fn point_identity() -> Pt<N> {
+                        None
+                    }
+
+                    fn point_from_affine(p: &$point) -> Option<Pt<N>> {
+                        let on_curve = with_pka(|pka| is_on_curve(pka, &CURVE, &p.x, &p.y));
+                        on_curve.then_some(Some(from_point(p)))
+                    }
+
+                    fn point_from_affine_unchecked(p: &$point) -> Pt<N> {
+                        Some(from_point(p))
+                    }
+
+                    fn point_to_affine(p: &Pt<N>) -> Option<$point> {
+                        p.as_ref().map(to_point)
+                    }
+
+                    fn point_is_identity(p: &Pt<N>) -> bool {
+                        p.is_none()
+                    }
+
+                    fn point_neg(p: &Pt<N>) -> Pt<N> {
+                        // A valid point of a prime-order curve never has y = 0.
+                        p.map(|p| Aff {
+                            x: p.x,
+                            y: bytes(&uint(&p.y).neg_mod(FIELD.modulus().as_nz_ref())),
+                        })
+                    }
+
+                    fn point_add(p: &Pt<N>, q: &Pt<N>) -> Pt<N> {
+                        with_pka(|pka| add_pt(pka, &CURVE, &FIELD, p, q))
+                    }
+
+                    fn point_mul(k: &$scalar, p: &Pt<N>) -> Pt<N> {
+                        with_pka(|pka| mul_pt(pka, &CURVE, &k.0, p))
+                    }
+
+                    fn point_mul_base(k: &$scalar) -> Pt<N> {
+                        with_pka(|pka| mul_pt(pka, &CURVE, &k.0, &Some(generator())))
+                    }
+
+                    fn point_lincomb(a: &$scalar, p: &Pt<N>, b: &$scalar, q: &Pt<N>) -> Pt<N> {
+                        with_pka(|pka| lincomb_separate(pka, &CURVE, &FIELD, &a.0, p, &b.0, q))
+                    }
+
+                    fn point_lincomb_vartime(a: &$scalar, p: &Pt<N>, b: &$scalar, q: &Pt<N>) -> Pt<N> {
+                        with_pka(|pka| lincomb(pka, &CURVE, &FIELD, &a.0, p, &b.0, q))
+                    }
+                }
+
+                embassy_crypto::$arith_register!(Driver);
+            }
+
+            #[cfg(feature = $ecdh_feature)]
+            mod ecdh {
+                use super::*;
+
+                struct Driver;
+
+                impl embassy_crypto::driver::$ecdh_trait for Driver {
+                    fn public_key(k: &$scalar) -> Result<$point, CryptoError> {
+                        public_key(&CURVE, &generator(), &k.0).map(|p| to_point(&p))
+                    }
+
+                    fn shared_secret(k: &$scalar, peer: &$point) -> Result<[u8; N], CryptoError> {
+                        shared_secret(&CURVE, &k.0, &from_point(peer))
+                    }
+                }
+
+                embassy_crypto::$ecdh_register!(Driver);
+            }
+
+            #[cfg(feature = $ecdsa_feature)]
+            mod ecdsa {
+                use super::*;
+
+                struct Driver;
+
+                impl embassy_crypto::driver::$ecdsa_trait for Driver {
+                    fn public_key(k: &$scalar) -> Result<$point, CryptoError> {
+                        public_key(&CURVE, &generator(), &k.0).map(|p| to_point(&p))
+                    }
+
+                    fn sign(k: &$scalar, digest: &[u8; N]) -> Result<$signature, CryptoError> {
+                        let (r, s) = sign(&CURVE, ORDER.modulus().as_nz_ref(), &HALF_ORDER, &k.0, digest)?;
+                        Ok($signature {
+                            r: $scalar(r),
+                            s: $scalar(s),
+                        })
+                    }
+
+                    fn verify(q: &$point, digest: &[u8; N], sig: &$signature) -> Result<(), CryptoError> {
+                        verify(&CURVE, &from_point(q), digest, &sig.r.0, &sig.s.0)
+                    }
+                }
+
+                embassy_crypto::$ecdsa_register!(Driver);
+            }
+        }
+    };
+}
+
+impl_curve!(
+    p256,
+    EcdsaCurveParams::nist_p256(),
+    32,
+    scalar = P256Scalar,
+    point = P256Point,
+    signature = P256Signature,
+    arith = ("embassy-crypto-p256-arith", P256Arith, p256_arith_impl),
+    ecdh = ("embassy-crypto-p256-ecdh", P256Ecdh, p256_ecdh_impl),
+    ecdsa = ("embassy-crypto-p256-ecdsa", P256Ecdsa, p256_ecdsa_impl),
+);
+impl_curve!(
+    p384,
+    EcdsaCurveParams::nist_p384(),
+    48,
+    scalar = P384Scalar,
+    point = P384Point,
+    signature = P384Signature,
+    arith = ("embassy-crypto-p384-arith", P384Arith, p384_arith_impl),
+    ecdh = ("embassy-crypto-p384-ecdh", P384Ecdh, p384_ecdh_impl),
+    ecdsa = ("embassy-crypto-p384-ecdsa", P384Ecdsa, p384_ecdsa_impl),
+);

--- a/embassy-stm32/src/pka/mod.rs
+++ b/embassy-stm32/src/pka/mod.rs
@@ -21,6 +21,14 @@
 //! | ECDSA Verify | 0x26 | Verify ECDSA signatures |
 //! | Point Check | 0x28 | Validate point is on curve |
 //!
+//! Three hardware revisions are supported: `pka_v1a` (STM32H5, H7RS, WBA),
+//! `pka_v1b` (STM32U3, U5) and `pka_v1c` (STM32L4+, L5, WB, WL). The older
+//! `pka_v1c` has a different RAM layout, no RAM initialization from the RNG
+//! and no operation error flag, and lacks the protected exponentiation, the
+//! complete point addition, the double base ladder and the projective to
+//! affine conversion, so those methods do not exist there. Its scalar
+//! multiplication also does not report the point at infinity.
+//!
 //! # Example - ECDSA Signature Verification (async)
 //!
 //! ```no_run
@@ -64,6 +72,26 @@
 //! - Validate all public keys before use (call `point_check`).
 //! - Call [`Pka::scrub`] between operations that touch sensitive material.
 //! - Clear sensitive data from caller-owned buffers after use.
+//!
+//! # RNG dependency
+//!
+//! On `pka_v1a` and `pka_v1b`, the PKA initializes its RAM with random data
+//! whenever it is enabled, and the initialization does not complete unless the
+//! RNG is running: create an [`Rng`](crate::rng::Rng) before the [`Pka`], and
+//! keep it alive for as long as the PKA is in use. On STM32WBA6 the driver
+//! enables the RNG itself. `pka_v1c` has no such dependency.
+//!
+//! # `embassy-crypto`
+//!
+//! With the `embassy-crypto-p256-arith`, `embassy-crypto-p256-ecdh` and
+//! `embassy-crypto-p256-ecdsa` features, and their `p384` counterparts, the PKA
+//! serves the curve arithmetic, ECDH and ECDSA of the `embassy-crypto` crate:
+//! its `p256` and `p384` modules, and everything built on them. The drivers
+//! take the peripheral over, so the `Pka` must not be constructed by the
+//! application. They need a running RNG too: with the `embassy-crypto-rng`
+//! feature they start it themselves, otherwise keep an
+//! [`Rng`](crate::rng::Rng) alive. ECDSA signing draws its nonces from the
+//! `embassy-crypto` random number driver, whichever one is registered.
 
 use core::future::poll_fn;
 use core::marker::PhantomData;
@@ -75,6 +103,16 @@ use embassy_sync::waitqueue::AtomicWaker;
 use crate::interrupt::typelevel::Interrupt;
 use crate::mode::{Async, Blocking, Mode};
 use crate::{interrupt, pac, peripherals, rcc};
+
+#[cfg(any(
+    feature = "embassy-crypto-p256-arith",
+    feature = "embassy-crypto-p256-ecdh",
+    feature = "embassy-crypto-p256-ecdsa",
+    feature = "embassy-crypto-p384-arith",
+    feature = "embassy-crypto-p384-ecdh",
+    feature = "embassy-crypto-p384-ecdsa",
+))]
+mod driver;
 
 static PKA_WAKER: AtomicWaker = AtomicWaker::new();
 const MAX_ECC_BYTES: usize = 80; // 640-bit ECC operand support
@@ -95,6 +133,7 @@ pub enum PkaMode {
     /// Modular exponentiation fast mode
     ModularExpFast = 0x02,
     /// Modular exponentiation with protection
+    #[cfg(not(pka_v1c))]
     ModularExpProtect = 0x03,
     /// RSA CRT exponentiation
     RsaCrtExp = 0x07,
@@ -119,16 +158,19 @@ pub enum PkaMode {
     /// ECC scalar multiplication
     EccMul = 0x20,
     /// ECC complete addition
+    #[cfg(not(pka_v1c))]
     EccCompleteAdd = 0x23,
     /// ECDSA signature generation
     EcdsaSign = 0x24,
     /// ECDSA signature verification
     EcdsaVerify = 0x26,
     /// Double base ladder
+    #[cfg(not(pka_v1c))]
     DoubleBaseLadder = 0x27,
     /// Point check (validate point on curve)
     PointCheck = 0x28,
     /// ECC projective to affine
+    #[cfg(not(pka_v1c))]
     EccProjectiveToAffine = 0x2F,
 }
 
@@ -137,6 +179,129 @@ pub enum PkaMode {
 // Derived from CMSIS headers: offset = raw_address - 0x0400
 // ============================================================================
 
+// The older `pka_v1c` layout (STM32WB55 CMSIS header).
+#[cfg(pka_v1c)]
+mod offsets {
+    // Montgomery parameter computation
+    pub mod montgomery_param {
+        pub const IN_MOD_NB_BITS: usize = 0x04;
+        pub const IN_MODULUS: usize = 0x95C;
+        pub const OUT_PARAMETER: usize = 0x194;
+    }
+
+    // Modular exponentiation (RSA)
+    pub mod modular_exp {
+        pub const IN_EXP_NB_BITS: usize = 0x00;
+        pub const IN_OP_NB_BITS: usize = 0x04;
+        pub const IN_MONTGOMERY_PARAM: usize = 0x194;
+        pub const IN_EXPONENT_BASE: usize = 0x644;
+        pub const IN_EXPONENT: usize = 0x7D0;
+        pub const IN_MODULUS: usize = 0x95C;
+        pub const OUT_RESULT: usize = 0x324;
+    }
+
+    // RSA CRT exponentiation
+    pub mod rsa_crt {
+        pub const IN_MOD_NB_BITS: usize = 0x04;
+        pub const IN_DP_CRT: usize = 0x25C;
+        pub const IN_DQ_CRT: usize = 0x7D0;
+        pub const IN_QINV_CRT: usize = 0x3EC;
+        pub const IN_PRIME_P: usize = 0x57C;
+        pub const IN_PRIME_Q: usize = 0x95C;
+        pub const IN_EXPONENT_BASE: usize = 0xAEC;
+        pub const OUT_RESULT: usize = 0x324;
+    }
+
+    // ECC scalar multiplication: no curve coefficient b, no order, no error word.
+    pub mod ecc_mul {
+        pub const IN_EXP_NB_BITS: usize = 0x00;
+        pub const IN_OP_NB_BITS: usize = 0x04;
+        pub const IN_A_COEFF_SIGN: usize = 0x08;
+        pub const IN_A_COEFF: usize = 0x0C;
+        pub const IN_MOD_GF: usize = 0x60;
+        pub const IN_K: usize = 0x108;
+        pub const IN_INITIAL_POINT_X: usize = 0x15C;
+        pub const IN_INITIAL_POINT_Y: usize = 0x1B0;
+        pub const OUT_RESULT_X: usize = 0x15C;
+        pub const OUT_RESULT_Y: usize = 0x1B0;
+    }
+
+    // ECDSA signature generation: no curve coefficient b.
+    pub mod ecdsa_sign {
+        pub const IN_ORDER_NB_BITS: usize = 0x00;
+        pub const IN_MOD_NB_BITS: usize = 0x04;
+        pub const IN_A_COEFF_SIGN: usize = 0x08;
+        pub const IN_A_COEFF: usize = 0x0C;
+        pub const IN_MOD_GF: usize = 0x60;
+        pub const IN_K: usize = 0x108;
+        pub const IN_INITIAL_POINT_X: usize = 0x15C;
+        pub const IN_INITIAL_POINT_Y: usize = 0x1B0;
+        pub const IN_HASH_E: usize = 0x9E8;
+        pub const IN_PRIVATE_KEY_D: usize = 0xA3C;
+        pub const IN_ORDER_N: usize = 0xA94;
+        pub const OUT_ERROR: usize = 0xAE8;
+        pub const OUT_SIGNATURE_R: usize = 0x300;
+        pub const OUT_SIGNATURE_S: usize = 0x354;
+    }
+
+    // ECDSA signature verification
+    pub mod ecdsa_verif {
+        pub const IN_ORDER_NB_BITS: usize = 0x04;
+        pub const IN_MOD_NB_BITS: usize = 0xB4;
+        pub const IN_A_COEFF_SIGN: usize = 0x5C;
+        pub const IN_A_COEFF: usize = 0x60;
+        pub const IN_MOD_GF: usize = 0xB8;
+        pub const IN_INITIAL_POINT_X: usize = 0x1E8;
+        pub const IN_INITIAL_POINT_Y: usize = 0x23C;
+        pub const IN_PUBLIC_KEY_POINT_X: usize = 0xB40;
+        pub const IN_PUBLIC_KEY_POINT_Y: usize = 0xB94;
+        pub const IN_SIGNATURE_R: usize = 0xC98;
+        pub const IN_SIGNATURE_S: usize = 0x644;
+        pub const IN_HASH_E: usize = 0xBE8;
+        pub const IN_ORDER_N: usize = 0x95C;
+        pub const OUT_RESULT: usize = 0x1B0;
+    }
+
+    // Point check: no Montgomery parameter.
+    pub mod point_check {
+        pub const IN_MOD_NB_BITS: usize = 0x04;
+        pub const IN_A_COEFF_SIGN: usize = 0x08;
+        pub const IN_A_COEFF: usize = 0x0C;
+        pub const IN_B_COEFF: usize = 0x3FC;
+        pub const IN_MOD_GF: usize = 0x60;
+        pub const IN_INITIAL_POINT_X: usize = 0x15C;
+        pub const IN_INITIAL_POINT_Y: usize = 0x1B0;
+        pub const OUT_ERROR: usize = 0x00;
+    }
+
+    // Modular inversion
+    pub mod modular_inv {
+        pub const IN_NB_BITS: usize = 0x04;
+        pub const IN_OP1: usize = 0x4B4;
+        pub const IN_OP2_MOD: usize = 0x644;
+        pub const OUT_RESULT: usize = 0x7D0;
+    }
+
+    // Generic arithmetic operations (add, sub, mul, comparison, modular add/sub, montgomery mul)
+    pub mod arithmetic {
+        pub const IN_NB_BITS: usize = 0x04;
+        pub const IN_OP1: usize = 0x4B4;
+        pub const IN_OP2: usize = 0x644;
+        pub const IN_OP3_MOD: usize = 0x95C;
+        pub const OUT_RESULT: usize = 0x7D0;
+    }
+
+    // Modular reduction
+    pub mod modular_red {
+        pub const IN_OP_LENGTH: usize = 0x00;
+        pub const IN_MOD_LENGTH: usize = 0x04;
+        pub const IN_OPERAND: usize = 0x4B4;
+        pub const IN_MODULUS: usize = 0x644;
+        pub const OUT_RESULT: usize = 0x7D0;
+    }
+}
+
+#[cfg(not(pka_v1c))]
 mod offsets {
     // Montgomery parameter computation
     pub mod montgomery_param {
@@ -248,7 +413,6 @@ mod offsets {
         pub const IN_MOD_GF: usize = 0x70;
         pub const IN_INITIAL_POINT_X: usize = 0x178;
         pub const IN_INITIAL_POINT_Y: usize = 0x1D0;
-        #[allow(dead_code)]
         pub const IN_MONTGOMERY_PARAM: usize = 0xC8;
         pub const OUT_ERROR: usize = 0x280;
     }
@@ -342,14 +506,19 @@ pub struct InterruptHandler<T: Instance> {
 impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandler<T> {
     unsafe fn on_interrupt() {
         let sr = T::regs().sr().read();
+        #[cfg(pka_v1c)]
+        let operrf = false;
+        #[cfg(not(pka_v1c))]
+        let operrf = sr.operrf();
 
         // Disable the IE bits so the IRQ doesn't refire while the future is waking.
         // The poll_fn loop in `start_and_wait_async` reads SR and clears the flags itself.
-        if sr.procendf() || sr.ramerrf() || sr.addrerrf() || sr.operrf() {
+        if sr.procendf() || sr.ramerrf() || sr.addrerrf() || operrf {
             T::regs().cr().modify(|w| {
                 w.set_procendie(false);
                 w.set_ramerrie(false);
                 w.set_addrerrie(false);
+                #[cfg(not(pka_v1c))]
                 w.set_operrie(false);
             });
             PKA_WAKER.wake();
@@ -416,6 +585,20 @@ impl EcdsaCurveParams {
             order: &P256_N,
         }
     }
+
+    /// NIST P-384 (secp384r1) curve parameters
+    pub const fn nist_p384() -> Self {
+        Self {
+            p_modulus: &P384_P,
+            // For P-384, a = -3 (mod p), so we use |a| = 3 with sign = 1 (negative)
+            a_coefficient: &P384_A,
+            a_coefficient_sign: 1, // negative
+            b_coefficient: &P384_B,
+            generator_x: &P384_GX,
+            generator_y: &P384_GY,
+            order: &P384_N,
+        }
+    }
 }
 
 // NIST P-256 curve parameters (big-endian)
@@ -443,6 +626,39 @@ const P256_GY: [u8; 32] = [
 const P256_N: [u8; 32] = [
     0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xBC, 0xE6, 0xFA,
     0xAD, 0xA7, 0x17, 0x9E, 0x84, 0xF3, 0xB9, 0xCA, 0xC2, 0xFC, 0x63, 0x25, 0x51,
+];
+
+// NIST P-384 curve parameters (big-endian)
+const P384_P: [u8; 48] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE, 0xFF, 0xFF, 0xFF, 0xFF, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0xFF, 0xFF,
+];
+// |a| = 3 (absolute value of -3)
+const P384_A: [u8; 48] = [
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+];
+const P384_B: [u8; 48] = [
+    0xB3, 0x31, 0x2F, 0xA7, 0xE2, 0x3E, 0xE7, 0xE4, 0x98, 0x8E, 0x05, 0x6B, 0xE3, 0xF8, 0x2D, 0x19, 0x18, 0x1D, 0x9C,
+    0x6E, 0xFE, 0x81, 0x41, 0x12, 0x03, 0x14, 0x08, 0x8F, 0x50, 0x13, 0x87, 0x5A, 0xC6, 0x56, 0x39, 0x8D, 0x8A, 0x2E,
+    0xD1, 0x9D, 0x2A, 0x85, 0xC8, 0xED, 0xD3, 0xEC, 0x2A, 0xEF,
+];
+const P384_GX: [u8; 48] = [
+    0xAA, 0x87, 0xCA, 0x22, 0xBE, 0x8B, 0x05, 0x37, 0x8E, 0xB1, 0xC7, 0x1E, 0xF3, 0x20, 0xAD, 0x74, 0x6E, 0x1D, 0x3B,
+    0x62, 0x8B, 0xA7, 0x9B, 0x98, 0x59, 0xF7, 0x41, 0xE0, 0x82, 0x54, 0x2A, 0x38, 0x55, 0x02, 0xF2, 0x5D, 0xBF, 0x55,
+    0x29, 0x6C, 0x3A, 0x54, 0x5E, 0x38, 0x72, 0x76, 0x0A, 0xB7,
+];
+const P384_GY: [u8; 48] = [
+    0x36, 0x17, 0xDE, 0x4A, 0x96, 0x26, 0x2C, 0x6F, 0x5D, 0x9E, 0x98, 0xBF, 0x92, 0x92, 0xDC, 0x29, 0xF8, 0xF4, 0x1D,
+    0xBD, 0x28, 0x9A, 0x14, 0x7C, 0xE9, 0xDA, 0x31, 0x13, 0xB5, 0xF0, 0xB8, 0xC0, 0x0A, 0x60, 0xB1, 0xCE, 0x1D, 0x7E,
+    0x81, 0x9D, 0x7A, 0x43, 0x1D, 0x7C, 0x90, 0xEA, 0x0E, 0x5F,
+];
+const P384_N: [u8; 48] = [
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+    0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC7, 0x63, 0x4D, 0x81, 0xF4, 0x37, 0x2D, 0xDF, 0x58, 0x1A, 0x0D, 0xB2, 0x48, 0xB0,
+    0xA7, 0x7A, 0xEC, 0xEC, 0x19, 0x6A, 0xCC, 0xC5, 0x29, 0x73,
 ];
 
 /// ECDSA public key
@@ -602,7 +818,14 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
 }
 
 impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
+    #[cfg(not(pka_v1c))]
     const RAM_ERASE_TIMEOUT: u32 = 100_000;
+
+    /// The value the engine leaves in a result or error word to report success.
+    #[cfg(not(pka_v1c))]
+    const SUCCESS: u32 = 0xD60D;
+    #[cfg(pka_v1c)]
+    const SUCCESS: u32 = 0;
 
     fn new_inner(peripheral: Peri<'d, T>) -> Self {
         rcc::enable_and_reset::<T>();
@@ -678,7 +901,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
 
     fn read_ecdsa_verify(&mut self) -> Result<bool, Error> {
         let result = self.read_ram_word(offsets::ecdsa_verif::OUT_RESULT);
-        Ok(result == 0xD60D)
+        Ok(result == Self::SUCCESS)
     }
 
     fn prepare_ecdsa_sign(
@@ -715,6 +938,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
 
         // Write curve parameters
         self.write_operand(offsets::ecdsa_sign::IN_A_COEFF, curve.a_coefficient);
+        #[cfg(not(pka_v1c))]
         self.write_operand(offsets::ecdsa_sign::IN_B_COEFF, curve.b_coefficient);
         self.write_operand(offsets::ecdsa_sign::IN_MOD_GF, curve.p_modulus);
         self.write_operand(offsets::ecdsa_sign::IN_INITIAL_POINT_X, curve.generator_x);
@@ -735,9 +959,8 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         signature_r: &mut [u8],
         signature_s: &mut [u8],
     ) -> Result<(), Error> {
-        // Check for errors - 0xD60D indicates success
         let result = self.read_ram_word(offsets::ecdsa_sign::OUT_ERROR);
-        if result != 0xD60D {
+        if result != Self::SUCCESS {
             return Err(Error::OperationError);
         }
 
@@ -782,8 +1005,10 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
 
         // Write curve parameters
         self.write_operand(offsets::ecc_mul::IN_A_COEFF, curve.a_coefficient);
+        #[cfg(not(pka_v1c))]
         self.write_operand(offsets::ecc_mul::IN_B_COEFF, curve.b_coefficient);
         self.write_operand(offsets::ecc_mul::IN_MOD_GF, curve.p_modulus);
+        #[cfg(not(pka_v1c))]
         self.write_operand(offsets::ecc_mul::IN_N_PRIME_ORDER, curve.order);
 
         // Write scalar and point
@@ -797,10 +1022,13 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
     }
 
     fn read_ecc_mul(&mut self, modulus_size: usize, result: &mut EccPoint) -> Result<(), Error> {
-        // Check for errors - 0xD60D indicates success
-        let status = self.read_ram_word(offsets::ecc_mul::OUT_ERROR);
-        if status != 0xD60D {
-            return Err(Error::OperationError);
+        // pka_v1c reports nothing: the point at infinity comes out as garbage.
+        #[cfg(not(pka_v1c))]
+        {
+            let status = self.read_ram_word(offsets::ecc_mul::OUT_ERROR);
+            if status != Self::SUCCESS {
+                return Err(Error::OperationError);
+            }
         }
 
         // Read result
@@ -810,10 +1038,20 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
-    fn prepare_point_check(&mut self, curve: &EcdsaCurveParams, point_x: &[u8], point_y: &[u8]) -> Result<(), Error> {
+    fn prepare_point_check(
+        &mut self,
+        curve: &EcdsaCurveParams,
+        point_x: &[u8],
+        point_y: &[u8],
+        montgomery_param: &[u32],
+    ) -> Result<(), Error> {
         let modulus_size = curve.p_modulus.len();
 
         if point_x.len() != modulus_size || point_y.len() != modulus_size {
+            return Err(Error::InvalidSize);
+        }
+        #[cfg(not(pka_v1c))]
+        if montgomery_param.len() < modulus_size.div_ceil(4) {
             return Err(Error::InvalidSize);
         }
 
@@ -828,6 +1066,13 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         self.write_operand(offsets::point_check::IN_INITIAL_POINT_X, point_x);
         self.write_operand(offsets::point_check::IN_INITIAL_POINT_Y, point_y);
 
+        // The check works in Montgomery form and needs R^2 mod p, which this
+        // operation does not compute itself, except on pka_v1c.
+        #[cfg(not(pka_v1c))]
+        self.write_montgomery_param(offsets::point_check::IN_MONTGOMERY_PARAM, montgomery_param);
+        #[cfg(pka_v1c)]
+        let _ = montgomery_param;
+
         // Set mode right before start (matching ST HAL order)
         self.set_mode(PkaMode::PointCheck);
         Ok(())
@@ -835,9 +1080,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
 
     fn read_point_check(&mut self) -> Result<bool, Error> {
         let result = self.read_ram_word(offsets::point_check::OUT_ERROR);
-
-        // 0xD60D means point is on curve
-        Ok(result == 0xD60D)
+        Ok(result == Self::SUCCESS)
     }
 
     // ========================================================================
@@ -1048,10 +1291,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         self.write_ram_word(offsets::modular_exp::IN_EXP_NB_BITS, exp_nb_bits);
         self.write_ram_word(offsets::modular_exp::IN_OP_NB_BITS, mod_nb_bits);
 
-        // Write Montgomery parameter (u32 words)
-        for (i, &word) in montgomery_param.iter().enumerate() {
-            self.write_ram_word(offsets::modular_exp::IN_MONTGOMERY_PARAM + i * 4, word);
-        }
+        self.write_montgomery_param(offsets::modular_exp::IN_MONTGOMERY_PARAM, montgomery_param);
 
         self.write_operand(offsets::modular_exp::IN_EXPONENT_BASE, base);
         self.write_operand(offsets::modular_exp::IN_EXPONENT, exponent);
@@ -1067,6 +1307,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn prepare_modular_exp_protect(&mut self, params: &ModExpProtectParams, result_len: usize) -> Result<(), Error> {
         let mod_size = params.modulus.len();
         let exp_size = params.exponent.len();
@@ -1092,6 +1333,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn read_modular_exp_protect(&mut self, mod_size: usize, result: &mut [u8]) -> Result<(), Error> {
         // Modular exponentiation (protected mode) doesn't write to OUT_ERROR
         // Errors are indicated by SR flags which are checked in the wait helper
@@ -1211,6 +1453,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
     // Advanced ECC Operations
     // ========================================================================
 
+    #[cfg(not(pka_v1c))]
     fn prepare_ecc_complete_add(
         &mut self,
         curve: &EcdsaCurveParams,
@@ -1246,6 +1489,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn read_ecc_complete_add(&mut self, modulus_size: usize, result: &mut EccProjectivePoint) -> Result<(), Error> {
         // Read result
         self.read_operand(offsets::ecc_complete_add::OUT_RESULT_X, &mut result.x[..modulus_size]);
@@ -1255,6 +1499,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn prepare_double_base_ladder(
         &mut self,
         curve: &EcdsaCurveParams,
@@ -1304,10 +1549,11 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn read_double_base_ladder(&mut self, modulus_size: usize, result: &mut EccPoint) -> Result<(), Error> {
         // Check for errors
         let status = self.read_ram_word(offsets::double_base_ladder::OUT_ERROR);
-        if status != 0xD60D {
+        if status != Self::SUCCESS {
             return Err(Error::OperationError);
         }
 
@@ -1318,6 +1564,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn prepare_projective_to_affine(
         &mut self,
         modulus: &[u8],
@@ -1336,10 +1583,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         self.write_ram_word(offsets::projective_to_affine::IN_MOD_NB_BITS, mod_nb_bits);
         self.write_operand(offsets::projective_to_affine::IN_MOD_P, modulus);
 
-        // Write Montgomery parameter
-        for (i, &word) in montgomery_param.iter().enumerate() {
-            self.write_ram_word(offsets::projective_to_affine::IN_MONTGOMERY_PARAM + i * 4, word);
-        }
+        self.write_montgomery_param(offsets::projective_to_affine::IN_MONTGOMERY_PARAM, montgomery_param);
 
         // Write projective point
         self.write_operand(offsets::projective_to_affine::IN_POINT_X, &point.x[..modulus_size]);
@@ -1350,10 +1594,11 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         Ok(())
     }
 
+    #[cfg(not(pka_v1c))]
     fn read_projective_to_affine(&mut self, modulus_size: usize, result: &mut EccPoint) -> Result<(), Error> {
         // Check for errors
         let status = self.read_ram_word(offsets::projective_to_affine::OUT_ERROR);
-        if status != 0xD60D {
+        if status != Self::SUCCESS {
             return Err(Error::OperationError);
         }
 
@@ -1374,6 +1619,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
     // Internal Helper Functions
     // ========================================================================
 
+    #[cfg(not(pka_v1c))]
     fn begin_init(&mut self) -> Result<bool, Error> {
         let p = T::regs();
         let sr_ptr = p.sr().as_ptr() as *const u32;
@@ -1439,11 +1685,13 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
             w.set_procendfc(true);
             w.set_ramerrfc(true);
             w.set_addrerrfc(true);
+            #[cfg(not(pka_v1c))]
             w.set_operrfc(true);
         });
     }
 
     // Wait for INITOK (bit 0 of SR) - indicated RAM initialization complete
+    #[cfg(not(pka_v1c))]
     fn wait_initok_blocking(&mut self) -> Result<(), Error> {
         let p = T::regs();
         let sr_ptr = p.sr().as_ptr() as *const u32;
@@ -1460,12 +1708,38 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
         }
     }
 
+    #[cfg(not(pka_v1c))]
     fn ensure_init_blocking(&mut self) -> Result<(), Error> {
         if self.begin_init()? {
             self.wait_initok_blocking()?;
         }
         self.finish_init();
         Ok(())
+    }
+
+    // pka_v1c has no RAM initialization to wait for: enabling is all there is to it.
+    #[cfg(pka_v1c)]
+    fn ensure_init_blocking(&mut self) -> Result<(), Error> {
+        let p = T::regs();
+        if !p.cr().read().en() {
+            p.cr().write(|w| w.set_en(true));
+        }
+        self.finish_init();
+        Ok(())
+    }
+
+    /// Whether the PKA runs in limited mode, in which only ECDSA signature
+    /// verification is available and every other operation fails with
+    /// [`Error::OperationError`].
+    ///
+    /// Some parts have such a PKA, meant for secure boot: the STM32H56x, as
+    /// opposed to the STM32H57x.
+    #[cfg(any(pka_v1a, pka_n6))]
+    pub fn is_limited(&self) -> bool {
+        let lmf = T::regs().sr().read().lmf();
+        #[cfg(pka_v1a)]
+        let lmf = lmf == pac::pka::vals::Lmf::Limited;
+        lmf
     }
 
     /// Zero out the PKA RAM (basic hygiene scrub).
@@ -1497,6 +1771,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
             w.set_procendie(false);
             w.set_ramerrie(false);
             w.set_addrerrie(false);
+            #[cfg(not(pka_v1c))]
             w.set_operrie(false);
         });
     }
@@ -1518,6 +1793,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
                 p.clrfr().write(|w| w.set_addrerrfc(true));
                 return Err(Error::AddressError);
             }
+            #[cfg(not(pka_v1c))]
             if sr.operrf() {
                 p.clrfr().write(|w| w.set_operrfc(true));
                 return Err(Error::OperationError);
@@ -1546,6 +1822,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
             w.set_procendie(true);
             w.set_ramerrie(true);
             w.set_addrerrie(true);
+            #[cfg(not(pka_v1c))]
             w.set_operrie(true);
             w.set_start(true);
         });
@@ -1570,6 +1847,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
             w.set_procendie(false);
             w.set_ramerrie(false);
             w.set_addrerrie(false);
+            #[cfg(not(pka_v1c))]
             w.set_operrie(false);
         });
 
@@ -1588,6 +1866,7 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
             p.clrfr().write(|w| w.set_addrerrfc(true));
             return Some(Err(Error::AddressError));
         }
+        #[cfg(not(pka_v1c))]
         if sr.operrf() {
             p.clrfr().write(|w| w.set_operrfc(true));
             return Some(Err(Error::OperationError));
@@ -1664,6 +1943,16 @@ impl<'d, T: Instance, M: Mode> Pka<'d, T, M> {
                 _ => {}
             }
         }
+    }
+
+    /// Writes a Montgomery parameter as the little-endian words the hardware
+    /// produced it in, terminated like any other operand.
+    fn write_montgomery_param(&mut self, offset: usize, words: &[u32]) {
+        for (i, &word) in words.iter().enumerate() {
+            self.write_ram_word(offset + i * 4, word);
+        }
+        self.write_ram_word(offset + words.len() * 4, 0);
+        self.write_ram_word(offset + (words.len() + 1) * 4, 0);
     }
 
     fn write_ram_word(&mut self, offset: usize, value: u32) {
@@ -1778,7 +2067,12 @@ impl<'d, T: Instance> Pka<'d, T, Blocking> {
         point_x: &[u8],
         point_y: &[u8],
     ) -> Result<bool, Error> {
-        self.prepare_point_check(curve, point_x, point_y)?;
+        #[cfg_attr(pka_v1c, allow(unused_mut))]
+        let mut r2 = [0u32; MAX_ECC_BYTES / 4];
+        let words = curve.p_modulus.len().div_ceil(4);
+        #[cfg(not(pka_v1c))]
+        self.montgomery_param_blocking(curve.p_modulus, &mut r2[..words])?;
+        self.prepare_point_check(curve, point_x, point_y, &r2[..words])?;
         self.start_and_wait_blocking()?;
         self.read_point_check()
     }
@@ -1911,6 +2205,7 @@ impl<'d, T: Instance> Pka<'d, T, Blocking> {
     /// # Arguments
     /// * `params` -- Protected-mode parameters including `phi(n)`.
     /// * `result` -- Output buffer (must be at least the size of `params.modulus`).
+    #[cfg(not(pka_v1c))]
     pub fn modular_exp_protect_blocking(
         &mut self,
         params: &ModExpProtectParams,
@@ -1991,6 +2286,7 @@ impl<'d, T: Instance> Pka<'d, T, Blocking> {
     /// * `p` -- First point in projective coordinates.
     /// * `q` -- Second point in projective coordinates.
     /// * `result` -- Output point in Jacobian projective coordinates.
+    #[cfg(not(pka_v1c))]
     pub fn ecc_complete_add_blocking(
         &mut self,
         curve: &EcdsaCurveParams,
@@ -2016,6 +2312,7 @@ impl<'d, T: Instance> Pka<'d, T, Blocking> {
     /// * `m` -- Scalar for point `Q`.
     /// * `q` -- Second point in projective coordinates.
     /// * `result` -- Output point in affine coordinates.
+    #[cfg(not(pka_v1c))]
     pub fn double_base_ladder_blocking(
         &mut self,
         curve: &EcdsaCurveParams,
@@ -2038,6 +2335,7 @@ impl<'d, T: Instance> Pka<'d, T, Blocking> {
     /// * `montgomery_param` -- Pre-computed Montgomery parameter `R^2 mod p`.
     /// * `point` -- Point in projective coordinates.
     /// * `result` -- Output point in affine coordinates.
+    #[cfg(not(pka_v1c))]
     pub fn projective_to_affine_blocking(
         &mut self,
         modulus: &[u8],
@@ -2200,7 +2498,12 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
         point_x: &[u8],
         point_y: &[u8],
     ) -> Result<bool, Error> {
-        self.prepare_point_check(curve, point_x, point_y)?;
+        #[cfg_attr(pka_v1c, allow(unused_mut))]
+        let mut r2 = [0u32; MAX_ECC_BYTES / 4];
+        let words = curve.p_modulus.len().div_ceil(4);
+        #[cfg(not(pka_v1c))]
+        self.montgomery_param(curve.p_modulus, &mut r2[..words]).await?;
+        self.prepare_point_check(curve, point_x, point_y, &r2[..words])?;
         self.start_and_wait_async().await?;
         self.read_point_check()
     }
@@ -2333,6 +2636,7 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
     /// # Arguments
     /// * `params` -- Protected-mode parameters including `phi(n)`.
     /// * `result` -- Output buffer (must be at least the size of `params.modulus`).
+    #[cfg(not(pka_v1c))]
     pub async fn modular_exp_protect(
         &mut self,
         params: &ModExpProtectParams<'_>,
@@ -2406,6 +2710,7 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
     /// * `p` -- First point in projective coordinates.
     /// * `q` -- Second point in projective coordinates.
     /// * `result` -- Output point in Jacobian projective coordinates.
+    #[cfg(not(pka_v1c))]
     pub async fn ecc_complete_add(
         &mut self,
         curve: &EcdsaCurveParams,
@@ -2431,6 +2736,7 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
     /// * `m` -- Scalar for point `Q`.
     /// * `q` -- Second point in projective coordinates.
     /// * `result` -- Output point in affine coordinates.
+    #[cfg(not(pka_v1c))]
     pub async fn double_base_ladder(
         &mut self,
         curve: &EcdsaCurveParams,
@@ -2453,6 +2759,7 @@ impl<'d, T: Instance> Pka<'d, T, Async> {
     /// * `montgomery_param` -- Pre-computed Montgomery parameter `R^2 mod p`.
     /// * `point` -- Point in projective coordinates.
     /// * `result` -- Output point in affine coordinates.
+    #[cfg(not(pka_v1c))]
     pub async fn projective_to_affine(
         &mut self,
         modulus: &[u8],

--- a/embassy-stm32/src/rcc/bd.rs
+++ b/embassy-stm32/src/rcc/bd.rs
@@ -329,7 +329,7 @@ impl LsConfig {
         }
 
         // If not OK, reset backup domain and configure it.
-        #[cfg(not(any(rcc_l0, rcc_l0_v2, rcc_l1, stm32h5, stm32h7rs, stm32c0, stm32n6)))]
+        #[cfg(not(any(rcc_l0, rcc_l0_v2, rcc_l1, stm32h5, stm32h7rs, stm32c0, stm32n6, stm32u5)))]
         {
             bdcr().modify(|w| w.set_bdrst(true));
             bdcr().modify(|w| w.set_bdrst(false));
@@ -341,6 +341,9 @@ impl LsConfig {
         // letting half our RAM go magically *poof*.
         // STM32H503CB/EB/KB/RB device errata - 2.2.8 SRAM2 unduly erased upon a backup domain reset
         // STM32H562xx/563xx/573xx device errata - 2.2.14 SRAM2 is erased when the backup domain is reset
+        // The U5 does the same: SRAM2 is one of the "device secrets" a backup domain reset wipes
+        // (RM0456, tamper and backup registers), observed on an STM32U585 where the erase zeroed
+        // the 64 kB of SRAM2 during `init`.
         //#[cfg(any(stm32h5, stm32h7rs))]
         #[cfg(any(stm32h7rs, stm32n6))]
         {

--- a/embassy-stm32/src/rng.rs
+++ b/embassy-stm32/src/rng.rs
@@ -572,3 +572,77 @@ foreach_interrupt!(
         }
     };
 );
+
+/// `embassy-crypto` random number driver served by the RNG, behind the
+/// `embassy-crypto-rng` feature.
+///
+/// The driver takes the peripheral over on first use and keeps it running:
+/// the PKA needs the RNG for its own initialization, and restarting the RNG
+/// for every draw would discard its conditioning.
+#[cfg(feature = "embassy-crypto-rng")]
+pub(crate) mod driver {
+    use embassy_crypto::Error as CryptoError;
+    use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+    use embassy_sync::mutex::Mutex;
+
+    use super::{MAX_RESET_RETRIES, Rng};
+
+    foreach_peripheral!(
+        (rng, $inst:ident) => {
+            type Instance = crate::peripherals::$inst;
+        };
+    );
+
+    static DRIVER: Mutex<CriticalSectionRawMutex, Option<Rng<'static, Instance>>> = Mutex::new(None);
+
+    /// Runs `f` on the RNG, starting it first if needed.
+    pub(crate) fn with_rng<R>(f: impl FnOnce(&mut Rng<'static, Instance>) -> R) -> R {
+        let mut driver = DRIVER.try_lock().expect("the RNG is in use");
+        let rng = driver.get_or_insert_with(|| {
+            let peri = unsafe { Instance::steal() };
+            #[cfg(rng_v1)]
+            {
+                Rng::new_inner(peri)
+            }
+            #[cfg(not(rng_v1))]
+            {
+                Rng::new_inner(peri, super::RngConfig::default())
+            }
+        });
+        f(rng)
+    }
+
+    /// Starts the RNG if it is not running yet.
+    pub(crate) fn ensure_running() {
+        with_rng(|_| ());
+    }
+
+    struct Driver;
+
+    impl embassy_crypto::driver::Rng for Driver {
+        fn fill_bytes(buf: &mut [u8]) -> Result<(), CryptoError> {
+            with_rng(|rng| {
+                let mut retries = 0;
+                for chunk in buf.chunks_mut(4) {
+                    let word = loop {
+                        if let Some(word) = rng.poll_word() {
+                            // The reference manual asks for a zero word to be treated as an error.
+                            if word != 0 {
+                                break word;
+                            }
+                        }
+                        if retries >= MAX_RESET_RETRIES {
+                            return Err(CryptoError::HardwareError);
+                        }
+                        retries += 1;
+                        rng.reset();
+                    };
+                    chunk.copy_from_slice(&word.to_ne_bytes()[..chunk.len()]);
+                }
+                Ok(())
+            })
+        }
+    }
+
+    embassy_crypto::rng_impl!(Driver);
+}

--- a/embassy-stm32/src/saes/mod.rs
+++ b/embassy-stm32/src/saes/mod.rs
@@ -77,39 +77,43 @@
 //! - **Key Wrapping**: Import encrypted keys securely
 //! - **Peripheral Isolation**: Keys can be shared without software access
 //!
-//! # Availability
+//! # Hardware revisions
 //!
-//! **Important**: SAES is only available on:
-//! - STM32WBA52 and higher
-//! - STM32WBA55
-//! - STM32WBA6x
-//! - NOT available on STM32WBA50
+//! - **`saes_v1a`** (STM32H5, WBA5x/WBA6x, C5): ECB, CBC, CTR, GCM, GMAC and CCM.
+//! - **`saes_v1b`** (STM32U3, U5): ECB and CBC only. CTR is accepted by the
+//!   hardware but behaves as ECB, and the authenticated modes do not exist, so
+//!   [`start`](Saes::start) panics if given anything else.
+//! - **`saes_n6`** (STM32N6).
 //!
-//! # Use Cases
+//! # RNG dependency
 //!
-//! - Secure boot key management
-//! - Device-unique encryption (uses DHUK based on chip UID)
-//! - Key provisioning and wrapping
-//! - Multi-peripheral cryptographic workflows
-//! - High-security applications requiring hardware root of trust
+//! The SAES fetches random numbers from the RNG for its countermeasures every
+//! time it is reset or its key size changes, and never leaves its busy state if
+//! the RNG is not running: create an [`Rng`](crate::rng::Rng) before the
+//! [`Saes`] and keep it alive. On STM32WBA6 and C5 the constructors take it as
+//! a parameter.
+//!
+//! On STM32U5 the SAES also runs off a kernel clock of its own, the SHSI
+//! oscillator, which the driver turns on. Stop mode turns it off again, so a
+//! `Saes` must not be used across a stop.
+//!
+//! # `embassy-crypto`
+//!
+//! With the `embassy-crypto-saes` feature, the SAES serves the
+//! `embassy-crypto-aes*` operations instead of the AES peripheral. See
+//! [`aes`](crate::aes).
 //!
 //! # See Also
 //!
-//! - [`aes`](crate::aes) - Standard AES implementation (all WBA chips)
+//! - [`aes`](crate::aes) - Standard AES implementation
 //! - [`pka`](crate::pka) - Public Key Accelerator
 
-// Re-export cipher types from AES (WBA) or the shared crypto module (N6).
 use core::marker::PhantomData;
 
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
-#[cfg(any(aes_v3a, aes_v3b))]
-pub use crate::aes::{
-    AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Cipher, CipherAuthenticated, CipherSized, Context, Direction, Error,
-    IVSized, KeySize,
-};
-#[cfg(all(saes_n6, not(any(aes_v3a, aes_v3b))))]
+// The cipher-mode types are shared with `aes` and live in `crate::crypto`.
 pub use crate::crypto::{
     AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, AesGmac, Cipher, CipherAuthenticated, CipherSized, Context, Direction,
     Error, IVSized, KeySize,
@@ -180,6 +184,8 @@ fn set_kmod(p: pac::saes::Saes, key_mode: KeyMode) {
     });
 }
 
+/// Select a GCM/CCM phase. `saes_v1b` has no such phases.
+#[cfg(not(saes_v1b))]
 #[inline]
 fn set_gcmph(p: pac::saes::Saes, phase: u8) {
     p.cr().modify(|w| {
@@ -210,6 +216,49 @@ fn set_kshareid(p: pac::saes::Saes, target: KeyShareTarget) {
     });
 }
 
+/// Clear every interrupt flag.
+#[inline]
+fn clear_flags(p: pac::saes::Saes) {
+    p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+}
+
+/// Wait for the computation-complete flag, then clear it.
+///
+/// The flag lives in `ISR`, not `SR` as on the AES. `BUSY` is not a completion
+/// signal: it also clears after the random number fetches and key transfers.
+#[inline]
+fn wait_ccf_blocking(p: pac::saes::Saes) {
+    while !p.isr().read().ccf() {}
+    clear_flags(p);
+}
+
+/// Wait for the random number fetch that follows a reset or a key size change.
+///
+/// The fetch never completes without the RNG running; see the module docs.
+fn wait_ready(p: pac::saes::Saes) {
+    // Some parts (seen on STM32U5A5) come out of the peripheral reset with the
+    // software reset asserted, and stay busy until it is released.
+    if p.cr().read().iprst() {
+        p.cr().modify(|w| w.set_iprst(false));
+    }
+    while p.sr().read().busy() {}
+    assert!(!p.isr().read().rngeif(), "SAES: RNG error during initialization");
+}
+
+/// Enable the peripheral, with its clocks.
+///
+/// On STM32U5 the SAES has a kernel clock of its own, the SHSI (secure HSI)
+/// oscillator that nothing else uses, and stays busy forever without it.
+fn enable_and_reset<T: Instance>() {
+    #[cfg(rcc_u5)]
+    {
+        let rcc = crate::pac::RCC;
+        rcc.cr().modify(|w| w.set_shsion(true));
+        while !rcc.cr().read().shsirdy() {}
+    }
+    rcc::enable_and_reset::<T>();
+}
+
 /// SAES interrupt handler.
 pub struct InterruptHandler<T: Instance> {
     _marker: PhantomData<T>,
@@ -219,17 +268,15 @@ impl<T: Instance> interrupt::typelevel::Handler<T::Interrupt> for InterruptHandl
     unsafe fn on_interrupt() {
         // Wake on computation complete flag (CCF) from ISR, not on BUSY clearing.
         // BUSY also clears during init/RNG-fetch/key-transfer which must not wake tasks.
-        // Note: CCF is in SAES_ISR, not SAES_SR (unlike AES which has CCF in SR).
         let isr = T::regs().isr().read();
         if isr.ccf() {
-            // Clear all interrupt flags
-            T::regs().icr().write(|w| w.0 = 0xFFFF_FFFF);
+            clear_flags(T::regs());
             SAES_WAKER.wake();
         }
 
         // Clear error flags
         if isr.rweif() {
-            T::regs().icr().write(|w| w.0 = 0xFFFF_FFFF);
+            clear_flags(T::regs());
         }
     }
 }
@@ -283,14 +330,11 @@ impl<'d, T: Instance> Saes<'d, T, Blocking> {
         _irq: impl interrupt::typelevel::Binding<T::Interrupt, InterruptHandler<T>> + 'd,
         #[cfg(any(rng_wba6, rng_v4))] _rng: &crate::rng::Rng<'rng, RNG>, // On WBA6 and C5, SAES fetches a random seed from the RNG on every reset/enable.
     ) -> Self {
-        rcc::enable_and_reset::<T>();
+        enable_and_reset::<T>();
 
-        let p = T::regs();
         // After reset, SAES sets BUSY while it fetches a random number from the internal RNG.
         // Writing CR before BUSY clears is forbidden (HAL: CRYP_FLAG_BUSY check at init).
-        while p.sr().read().busy() {}
-        // Panic on RNG error - the peripheral is unusable without a working RNG.
-        assert!(!p.isr().read().rngeif(), "SAES: RNG error during initialization");
+        wait_ready(T::regs());
 
         let instance = Self {
             _peripheral: peripheral,
@@ -303,6 +347,32 @@ impl<'d, T: Instance> Saes<'d, T, Blocking> {
         unsafe { T::Interrupt::enable() };
 
         instance
+    }
+}
+
+impl<'d, T: Instance> crate::suspend::SealedSuspendablePeripheral for Saes<'d, T, Blocking> {
+    type InternalState = Peri<'d, T>;
+
+    fn resume(state: Self::InternalState) -> Self {
+        #[cfg(rcc_u5)]
+        {
+            let rcc = crate::pac::RCC;
+            rcc.cr().modify(|w| w.set_shsion(true));
+            while !rcc.cr().read().shsirdy() {}
+        }
+        critical_section::with(|cs| rcc::enable_and_reset_with_cs_no_refcount::<T>(cs));
+        wait_ready(T::regs());
+
+        Self {
+            _peripheral: state,
+            _marker: PhantomData,
+            dma_in: None,
+            dma_out: None,
+        }
+    }
+
+    fn suspend(self) -> Self::InternalState {
+        unsafe { self._peripheral.clone_unchecked() }
     }
 }
 
@@ -323,14 +393,11 @@ impl<'d, T: Instance> Saes<'d, T, Async> {
         + 'd,
         #[cfg(any(rng_wba6, rng_v4))] _rng: &crate::rng::Rng<'rng, RNG>, // On WBA6 and C5, SAES fetches a random seed from the RNG on every reset/enable.
     ) -> Self {
-        rcc::enable_and_reset::<T>();
+        enable_and_reset::<T>();
 
-        let p = T::regs();
         // After reset, SAES sets BUSY while it fetches a random number from the internal RNG.
         // Writing CR before BUSY clears is forbidden (HAL: CRYP_FLAG_BUSY check at init).
-        while p.sr().read().busy() {}
-        // Panic on RNG error - the peripheral is unusable without a working RNG.
-        assert!(!p.isr().read().rngeif(), "SAES: RNG error during initialization");
+        wait_ready(T::regs());
 
         let instance = Self {
             _peripheral: peripheral,
@@ -414,6 +481,10 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
     {
         let p = T::regs();
 
+        let is_gcm_ccm = cipher.uses_gcm_phases();
+        #[cfg(saes_v1b)]
+        assert!(cipher.chmod_bits() < 2, "this SAES only does ECB and CBC");
+
         // Disable the peripheral, then wait for BUSY to clear before touching CR.
         // The HAL checks BUSY before every CR write (SetConfig, Encrypt, Decrypt).
         p.cr().modify(|w| w.set_en(false));
@@ -429,7 +500,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
 
         // Clear all pending flags — in particular KEIF, which if left set will permanently
         // block KEYVALID from being asserted, making the key load silently fail.
-        p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+        clear_flags(p);
 
         // Configure data type based on cipher mode (NO_SWAP, BYTE_SWAP, or BIT_SWAP)
         set_datatype(p, cipher.datatype());
@@ -442,8 +513,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         while p.sr().read().busy() {}
 
         // Set cipher mode using SAES-compatible method
-        self.set_cipher_mode(p, cipher);
-        let is_gcm_ccm = cipher.uses_gcm_phases();
+        set_chmod(p, cipher.chmod_bits());
 
         // Set direction
         set_mode(p, dir as u8);
@@ -452,8 +522,11 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         set_kmod(p, key_mode);
 
         // For GCM/CCM (authenticated) modes, set GCMPH=0 (init phase) BEFORE loading the key.
+        #[cfg(not(saes_v1b))]
         if is_gcm_ccm {
             set_gcmph(p, 0);
+            // Like NPBLB, which the hardware keeps from one operation to the next.
+            p.cr().modify(|w| w.set_npblb(0));
         }
 
         // Configure and load the key (after GCMPH is set).
@@ -476,10 +549,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         if needs_key_derivation {
             set_mode(p, 1);
             p.cr().modify(|w| w.set_en(true));
-            // Wait for CCF (computation complete), not BUSY
-            while !p.isr().read().ccf() {}
-            // Clear CCF via ICR
-            p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+            wait_ccf_blocking(p);
             // Restore decrypt mode for the actual operation
             set_mode(p, dir as u8);
         }
@@ -487,20 +557,16 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         // Load IV
         self.load_iv(cipher.iv());
 
-        // Perform init phase for GCM/CCM (hash-key H calculation, phase 0).
-        // MODE is already ENCRYPTION here (set above) — correct for H = AES_ENCRYPT(K, 0).
         if is_gcm_ccm {
+            // Perform init phase for GCM/CCM (hash-key H calculation, phase 0).
+            // MODE is already ENCRYPTION here (set above) — correct for H = AES_ENCRYPT(K, 0).
             p.cr().modify(|w| w.set_en(true));
-            // Wait for CCF (init phase complete)
-            while !p.isr().read().ccf() {}
-            // Clear flags
-            p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+            wait_ccf_blocking(p);
         } else {
-            // For non-GCM/CCM modes, enable the peripheral then wait for BUSY to clear.
-            // SAES may assert BUSY after EN=1 to apply the per-key-size RNG mask
-            // (observed with 256-bit keys: the upper-half mask is applied here).
+            // For non-GCM/CCM modes, just enable the peripheral. BUSY is not waited
+            // for here: in CTR mode it stays set while the engine holds a keystream
+            // block ready, and the data writes below are what it is waiting for.
             p.cr().modify(|w| w.set_en(true));
-            while p.sr().read().busy() {}
         }
 
         // Create context (peripheral is now enabled)
@@ -526,20 +592,19 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         set_kshareid(T::regs(), target);
     }
 
-    /// Set cipher mode for SAES peripheral using the cipher's CHMOD bits.
-    fn set_cipher_mode<'c, C>(&mut self, p: pac::saes::Saes, cipher: &C)
-    where
-        C: Cipher<'c>,
-    {
-        set_chmod(p, cipher.chmod_bits());
-    }
-
     /// Process authenticated additional data (AAD) for GCM/CCM modes.
-    pub fn aad_blocking<'c, C>(&mut self, ctx: &mut Context<'c, C>, aad: &[u8], last: bool) -> Result<(), Error>
+    /// Must be called after `start` and before `payload_blocking`.
+    /// Set `last` to true for the final AAD block.
+    #[cfg(not(saes_v1b))]
+    pub fn aad_blocking<'c, C, const TAG_SIZE: usize>(
+        &mut self,
+        ctx: &mut Context<'c, C>,
+        aad: &[u8],
+        last: bool,
+    ) -> Result<(), Error>
     where
-        C: Cipher<'c> + CipherAuthenticated<16>,
+        C: Cipher<'c> + CipherAuthenticated<TAG_SIZE>,
     {
-        // Reuse AES implementation logic
         let p = T::regs();
 
         if ctx.header_processed && last {
@@ -550,6 +615,13 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         // After the init phase SAES auto-clears EN, so we must set EN=1 here.
         set_gcmph(p, 1);
         p.cr().modify(|w| w.set_en(true));
+
+        // CCM's first header block starts with the encoded associated-data length.
+        if ctx.header_len == 0 && ctx.aad_buffer_len == 0 {
+            let (header, len) = ctx.cipher.ccm_aad_header();
+            ctx.aad_buffer[..len].copy_from_slice(&header[..len]);
+            ctx.aad_buffer_len = len;
+        }
 
         let mut aad_remaining = aad.len();
         let mut aad_index = 0;
@@ -564,11 +636,9 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
             aad_remaining -= to_copy;
 
             if ctx.aad_buffer_len == 16 {
+                // No output is read in the header phase.
                 self.write_block_blocking(&ctx.aad_buffer)?;
-                // Wait for CCF (header block processed) — no output read in header phase.
-                // SAES CCF is in ISR, not SR (unlike plain AES).
-                while !p.isr().read().ccf() {}
-                p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+                wait_ccf_blocking(p);
                 ctx.header_len += 16;
                 ctx.aad_buffer_len = 0;
             }
@@ -577,9 +647,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         // Process complete blocks
         while aad_remaining >= 16 {
             self.write_block_blocking(&aad[aad_index..aad_index + 16])?;
-            // Wait for CCF after each header block
-            while !p.isr().read().ccf() {}
-            p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+            wait_ccf_blocking(p);
             ctx.header_len += 16;
             aad_index += 16;
             aad_remaining -= 16;
@@ -599,9 +667,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
                     ctx.aad_buffer[i] = 0;
                 }
                 self.write_block_blocking(&ctx.aad_buffer)?;
-                // Wait for CCF after last header block
-                while !p.isr().read().ccf() {}
-                p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+                wait_ccf_blocking(p);
                 ctx.header_len += ctx.aad_buffer_len as u64;
                 ctx.aad_buffer_len = 0;
             }
@@ -612,6 +678,9 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
     }
 
     /// Process payload data in blocking mode.
+    ///
+    /// Set `last` to true for the final block. Intermediate chunks (`last=false`)
+    /// must be block-aligned (16 bytes); only the final chunk can be partial.
     pub fn payload_blocking<'c, C>(
         &mut self,
         ctx: &mut Context<'c, C>,
@@ -623,6 +692,8 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         C: Cipher<'c>,
     {
         let p = T::regs();
+        #[cfg(saes_v1b)]
+        let _ = p;
 
         if output.len() < input.len() {
             return Err(Error::ConfigError);
@@ -632,6 +703,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         // SAES requires EN=0→1 at every GCMPH transition; without re-enabling here,
         // the GHASH state from the header phase is not properly transferred and the
         // encrypt/decrypt tags diverge (observed on SAES v1a / WBA65RI with AAD).
+        #[cfg(not(saes_v1b))]
         if ctx.is_gcm_ccm {
             if !ctx.header_processed {
                 ctx.header_processed = true;
@@ -644,17 +716,12 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         let block_size = C::BLOCK_SIZE;
         let mut processed = 0;
 
-        // Ensure proper block alignment for modes that require padding
-        if C::REQUIRES_PADDING && !last && input.len() % block_size != 0 {
+        // Intermediate chunks must be block-aligned (all modes).
+        if !last && input.len() % block_size != 0 {
             return Err(Error::ConfigError);
         }
 
-        // Process complete blocks
-        let complete_blocks = if last {
-            input.len() / block_size
-        } else {
-            input.len() / block_size
-        };
+        let complete_blocks = input.len() / block_size;
 
         for _ in 0..complete_blocks {
             let block = &input[processed..processed + block_size];
@@ -675,10 +742,19 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
             let mut partial_block = [0u8; 16];
             partial_block[..remaining].copy_from_slice(&input[processed..]);
 
-            // NPBLB = Number of Padding Bytes in Last Block.
-            // For `remaining` valid bytes, there are (16 - remaining) padding bytes.
-            let padding_bytes = (16 - remaining) as u8;
-            p.cr().modify(|w| w.set_npblb(padding_bytes));
+            // NPBLB, the number of padding bytes in the last block: GCM sets it
+            // for both directions, CCM only for decryption.
+            #[cfg(not(saes_v1b))]
+            {
+                let should_set_npblb = if ctx.cipher.is_ccm_mode() {
+                    ctx.dir == Direction::Decrypt
+                } else {
+                    ctx.is_gcm_ccm
+                };
+                if should_set_npblb {
+                    p.cr().modify(|w| w.set_npblb((16 - remaining) as u8));
+                }
+            }
 
             self.write_block_blocking(&partial_block)?;
             self.read_block_blocking(&mut partial_block)?;
@@ -701,7 +777,9 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
     {
         let p = T::regs();
 
-        // For GCM, perform final phase to get tag
+        #[cfg(saes_v1b)]
+        let _ = &ctx;
+        #[cfg(not(saes_v1b))]
         if ctx.is_gcm_ccm {
             // SAES may set BUSY during GCM payload encryption. The PAC document states:
             // "When GCM encryption is selected, the flag must be at zero before selecting
@@ -712,15 +790,20 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
             // Set GCM phase to final (phase 3)
             set_gcmph(p, 3);
 
-            // Write lengths (in bits) as final block
-            let header_bits = (ctx.header_len * 8) as u64;
-            let payload_bits = (ctx.payload_len * 8) as u64;
+            if ctx.cipher.is_ccm_mode() {
+                // CCM computes the tag from the state it holds: enabling starts it.
+                p.cr().modify(|w| w.set_en(true));
+            } else {
+                // Write lengths (in bits) as final block
+                let header_bits = ctx.header_len * 8;
+                let payload_bits = ctx.payload_len * 8;
 
-            let mut length_block = [0u8; 16];
-            length_block[0..8].copy_from_slice(&header_bits.to_be_bytes());
-            length_block[8..16].copy_from_slice(&payload_bits.to_be_bytes());
+                let mut length_block = [0u8; 16];
+                length_block[0..8].copy_from_slice(&header_bits.to_be_bytes());
+                length_block[8..16].copy_from_slice(&payload_bits.to_be_bytes());
 
-            self.write_block_blocking(&length_block)?;
+                self.write_block_blocking(&length_block)?;
+            }
 
             // Read the authentication tag
             let mut tag = [0u8; 16];
@@ -729,12 +812,12 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
             // Disable peripheral
             p.cr().modify(|w| w.set_en(false));
 
-            Ok(Some(tag))
-        } else {
-            // For non-authenticated modes, just disable
-            p.cr().modify(|w| w.set_en(false));
-            Ok(None)
+            return Ok(Some(tag));
         }
+
+        // For non-authenticated modes, just disable
+        p.cr().modify(|w| w.set_en(false));
+        Ok(None)
     }
 
     /// Load key into SAES peripheral.
@@ -759,21 +842,12 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
 
         let p = T::regs();
 
-        // IV is loaded as 32-bit words (big-endian byte order)
+        // Like the key, the IV goes in as big-endian words, high register first:
+        // IVR3 = iv[0..4], IVR0 = iv[12..16] (HAL CRYP_SetIV).
         let iv_words = core::cmp::min(iv.len(), 16) / 4;
         for i in 0..iv_words {
             let word = u32::from_be_bytes([iv[i * 4], iv[i * 4 + 1], iv[i * 4 + 2], iv[i * 4 + 3]]);
-            p.ivr(i).write_value(word);
-        }
-
-        // Handle partial IV words
-        let remaining = core::cmp::min(iv.len(), 16) % 4;
-        if remaining > 0 {
-            let i = iv_words * 4;
-            let mut bytes = [0u8; 4];
-            bytes[..remaining].copy_from_slice(&iv[i..i + remaining]);
-            let word = u32::from_be_bytes(bytes);
-            p.ivr(iv_words).write_value(word);
+            p.ivr(iv_words - 1 - i).write_value(word);
         }
     }
 
@@ -810,7 +884,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
 
         // Check for read/write error flag in ISR before reading output
         if p.isr().read().rweif() {
-            p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+            clear_flags(p);
             return Err(Error::ReadError);
         }
 
@@ -822,7 +896,7 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
         }
 
         // Clear flags after successful read
-        p.icr().write(|w| w.0 = 0xFFFF_FFFF);
+        clear_flags(p);
 
         Ok(())
     }
@@ -830,9 +904,15 @@ impl<'d, T: Instance, M: Mode> Saes<'d, T, M> {
 
 impl<'d, T: Instance> Saes<'d, T, Async> {
     /// Process authenticated additional data (AAD) for GCM/CCM modes (async facade).
-    pub async fn aad<'c, C>(&mut self, ctx: &mut Context<'c, C>, aad: &[u8], last: bool) -> Result<(), Error>
+    #[cfg(not(saes_v1b))]
+    pub async fn aad<'c, C, const TAG_SIZE: usize>(
+        &mut self,
+        ctx: &mut Context<'c, C>,
+        aad: &[u8],
+        last: bool,
+    ) -> Result<(), Error>
     where
-        C: Cipher<'c> + CipherAuthenticated<16>,
+        C: Cipher<'c> + CipherAuthenticated<TAG_SIZE>,
     {
         self.aad_blocking(ctx, aad, last)
     }

--- a/embassy-stm32/src/saes/mod.rs
+++ b/embassy-stm32/src/saes/mod.rs
@@ -104,12 +104,12 @@ use core::marker::PhantomData;
 use embassy_hal_internal::{Peri, PeripheralType};
 use embassy_sync::waitqueue::AtomicWaker;
 
-#[cfg(aes_v3b)]
+#[cfg(any(aes_v3a, aes_v3b))]
 pub use crate::aes::{
     AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, Cipher, CipherAuthenticated, CipherSized, Context, Direction, Error,
     IVSized, KeySize,
 };
-#[cfg(all(saes_n6, not(aes_v3b)))]
+#[cfg(all(saes_n6, not(any(aes_v3a, aes_v3b))))]
 pub use crate::crypto::{
     AesCbc, AesCcm, AesCtr, AesEcb, AesGcm, AesGmac, Cipher, CipherAuthenticated, CipherSized, Context, Direction,
     Error, IVSized, KeySize,

--- a/tests/stm32/Cargo.toml
+++ b/tests/stm32/Cargo.toml
@@ -26,33 +26,57 @@ stm32h7a3zi = ["embassy-stm32/stm32h7a3zi", "not-stop", "spi-v345", "not-gpdma",
 stm32l073rz = ["embassy-stm32/stm32l073rz", "not-stop", "cm0", "not-gpdma", "rng", "eeprom"]
 stm32l152re = ["embassy-stm32/stm32l152re", "not-stop", "spi-v1", "chrono", "not-gpdma", "eeprom"]
 stm32l496zg = ["embassy-stm32/stm32l496zg", "not-stop", "not-gpdma", "rng"]
-stm32l4a6zg = ["embassy-stm32/stm32l4a6zg", "not-stop", "chrono", "not-gpdma", "rng", "hash"]
+stm32l4a6zg = ["embassy-stm32/stm32l4a6zg", "not-stop", "chrono", "not-gpdma", "rng", "hash", "aes-basic"]
 stm32l4r5zi = ["embassy-stm32/stm32l4r5zi", "not-stop", "chrono", "not-gpdma", "rng", "dual-bank"]
 stm32l552ze = ["embassy-stm32/stm32l552ze", "not-stop", "not-gpdma", "rng", "hash", "dual-bank"]
-stm32u585ai = ["embassy-stm32/stm32u585ai", "not-stop", "spi-v345", "chrono", "rng", "hash", "cordic"]
-stm32u5a5zj = ["embassy-stm32/stm32u5a5zj", "not-stop", "spi-v345", "chrono", "rng", "hash", "cordic"]
-stm32wb55rg = ["embassy-stm32/stm32wb55rg", "embassy-stm32-wpan?/stm32wb55rg", "fake-stop", "chrono", "not-gpdma", "ble", "mac" , "rng", "hsem"]
-stm32wba52cg = ["embassy-stm32/stm32wba52cg", "not-stop", "spi-v345", "chrono", "rng", "hash", "adc"]
-stm32wba65ri = ["embassy-stm32/stm32wba65ri", "not-stop", "spi-v345", "chrono", "rng", "hash", "adc"]
-stm32wl55jc = ["embassy-stm32/stm32wl55jc-cm4", "fake-stop", "not-gpdma", "rng", "chrono", "hsem"]
+stm32u585ai = ["embassy-stm32/stm32u585ai", "not-stop", "spi-v345", "chrono", "rng", "hash", "cordic", "pka", "aes-via-saes", "saes"]
+stm32u5a5zj = ["embassy-stm32/stm32u5a5zj", "not-stop", "spi-v345", "chrono", "rng", "hash", "cordic", "pka", "aes"] # the SAES of this board never leaves its busy state
+stm32wb55rg = ["embassy-stm32/stm32wb55rg", "embassy-stm32-wpan?/stm32wb55rg", "fake-stop", "chrono", "not-gpdma", "ble", "mac" , "rng", "hsem", "pka"]
+stm32wba52cg = ["embassy-stm32/stm32wba52cg", "not-stop", "spi-v345", "chrono", "rng", "hash", "adc", "pka", "aes", "saes-full"]
+stm32wba65ri = ["embassy-stm32/stm32wba65ri", "not-stop", "spi-v345", "chrono", "rng", "hash", "adc", "aes"]
+stm32wl55jc = ["embassy-stm32/stm32wl55jc-cm4", "fake-stop", "not-gpdma", "rng", "chrono", "hsem", "aes", "pka"]
 stm32f091rc = ["embassy-stm32/stm32f091rc", "not-stop", "cm0", "not-gpdma", "chrono"]
-stm32h503rb = ["embassy-stm32/stm32h503rb", "stop", "spi-v345", "rng"]
-stm32h7s3l8 = ["embassy-stm32/stm32h7s3l8", "not-stop", "spi-v345", "rng", "cordic", "hash-v34", "cryp"] # TODO: fdcan crashes.
-stm32u083rc = ["embassy-stm32/stm32u083rc", "not-stop", "cm0", "rng", "chrono"]
+stm32h503rb = ["embassy-stm32/stm32h503rb", "stop", "spi-v345", "rng", "hash-v34"]
+stm32h7s3l8 = ["embassy-stm32/stm32h7s3l8", "not-stop", "spi-v345", "rng", "cordic", "hash-v34", "cryp", "pka"] # TODO: fdcan crashes.
+stm32u083rc = ["embassy-stm32/stm32u083rc", "not-stop", "cm0", "rng", "chrono", "aes"]
 
 i2s_f4 = []
 spi-v1 = []
 spi-v345 = []
-cryp = [
+# The `embassy-crypto` AES drivers, served by the AES or the CRYP peripheral:
+# `aes-ecb-cbc` is what every revision does, `aes-basic` adds CTR and `aes` the
+# authenticated modes.
+aes-ecb-cbc = [
     "embassy-stm32/embassy-crypto-aes128-ecb",
     "embassy-stm32/embassy-crypto-aes128-cbc",
-    "embassy-stm32/embassy-crypto-aes128-ctr",
+]
+aes-basic = ["aes-ecb-cbc", "embassy-stm32/embassy-crypto-aes128-ctr"]
+aes = [
+    "aes-basic",
     "embassy-stm32/embassy-crypto-aes128-gcm",
     "embassy-stm32/embassy-crypto-aes128-ccm",
     "embassy-stm32/embassy-crypto-aes256-gcm",
 ]
+# The same drivers served by the SAES peripheral, which on STM32U5 only does ECB
+# and CBC.
+aes-via-saes = ["aes-ecb-cbc", "embassy-stm32/embassy-crypto-saes"]
+# The CRYP peripheral itself, on top of the drivers it serves.
+cryp = ["aes"]
+# The SAES peripheral itself, through its own API; `saes-full` where it has CTR
+# and the authenticated modes (not on STM32U5).
+saes = []
+saes-full = ["saes"]
 hash = ["embassy-stm32/embassy-crypto-sha1", "embassy-stm32/embassy-crypto-sha256", "embassy-stm32/embassy-crypto-hmac-sha256"]
 hash-v34 = ["hash"]
+# The RNG driver is not enabled: `embassy-crypto-test` registers its own.
+pka = [
+    "embassy-stm32/embassy-crypto-p256-arith",
+    "embassy-stm32/embassy-crypto-p256-ecdh",
+    "embassy-stm32/embassy-crypto-p256-ecdsa",
+    "embassy-stm32/embassy-crypto-p384-arith",
+    "embassy-stm32/embassy-crypto-p384-ecdh",
+    "embassy-stm32/embassy-crypto-p384-ecdsa",
+]
 eth = []
 rng = []
 sdmmc = []
@@ -157,7 +181,22 @@ required-features = [ "cryp",]
 [[bin]]
 name = "crypto_aes"
 path = "src/bin/crypto_aes.rs"
-required-features = [ "cryp",]
+required-features = [ "aes-ecb-cbc",]
+
+[[bin]]
+name = "crypto_ec"
+path = "src/bin/crypto_ec.rs"
+required-features = [ "pka",]
+
+[[bin]]
+name = "crypto_ecdh"
+path = "src/bin/crypto_ecdh.rs"
+required-features = [ "pka",]
+
+[[bin]]
+name = "crypto_ecdsa"
+path = "src/bin/crypto_ecdsa.rs"
+required-features = [ "pka",]
 
 [[bin]]
 name = "crypto_hash"
@@ -223,6 +262,11 @@ required-features = [ "rng",]
 name = "rtc"
 path = "src/bin/rtc.rs"
 required-features = [ "chrono",]
+
+[[bin]]
+name = "saes"
+path = "src/bin/saes.rs"
+required-features = [ "saes",]
 
 [[bin]]
 name = "sdmmc"

--- a/tests/stm32/build.rs
+++ b/tests/stm32/build.rs
@@ -8,7 +8,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-search={}", out.display());
     println!("cargo:rustc-link-arg-bins=--nmagic");
 
-    if cfg!(any(
+    let from_flash = cfg!(any(
         // too little RAM to run from RAM.
         feature = "stm32f103c8", // 20 kb
         feature = "stm32c031c6", // 6 kb
@@ -17,11 +17,33 @@ fn main() -> Result<(), Box<dyn Error>> {
         feature = "stm32h503rb", // 32 kb
         // no VTOR, so interrupts can't work when running from RAM
         feature = "stm32f091rc",
-    )) {
-        println!("cargo:rustc-link-arg-bins=-Tlink.x");
-    } else {
-        println!("cargo:rustc-link-arg-bins=-Tlink_ram.x");
-        println!("cargo:rerun-if-changed=../link_ram_cortex_m.x");
+    ));
+
+    // The crypto suites carry known-answer vectors of over 100 kB, more than
+    // the RAM of these chips.
+    let crypto_from_flash = cfg!(any(
+        feature = "stm32wba52cg", // 64 kb
+        feature = "stm32wba65ri", // 64 kb
+        feature = "stm32wl55jc",  // 64 kb
+        feature = "stm32u083rc",  // 40 kb
+        feature = "stm32wb55rg",  // 192 kb, but the ECDH suites do not fit next to the mailbox
+    ));
+
+    println!("cargo:rerun-if-changed=../link_ram_cortex_m.x");
+    println!("cargo:rerun-if-changed=src/bin");
+    for entry in fs::read_dir("src/bin")? {
+        let path = entry?.path();
+        let Some(name) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // The `saes` test carries the same suites as the `crypto_*` ones.
+        let carries_suites = name.starts_with("crypto_") || name == "saes";
+        let script = if from_flash || (crypto_from_flash && carries_suites) {
+            "link.x"
+        } else {
+            "link_ram.x"
+        };
+        println!("cargo:rustc-link-arg-bin={name}=-T{script}");
     }
 
     if cfg!(feature = "stm32wb55rg") {

--- a/tests/stm32/src/bin/crypto_aes.rs
+++ b/tests/stm32/src/bin/crypto_aes.rs
@@ -1,15 +1,29 @@
-// required-features: cryp
+// required-features: aes-ecb-cbc
 #![no_std]
 #![no_main]
 
-//! The CRYP peripheral through `embassy-crypto`, against the shared known-answer suites.
+//! The AES, CRYP or SAES peripheral through `embassy-crypto`, against the shared known-answer
+//! suites. CTR and the authenticated modes only run where the peripheral has them (`aes-basic`
+//! and `aes` features).
 
 #[path = "../common.rs"]
 mod common;
 use common::*;
 use defmt_rtt as _;
 use embassy_executor::Spawner;
+#[cfg(feature = "aes-via-saes")]
+use embassy_stm32::rng::Rng;
+#[cfg(feature = "aes-via-saes")]
+use embassy_stm32::{bind_interrupts, peripherals, rng};
 use panic_probe as _;
+
+// The known-answer blobs take a while to load.
+teleprobe_meta::timeout!(60);
+
+#[cfg(feature = "aes-via-saes")]
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
 
 /// Run every suite, logging each result, and fail at the end if any failed.
 macro_rules! suites {
@@ -34,9 +48,18 @@ macro_rules! suites {
 )]
 #[cfg_attr(not(feature = "stop"), embassy_executor::main)]
 async fn main(_spawner: Spawner) {
-    let _p: embassy_stm32::Peripherals = init();
+    #[allow(unused_variables)]
+    let p: embassy_stm32::Peripherals = init();
 
-    suites!(aes128_ecb, aes128_cbc, aes128_ctr, aes128_gcm, aes256_gcm, aes128_ccm);
+    // The SAES draws random numbers from the RNG whenever it is reset.
+    #[cfg(feature = "aes-via-saes")]
+    let _rng = Rng::new(p.RNG, Irqs);
+
+    suites!(aes128_ecb, aes128_cbc);
+    #[cfg(feature = "aes-basic")]
+    suites!(aes128_ctr);
+    #[cfg(feature = "aes")]
+    suites!(aes128_gcm, aes256_gcm, aes128_ccm);
 
     info!("Test OK");
     cortex_m::asm::bkpt();

--- a/tests/stm32/src/bin/crypto_ec.rs
+++ b/tests/stm32/src/bin/crypto_ec.rs
@@ -1,0 +1,29 @@
+// required-features: pka
+#![no_std]
+#![no_main]
+
+//! The PKA through the `embassy-crypto` curve arithmetic drivers, against the shared suites.
+//! ECDH and ECDSA have their own binaries: together the suites exceed the farm's time limit.
+
+#[path = "../common.rs"]
+mod common;
+#[path = "../crypto_pka.rs"]
+mod crypto_pka;
+use common::*;
+use embassy_executor::Spawner;
+
+teleprobe_meta::timeout!(60);
+
+#[cfg_attr(
+    feature = "stop",
+    embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")
+)]
+#[cfg_attr(not(feature = "stop"), embassy_executor::main)]
+async fn main(_spawner: Spawner) {
+    let _rng = crypto_pka::init();
+
+    crypto_pka::suites!(p256_arith, p384_arith);
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/stm32/src/bin/crypto_ecdh.rs
+++ b/tests/stm32/src/bin/crypto_ecdh.rs
@@ -1,0 +1,35 @@
+// required-features: pka
+#![no_std]
+#![no_main]
+
+//! The PKA through the `embassy-crypto` ECDH drivers, against the shared suites.
+
+#[path = "../common.rs"]
+mod common;
+#[path = "../crypto_pka.rs"]
+mod crypto_pka;
+use common::*;
+use embassy_executor::Spawner;
+
+teleprobe_meta::timeout!(120);
+
+#[cfg_attr(
+    feature = "stop",
+    embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")
+)]
+#[cfg_attr(not(feature = "stop"), embassy_executor::main)]
+async fn main(_spawner: Spawner) {
+    let _rng = crypto_pka::init();
+
+    // The P-384 suite runs some 1500 scalar multiplications, at 85 ms each on the STM32WBA52 at
+    // its top clock, and slower still on the `pka_v1c` of the STM32WB55 and WL55: more than the
+    // farm's time limit.
+    crypto_pka::suites!(
+        p256_ecdh,
+        #[cfg(not(any(feature = "stm32wba52cg", feature = "stm32wb55rg", feature = "stm32wl55jc")))]
+        p384_ecdh,
+    );
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/stm32/src/bin/crypto_ecdsa.rs
+++ b/tests/stm32/src/bin/crypto_ecdsa.rs
@@ -1,0 +1,33 @@
+// required-features: pka
+#![no_std]
+#![no_main]
+
+//! The PKA through the `embassy-crypto` ECDSA drivers, against the shared suites.
+
+#[path = "../common.rs"]
+mod common;
+#[path = "../crypto_pka.rs"]
+mod crypto_pka;
+use common::*;
+use embassy_executor::Spawner;
+
+teleprobe_meta::timeout!(60);
+
+#[cfg_attr(
+    feature = "stop",
+    embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")
+)]
+#[cfg_attr(not(feature = "stop"), embassy_executor::main)]
+async fn main(_spawner: Spawner) {
+    let _rng = crypto_pka::init();
+
+    // The `pka_v1c` of the STM32WB55 and WL55 takes half the time limit for P-256 alone.
+    crypto_pka::suites!(
+        p256_ecdsa,
+        #[cfg(not(any(feature = "stm32wb55rg", feature = "stm32wl55jc")))]
+        p384_ecdsa,
+    );
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/stm32/src/bin/crypto_hash.rs
+++ b/tests/stm32/src/bin/crypto_hash.rs
@@ -11,6 +11,9 @@ use defmt_rtt as _;
 use embassy_executor::Spawner;
 use panic_probe as _;
 
+// The known-answer blobs take a while to load.
+teleprobe_meta::timeout!(60);
+
 /// Run every suite, logging each result, and fail at the end if any failed.
 macro_rules! suites {
     ($($name:ident),* $(,)?) => {{

--- a/tests/stm32/src/bin/hash.rs
+++ b/tests/stm32/src/bin/hash.rs
@@ -231,7 +231,8 @@ fn test_boundary_sizes(hw_hasher: &mut Hash<'_, peripherals::HASH, Blocking>) {
 }
 
 // This uses sha512, so only supported on hash_v3 and up
-#[cfg(feature = "hash-v34")]
+// The HASH of the STM32H503 has no SHA-384/512.
+#[cfg(all(feature = "hash-v34", not(feature = "stm32h503rb")))]
 fn test_sizes(hw_hasher: &mut Hash<'_, peripherals::HASH, Blocking>) {
     let in1 = b"4BPuGudaDK";
     let in2 = b"cfFIGf0XSNhFBQ5LaIqzjnRKDRkoWweJI06HLUcicIUGjpuDNfOTQNSrRxDoveDPlazeZtt06SIYO5CvHvsJ98XSfO9yJEMHoDpDAmNQtwZOPlKmdiagRXsJ7w7IjdKpQH6I2t";
@@ -284,7 +285,8 @@ async fn main(_spawner: Spawner) {
     test_dinis_stall_regression(&mut hw_hasher);
     test_boundary_sizes(&mut hw_hasher);
 
-    #[cfg(feature = "hash-v34")]
+    // The HASH of the STM32H503 has no SHA-384/512.
+    #[cfg(all(feature = "hash-v34", not(feature = "stm32h503rb")))]
     test_sizes(&mut hw_hasher);
 
     info!("Test OK");

--- a/tests/stm32/src/bin/hash_dma.rs
+++ b/tests/stm32/src/bin/hash_dma.rs
@@ -96,7 +96,8 @@ async fn test_interrupt(hw_hasher: &mut Hash<'_, peripherals::HASH, Async>) {
 }
 
 // This uses sha512, so only supported on hash_v3 and up
-#[cfg(feature = "hash-v34")]
+// The HASH of the STM32H503 has no SHA-384/512.
+#[cfg(all(feature = "hash-v34", not(feature = "stm32h503rb")))]
 async fn test_sizes(hw_hasher: &mut Hash<'_, peripherals::HASH, Async>) {
     let in1 = b"4BPuGudaDK";
     let in2 = b"cfFIGf0XSNhFBQ5LaIqzjnRKDRkoWweJI06HLUcicIUGjpuDNfOTQNSrRxDoveDPlazeZtt06SIYO5CvHvsJ98XSfO9yJEMHoDpDAmNQtwZOPlKmdiagRXsJ7w7IjdKpQH6I2t";
@@ -146,6 +147,7 @@ async fn main(_spawner: Spawner) {
     // Run it a second time to check hash-after-hmac
     test_interrupt(&mut hw_hasher).await;
 
+    #[cfg(not(feature = "stm32h503rb"))]
     test_sizes(&mut hw_hasher).await;
 
     info!("Test OK");

--- a/tests/stm32/src/bin/saes.rs
+++ b/tests/stm32/src/bin/saes.rs
@@ -1,0 +1,584 @@
+// required-features: saes
+#![no_std]
+#![no_main]
+
+//! The SAES peripheral through its own API, against the shared known-answer suites.
+//!
+//! The suites are written for the `embassy-crypto` API, and `embassy-crypto` can only be
+//! served by one peripheral per binary, so this wraps the `Saes` driver in the suites'
+//! traits instead. CTR and the authenticated modes run where the SAES has them
+//! (`saes-full`); the STM32U5 one only does ECB and CBC.
+
+#[path = "../common.rs"]
+mod common;
+
+use core::cell::RefCell;
+
+use common::*;
+use critical_section::Mutex;
+use defmt_rtt as _;
+use embassy_crypto::Error;
+use embassy_crypto_test::vectors;
+use embassy_executor::Spawner;
+use embassy_stm32::mode::Blocking;
+use embassy_stm32::peripherals::SAES;
+use embassy_stm32::rng::Rng;
+use embassy_stm32::saes::{AesCbc, AesEcb, Cipher, CipherSized, Direction, IVSized, Saes};
+#[cfg(feature = "saes-full")]
+use embassy_stm32::saes::{AesCcm, AesCtr, AesGcm, CipherAuthenticated};
+use embassy_stm32::{bind_interrupts, peripherals, rng, saes};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    SAES => saes::InterruptHandler<peripherals::SAES>;
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
+
+/// The largest message the suites feed.
+const MAX: usize = 1024;
+
+static DRIVER: Mutex<RefCell<Option<Saes<'static, SAES, Blocking>>>> = Mutex::new(RefCell::new(None));
+
+fn with_saes<R>(f: impl FnOnce(&mut Saes<'static, SAES, Blocking>) -> R) -> R {
+    critical_section::with(|cs| f(DRIVER.borrow_ref_mut(cs).as_mut().unwrap()))
+}
+
+fn map(e: saes::Error) -> Error {
+    match e {
+        saes::Error::KeyError => Error::InvalidKey,
+        saes::Error::ConfigError => Error::InvalidInput,
+        saes::Error::ReadError | saes::Error::WriteError => Error::HardwareError,
+    }
+}
+
+/// Runs whole blocks of `input` into `output`, which must not alias.
+fn run_blocks<'c, C>(cipher: &'c C, dir: Direction, input: &[u8], output: &mut [u8]) -> Result<(), Error>
+where
+    C: Cipher<'c> + CipherSized + IVSized,
+{
+    if input.len() != output.len() || input.len() % 16 != 0 {
+        return Err(Error::InvalidInput);
+    }
+    with_saes(|saes| {
+        let mut ctx = saes.start(cipher, dir);
+        saes.payload_blocking(&mut ctx, input, output, true).map_err(map)?;
+        saes.finish_blocking(ctx).map_err(map)?;
+        Ok(())
+    })
+}
+
+/// Runs whole blocks in place, through a copy.
+fn run_blocks_in_place<'c, C>(cipher: &'c C, dir: Direction, buf: &mut [u8]) -> Result<(), Error>
+where
+    C: Cipher<'c> + CipherSized + IVSized,
+{
+    if buf.len() > MAX {
+        return Err(Error::InvalidInput);
+    }
+    let mut tmp = [0u8; MAX];
+    let tmp = &mut tmp[..buf.len()];
+    tmp.copy_from_slice(buf);
+    run_blocks(cipher, dir, tmp, buf)
+}
+
+// ===========================================================================
+// ECB
+// ===========================================================================
+
+struct Ecb<const K: usize>([u8; K]);
+
+macro_rules! impl_ecb {
+    ($k:literal) => {
+        impl embassy_crypto_test::BlockCipher for Ecb<$k> {
+            const KEY_SIZE: usize = $k;
+            fn new(key: &[u8]) -> Option<Self> {
+                Some(Self(key.try_into().ok()?))
+            }
+            fn encrypt_blocks(&self, blocks: &mut [u8]) -> Result<(), Error> {
+                run_blocks_in_place(&AesEcb::new(&self.0), Direction::Encrypt, blocks)
+            }
+            fn decrypt_blocks(&self, blocks: &mut [u8]) -> Result<(), Error> {
+                run_blocks_in_place(&AesEcb::new(&self.0), Direction::Decrypt, blocks)
+            }
+            fn encrypt_blocks_to(&self, input: &[u8], output: &mut [u8]) -> Result<(), Error> {
+                run_blocks(&AesEcb::new(&self.0), Direction::Encrypt, input, output)
+            }
+            fn decrypt_blocks_to(&self, input: &[u8], output: &mut [u8]) -> Result<(), Error> {
+                run_blocks(&AesEcb::new(&self.0), Direction::Decrypt, input, output)
+            }
+        }
+    };
+}
+impl_ecb!(16);
+impl_ecb!(32);
+
+// ===========================================================================
+// CBC
+// ===========================================================================
+
+/// A CBC direction: the IV chains from one call to the next.
+struct Cbc<const K: usize> {
+    key: [u8; K],
+    iv: [u8; 16],
+}
+
+fn last_block(buf: &[u8]) -> [u8; 16] {
+    buf[buf.len() - 16..].try_into().unwrap()
+}
+
+macro_rules! impl_cbc {
+    ($k:literal) => {
+        impl embassy_crypto_test::CbcEncrypt for Cbc<$k> {
+            fn new(key: &[u8], iv: &[u8; 16]) -> Option<Self> {
+                Some(Self {
+                    key: key.try_into().ok()?,
+                    iv: *iv,
+                })
+            }
+            fn encrypt(&mut self, blocks: &mut [u8]) -> Result<(), Error> {
+                if blocks.is_empty() {
+                    return Ok(());
+                }
+                run_blocks_in_place(&AesCbc::new(&self.key, &self.iv), Direction::Encrypt, blocks)?;
+                self.iv = last_block(blocks);
+                Ok(())
+            }
+            fn encrypt_to(&mut self, input: &[u8], output: &mut [u8]) -> Result<(), Error> {
+                if input.is_empty() && output.is_empty() {
+                    return Ok(());
+                }
+                run_blocks(
+                    &AesCbc::new(&self.key, &self.iv),
+                    Direction::Encrypt,
+                    input,
+                    output,
+                )?;
+                self.iv = last_block(output);
+                Ok(())
+            }
+        }
+        impl embassy_crypto_test::CbcDecrypt for Cbc<$k> {
+            fn new(key: &[u8], iv: &[u8; 16]) -> Option<Self> {
+                Some(Self {
+                    key: key.try_into().ok()?,
+                    iv: *iv,
+                })
+            }
+            fn decrypt(&mut self, blocks: &mut [u8]) -> Result<(), Error> {
+                if blocks.is_empty() {
+                    return Ok(());
+                }
+                let next = last_block(blocks);
+                run_blocks_in_place(&AesCbc::new(&self.key, &self.iv), Direction::Decrypt, blocks)?;
+                self.iv = next;
+                Ok(())
+            }
+            fn decrypt_to(&mut self, input: &[u8], output: &mut [u8]) -> Result<(), Error> {
+                if input.is_empty() && output.is_empty() {
+                    return Ok(());
+                }
+                run_blocks(
+                    &AesCbc::new(&self.key, &self.iv),
+                    Direction::Decrypt,
+                    input,
+                    output,
+                )?;
+                self.iv = last_block(input);
+                Ok(())
+            }
+        }
+    };
+}
+impl_cbc!(16);
+impl_cbc!(32);
+
+// ===========================================================================
+// CTR
+// ===========================================================================
+
+/// A CTR keystream: the counter block, and the unused end of the last block.
+#[cfg(feature = "saes-full")]
+struct Ctr<const K: usize> {
+    key: [u8; K],
+    counter: [u8; 16],
+    partial: [u8; 16],
+    partial_len: usize,
+}
+
+/// How many blocks one hardware run may take from `counter`: the peripheral only
+/// increments its low 32 bits, so a run stops where they would wrap.
+#[cfg(feature = "saes-full")]
+fn ctr_run_blocks(counter: &[u8; 16], blocks: usize) -> usize {
+    let low = u32::from_be_bytes(counter[12..].try_into().unwrap());
+    let until_wrap = u64::from(u32::MAX - low) + 1;
+    if until_wrap >= blocks as u64 {
+        blocks
+    } else {
+        until_wrap as usize
+    }
+}
+
+#[cfg(feature = "saes-full")]
+macro_rules! impl_ctr {
+    ($k:literal) => {
+        impl Ctr<$k> {
+            /// Encrypts whole blocks in place from the current counter, advancing it.
+            fn blocks(&mut self, buf: &mut [u8]) {
+                let mut buf = buf;
+                while !buf.is_empty() {
+                    let n = ctr_run_blocks(&self.counter, buf.len() / 16);
+                    let (run, rest) = buf.split_at_mut(n * 16);
+                    let start = self.counter;
+                    let cipher = AesCtr::<$k>::new(&self.key, &start);
+                    with_saes(|saes| {
+                        let mut ctx = saes.start(&cipher, Direction::Encrypt);
+                        for chunk in run.chunks_exact_mut(16) {
+                            let input: [u8; 16] = chunk.try_into().unwrap();
+                            saes.payload_blocking(&mut ctx, &input, chunk, true).unwrap();
+                        }
+                        saes.finish_blocking(ctx).unwrap();
+                    });
+                    self.counter = u128::from_be_bytes(self.counter)
+                        .wrapping_add(n as u128)
+                        .to_be_bytes();
+                    buf = rest;
+                }
+            }
+        }
+
+        impl embassy_crypto_test::Ctr for Ctr<$k> {
+            fn new(key: &[u8], iv: &[u8; 16]) -> Option<Self> {
+                Some(Self {
+                    key: key.try_into().ok()?,
+                    counter: *iv,
+                    partial: [0; 16],
+                    partial_len: 0,
+                })
+            }
+            fn apply_keystream(&mut self, buf: &mut [u8]) {
+                let mut buf = buf;
+                // The end of the previous block first.
+                let n = self.partial_len.min(buf.len());
+                for (b, k) in buf[..n].iter_mut().zip(&self.partial[16 - self.partial_len..]) {
+                    *b ^= k;
+                }
+                self.partial_len -= n;
+                buf = &mut buf[n..];
+                // Whole blocks through the hardware.
+                let full = buf.len() / 16 * 16;
+                let (whole, tail) = buf.split_at_mut(full);
+                self.blocks(whole);
+                // A last partial block: one more keystream block, the rest of which is kept.
+                if !tail.is_empty() {
+                    let mut keystream = [0u8; 16];
+                    self.blocks(&mut keystream);
+                    for (b, k) in tail.iter_mut().zip(&keystream) {
+                        *b ^= k;
+                    }
+                    self.partial = keystream;
+                    self.partial_len = 16 - tail.len();
+                }
+            }
+            fn apply_keystream_to(&mut self, input: &[u8], output: &mut [u8]) -> Result<(), Error> {
+                if input.len() != output.len() {
+                    return Err(Error::InvalidInput);
+                }
+                output.copy_from_slice(input);
+                self.apply_keystream(output);
+                Ok(())
+            }
+        }
+    };
+}
+#[cfg(feature = "saes-full")]
+impl_ctr!(16);
+#[cfg(feature = "saes-full")]
+impl_ctr!(32);
+
+// ===========================================================================
+// GCM and CCM
+// ===========================================================================
+
+/// Runs an authenticated operation: `output` is the payload, the tag is returned.
+#[cfg(feature = "saes-full")]
+fn run_aead<'c, C, const T: usize>(
+    cipher: &'c C,
+    dir: Direction,
+    aad: &[u8],
+    input: &[u8],
+    output: &mut [u8],
+) -> Result<[u8; 16], Error>
+where
+    C: Cipher<'c> + CipherSized + IVSized + CipherAuthenticated<T>,
+{
+    if input.len() != output.len() {
+        return Err(Error::InvalidInput);
+    }
+    with_saes(|saes| {
+        let mut ctx = saes.start(cipher, dir);
+        saes.aad_blocking(&mut ctx, aad, true).map_err(map)?;
+        saes.payload_blocking(&mut ctx, input, output, true).map_err(map)?;
+        saes.finish_blocking(ctx).map_err(map)?.ok_or(Error::HardwareError)
+    })
+}
+
+/// Like [`run_aead`], in place through a copy.
+#[cfg(feature = "saes-full")]
+fn run_aead_in_place<'c, C, const T: usize>(
+    cipher: &'c C,
+    dir: Direction,
+    aad: &[u8],
+    buf: &mut [u8],
+) -> Result<[u8; 16], Error>
+where
+    C: Cipher<'c> + CipherSized + IVSized + CipherAuthenticated<T>,
+{
+    if buf.len() > MAX {
+        return Err(Error::InvalidInput);
+    }
+    let mut tmp = [0u8; MAX];
+    let tmp = &mut tmp[..buf.len()];
+    tmp.copy_from_slice(buf);
+    run_aead(cipher, dir, aad, tmp, buf)
+}
+
+/// Checks a tag, in constant time.
+#[cfg(feature = "saes-full")]
+fn check_tag(computed: &[u8], expected: &[u8]) -> Result<(), Error> {
+    let mut diff = 0;
+    for (a, b) in computed.iter().zip(expected) {
+        diff |= a ^ b;
+    }
+    if diff == 0 {
+        Ok(())
+    } else {
+        Err(Error::InvalidSignature)
+    }
+}
+
+#[cfg(feature = "saes-full")]
+struct Gcm<const K: usize>([u8; K]);
+
+#[cfg(feature = "saes-full")]
+macro_rules! impl_gcm {
+    ($k:literal) => {
+        impl embassy_crypto_test::Gcm for Gcm<$k> {
+            fn new(key: &[u8]) -> Option<Self> {
+                Some(Self(key.try_into().ok()?))
+            }
+            fn encrypt(&self, nonce: &[u8; 12], aad: &[u8], buf: &mut [u8]) -> Result<[u8; 16], Error> {
+                run_aead_in_place(&AesGcm::new(&self.0, nonce), Direction::Encrypt, aad, buf)
+            }
+            fn encrypt_to(
+                &self,
+                nonce: &[u8; 12],
+                aad: &[u8],
+                input: &[u8],
+                output: &mut [u8],
+            ) -> Result<[u8; 16], Error> {
+                run_aead(
+                    &AesGcm::new(&self.0, nonce),
+                    Direction::Encrypt,
+                    aad,
+                    input,
+                    output,
+                )
+            }
+            fn decrypt(&self, nonce: &[u8; 12], aad: &[u8], buf: &mut [u8], tag: &[u8; 16]) -> Result<(), Error> {
+                let computed = run_aead_in_place(&AesGcm::new(&self.0, nonce), Direction::Decrypt, aad, buf)?;
+                check_tag(&computed, tag)
+            }
+            fn decrypt_to(
+                &self,
+                nonce: &[u8; 12],
+                aad: &[u8],
+                input: &[u8],
+                output: &mut [u8],
+                tag: &[u8; 16],
+            ) -> Result<(), Error> {
+                let computed = run_aead(
+                    &AesGcm::new(&self.0, nonce),
+                    Direction::Decrypt,
+                    aad,
+                    input,
+                    output,
+                )?;
+                check_tag(&computed, tag)
+            }
+        }
+    };
+}
+#[cfg(feature = "saes-full")]
+impl_gcm!(16);
+#[cfg(feature = "saes-full")]
+impl_gcm!(32);
+
+#[cfg(feature = "saes-full")]
+struct Ccm<const K: usize>([u8; K]);
+
+/// `AesCcm` takes the nonce and tag sizes as const generics: pick them at run time.
+#[cfg(feature = "saes-full")]
+macro_rules! ccm_run {
+    ($k:literal, $n:literal, $t:literal, $key:expr, $nonce:expr, $aad:expr, $input:expr, $output:expr, $dir:expr) => {{
+        let nonce: &[u8; $n] = $nonce.try_into().unwrap();
+        let cipher = AesCcm::<$k, $n, $t>::new($key, nonce, $aad.len(), $input.len());
+        run_aead(&cipher, $dir, $aad, $input, $output)
+    }};
+}
+#[cfg(feature = "saes-full")]
+macro_rules! ccm_tag {
+    ($k:literal, $n:literal, $tag_len:expr, $key:expr, $nonce:expr, $aad:expr, $input:expr, $output:expr, $dir:expr) => {
+        match $tag_len {
+            4 => ccm_run!($k, $n, 4, $key, $nonce, $aad, $input, $output, $dir),
+            6 => ccm_run!($k, $n, 6, $key, $nonce, $aad, $input, $output, $dir),
+            8 => ccm_run!($k, $n, 8, $key, $nonce, $aad, $input, $output, $dir),
+            10 => ccm_run!($k, $n, 10, $key, $nonce, $aad, $input, $output, $dir),
+            12 => ccm_run!($k, $n, 12, $key, $nonce, $aad, $input, $output, $dir),
+            14 => ccm_run!($k, $n, 14, $key, $nonce, $aad, $input, $output, $dir),
+            16 => ccm_run!($k, $n, 16, $key, $nonce, $aad, $input, $output, $dir),
+            _ => Err(Error::InvalidInput),
+        }
+    };
+}
+#[cfg(feature = "saes-full")]
+macro_rules! ccm {
+    ($k:literal, $key:expr, $nonce:expr, $tag_len:expr, $aad:expr, $input:expr, $output:expr, $dir:expr) => {
+        match $nonce.len() {
+            7 => ccm_tag!($k, 7, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            8 => ccm_tag!($k, 8, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            9 => ccm_tag!($k, 9, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            10 => ccm_tag!($k, 10, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            11 => ccm_tag!($k, 11, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            12 => ccm_tag!($k, 12, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            13 => ccm_tag!($k, 13, $tag_len, $key, $nonce, $aad, $input, $output, $dir),
+            _ => Err(Error::InvalidInput),
+        }
+    };
+}
+
+#[cfg(feature = "saes-full")]
+macro_rules! impl_ccm {
+    ($k:literal) => {
+        impl embassy_crypto_test::Ccm for Ccm<$k> {
+            fn new(key: &[u8]) -> Option<Self> {
+                Some(Self(key.try_into().ok()?))
+            }
+            fn encrypt(&self, nonce: &[u8], aad: &[u8], buf: &mut [u8], tag: &mut [u8]) -> Result<(), Error> {
+                if buf.len() > MAX {
+                    return Err(Error::InvalidInput);
+                }
+                let mut tmp = [0u8; MAX];
+                let tmp = &mut tmp[..buf.len()];
+                tmp.copy_from_slice(buf);
+                self.encrypt_to(nonce, aad, tmp, buf, tag)
+            }
+            fn encrypt_to(
+                &self,
+                nonce: &[u8],
+                aad: &[u8],
+                input: &[u8],
+                output: &mut [u8],
+                tag: &mut [u8],
+            ) -> Result<(), Error> {
+                let computed = ccm!(
+                    $k,
+                    &self.0,
+                    nonce,
+                    tag.len(),
+                    aad,
+                    input,
+                    output,
+                    Direction::Encrypt
+                )?;
+                tag.copy_from_slice(&computed[..tag.len()]);
+                Ok(())
+            }
+            fn decrypt(&self, nonce: &[u8], aad: &[u8], buf: &mut [u8], tag: &[u8]) -> Result<(), Error> {
+                if buf.len() > MAX {
+                    return Err(Error::InvalidInput);
+                }
+                let mut tmp = [0u8; MAX];
+                let tmp = &mut tmp[..buf.len()];
+                tmp.copy_from_slice(buf);
+                self.decrypt_to(nonce, aad, tmp, buf, tag)
+            }
+            fn decrypt_to(
+                &self,
+                nonce: &[u8],
+                aad: &[u8],
+                input: &[u8],
+                output: &mut [u8],
+                tag: &[u8],
+            ) -> Result<(), Error> {
+                let computed = ccm!(
+                    $k,
+                    &self.0,
+                    nonce,
+                    tag.len(),
+                    aad,
+                    input,
+                    output,
+                    Direction::Decrypt
+                )?;
+                check_tag(&computed[..tag.len()], tag)
+            }
+        }
+    };
+}
+#[cfg(feature = "saes-full")]
+impl_ccm!(16);
+#[cfg(feature = "saes-full")]
+impl_ccm!(32);
+
+// ===========================================================================
+// Suites
+// ===========================================================================
+
+/// Run every suite, logging each result, and fail at the end if any failed.
+macro_rules! suites {
+    ($($name:ident = $run:expr),* $(,)?) => {{
+        let mut ok = true;
+        $(
+            match $run {
+                Ok(stats) => info!("{}: {:?}", stringify!($name), stats),
+                Err(e) => {
+                    error!("{}: {:?}", stringify!($name), e);
+                    ok = false;
+                }
+            }
+        )*
+        defmt::assert!(ok, "some suites failed");
+    }};
+}
+
+#[cfg_attr(
+    feature = "stop",
+    embassy_executor::main(executor = "embassy_stm32::executor::Executor", entry = "cortex_m_rt::entry")
+)]
+#[cfg_attr(not(feature = "stop"), embassy_executor::main)]
+async fn main(_spawner: Spawner) {
+    let p: embassy_stm32::Peripherals = init();
+
+    // The SAES draws random numbers from the RNG whenever it is reset.
+    let _rng = Rng::new(p.RNG, Irqs);
+    let saes = Saes::new_blocking(p.SAES, Irqs);
+    critical_section::with(|cs| DRIVER.borrow_ref_mut(cs).replace(saes));
+    suites!(
+        aes128_ecb = embassy_crypto_test::aes_ecb::<Ecb<16>>(&vectors::AES_ECB_128),
+        aes256_ecb = embassy_crypto_test::aes_ecb::<Ecb<32>>(&vectors::AES_ECB_256),
+        aes128_cbc = embassy_crypto_test::aes_cbc::<Cbc<16>, Cbc<16>>(&vectors::AES_CBC_128),
+        aes256_cbc = embassy_crypto_test::aes_cbc::<Cbc<32>, Cbc<32>>(&vectors::AES_CBC_256),
+    );
+    #[cfg(feature = "saes-full")]
+    suites!(
+        aes128_ctr = embassy_crypto_test::aes_ctr::<Ctr<16>>(&vectors::AES_CTR_128),
+        aes256_ctr = embassy_crypto_test::aes_ctr::<Ctr<32>>(&vectors::AES_CTR_256),
+        aes128_gcm = embassy_crypto_test::aes_gcm::<Gcm<16>>(&vectors::AES_GCM_128),
+        aes256_gcm = embassy_crypto_test::aes_gcm::<Gcm<32>>(&vectors::AES_GCM_256),
+        aes128_ccm = embassy_crypto_test::aes_ccm::<Ccm<16>>(&vectors::AES_CCM_128),
+        aes256_ccm = embassy_crypto_test::aes_ccm::<Ccm<32>>(&vectors::AES_CCM_256),
+    );
+
+    info!("Test OK");
+    cortex_m::asm::bkpt();
+}

--- a/tests/stm32/src/crypto_pka.rs
+++ b/tests/stm32/src/crypto_pka.rs
@@ -1,0 +1,58 @@
+//! Shared setup of the `crypto_ec*` tests: the PKA needs the RNG running, and the STM32WBA52
+//! needs its PLL to get through the suites in time.
+
+use defmt_rtt as _;
+use embassy_stm32::rng::Rng;
+use embassy_stm32::{bind_interrupts, peripherals, rng};
+use panic_probe as _;
+
+bind_interrupts!(struct Irqs {
+    RNG => rng::InterruptHandler<peripherals::RNG>;
+});
+
+/// Run every suite, logging each result, and fail at the end if any failed.
+macro_rules! suites {
+    ($($(#[$meta:meta])* $name:ident),* $(,)?) => {{
+        let mut ok = true;
+        $(
+            $(#[$meta])*
+            match embassy_crypto_test::$name() {
+                Ok(stats) => defmt::info!("{}: {:?}", stringify!($name), stats),
+                Err(e) => {
+                    defmt::error!("{}: {:?}", stringify!($name), e);
+                    ok = false;
+                }
+            }
+        )*
+        defmt::assert!(ok, "some suites failed");
+    }};
+}
+pub(crate) use suites;
+
+/// Initializes the chip and starts the RNG, which the PKA initializes its RAM from.
+pub fn init() -> Rng<'static, peripherals::RNG> {
+    #[allow(unused_mut)]
+    let mut config = crate::common::config();
+
+    // The suites run hundreds of point multiplications: at the 16 MHz the board otherwise
+    // runs at, that does not fit the time limit.
+    #[cfg(feature = "stm32wba52cg")]
+    {
+        use embassy_stm32::rcc::*;
+        config.rcc.pll1 = Some(Pll {
+            source: PllSource::Hsi,
+            prediv: PllPreDiv::Div1,
+            mul: PllMul::Mul30,
+            divr: Some(PllDiv::Div5),
+            divq: None,
+            divp: Some(PllDiv::Div30),
+            frac: Some(0),
+        });
+        config.rcc.ahb5_pre = AHB5Prescaler::Div4;
+        config.rcc.voltage_scale = VoltageScale::Range1;
+        config.rcc.sys = Sysclk::Pll1R;
+    }
+
+    let p = crate::common::init_with_config(config);
+    Rng::new(p.RNG, Irqs)
+}


### PR DESCRIPTION
- **stm32/aes: add support for aes_v3a**
- **stm32/pka: add p384, add support for all chips, add embassy-crypto driver.**
- **stm32: don't do backup domain reset on U5 because it erases SRAM2**
- **stm32: add embassy-crypto rng driver.**
- **stm32: add AES and SAES support for all chips, add SAES embassy-crypto drivers.**
- **stm32: test aes, saes, cryp, pka on all chips**
